### PR TITLE
docs: specify the Yoda Observable architecture

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Documentation
+
+on:
+  pull_request:
+    branches: [developer, main]
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".lychee.toml"
+      - ".github/workflows/docs.yml"
+  push:
+    branches: [developer, main]
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".lychee.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  documentation:
+    name: Markdown and links
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
+        with:
+          globs: |
+            **/*.md
+            #node_modules
+      - name: Check links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: --config .lychee.toml './**/*.md'
+          fail: true
+          failIfEmpty: true
+          jobSummary: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,8 @@
+no_progress = true
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+max_concurrency = 8
+accept = ["200..=204", "429"]
+include_fragments = "full"
+include_mail = false

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -3,6 +3,6 @@ max_retries = 3
 retry_wait_time = 2
 timeout = 20
 max_concurrency = 8
-accept = ["200..=204", "429"]
+accept = ["200..=204"]
 include_fragments = "full"
 include_mail = false

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": {
+      "siblings_only": true
+    },
+    "MD033": {
+      "allowed_elements": [
+        "p",
+        "img"
+      ]
+    }
+  },
+  "globs": [
+    "**/*.md",
+    "!node_modules"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Manual phase jumping is not part of the design. The runtime determines which tra
 
 Mestre Yoda separates the portable decision engine from host-specific integration and project-specific state.
 
+The canonical [Yoda Observable Architecture Specification](docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md) defines the runtime, state, security, migration, testing, and rollout contracts. Structural choices and their consequences are indexed in the [Architecture Decision Records](docs/adr/README.md), and the required end-to-end architecture trace is recorded in [verification evidence](docs/architecture/verification.md).
+
 ```mermaid
 flowchart TB
     subgraph Plugin[Installed plugin]

--- a/docs/adr/0001-event-sourced-project-history.md
+++ b/docs/adr/0001-event-sourced-project-history.md
@@ -51,4 +51,3 @@ rebuilt only through an explicit audit or repair operation.
   makes workflow correctness depend on user commit behavior.
 - **A remote event service:** conflicts with local-first, offline operation and
   introduces privacy, availability, and tenancy requirements before beta.
-

--- a/docs/adr/0001-event-sourced-project-history.md
+++ b/docs/adr/0001-event-sourced-project-history.md
@@ -1,0 +1,54 @@
+# ADR 0001: Event-Sourced Project History
+
+Status: Accepted
+
+Date: 2026-08-06
+
+## Context
+
+Mestre Yoda must explain why a workflow advanced, stopped, or invalidated prior
+approval. A mutable state file can describe the present but cannot prove how the
+runtime reached it. Model-authored summaries are also insufficient because the
+runtime, rather than the model, owns transition authority.
+
+The project needs deterministic replay, content lineage, crash recovery, and
+evidence that can be inspected without trusting conversational memory. It also
+needs fast startup and human-readable status views.
+
+## Decision
+
+Each run owns an append-only, hash-linked event stream as its authoritative
+history. A validated `state.json` snapshot accelerates startup but is derived
+from the event cursor and hash. Markdown checkboxes, status pages, dashboards,
+and summaries are regenerable views.
+
+Every committed decision event records normalized inputs, contract and policy
+versions, prior and resulting state identities, stable reason code, effect
+summary, artifact digests, and observed host/model identity when available.
+Events reference sensitive evidence by digest. The hash chain detects mutation;
+it does not authenticate an author.
+
+State changes and their events commit through one recoverable transaction. A
+snapshot that does not match its event cursor and hash is rejected and may be
+rebuilt only through an explicit audit or repair operation.
+
+## Consequences
+
+- Decisions can be replayed and audited independently of generated prose.
+- Content-bound approvals and descendant invalidation have durable lineage.
+- Snapshots remain fast without becoming a competing source of truth.
+- Transaction, canonicalization, retention, and migration rules become public
+  compatibility concerns and require dedicated tests.
+- Corruption cannot be repaired silently; recovery must preserve the rejected
+  evidence and report what changed.
+- The hash chain provides integrity evidence only. Signed identity and remote
+  attestations remain a separate post-1.0 decision.
+
+## Alternatives rejected
+
+- **Mutable state only:** fast, but unable to explain or replay history.
+- **Git history as the event store:** excludes uncommitted runtime operations and
+  makes workflow correctness depend on user commit behavior.
+- **A remote event service:** conflicts with local-first, offline operation and
+  introduces privacy, availability, and tenancy requirements before beta.
+

--- a/docs/adr/0002-embedded-esm-runtime.md
+++ b/docs/adr/0002-embedded-esm-runtime.md
@@ -1,0 +1,53 @@
+# ADR 0002: Embedded Self-Contained ESM Runtime
+
+Status: Accepted
+
+Date: 2026-08-06
+
+## Context
+
+The Go v3 runtime is installed as a separate executable. That provides a static
+binary, but it also creates an independent installation and update lifecycle.
+The plugin, schemas, prompts, templates, and runtime can drift, and contributors
+must coordinate cross-platform binaries with host integration changes.
+
+The rewrite needs a productive typed development model while retaining a
+single, deterministic runtime artifact that works without a project dependency
+installation.
+
+## Decision
+
+Develop the runtime and supporting packages in strict TypeScript and distribute
+the executable runtime as one self-contained JavaScript ESM file at
+`runtime/yoda.mjs` inside the installed plugin. Runtime execution must not
+require TypeScript sources, a global `yoda` binary, project-local dependencies,
+a runtime `node_modules`, or network access.
+
+The plugin manifest binds the plugin, runtime, schema, skill, adapter, and
+template versions. Black-box tests execute the final bundle from a clean fixture
+before release.
+
+Development dependencies may use normal workspace packages, but bundling must
+either include or eliminate every runtime dependency. Package verification
+rejects accidental dynamic loads from the development workspace.
+
+## Consequences
+
+- Installing or updating the plugin installs one version-coherent runtime.
+- Users avoid PATH configuration and a separate global Yoda package.
+- The build must prove deterministic bundling, package contents, executable
+  behavior, license notices, and absence of runtime `node_modules` access.
+- Source maps and debugging metadata are deliberate release artifacts rather
+  than implicit development files.
+- Supported Node versions and ESM behavior become explicit compatibility policy.
+- Native operating-system behavior still requires real platform tests even
+  though no platform-specific Yoda binary is shipped.
+
+## Alternatives rejected
+
+- **Continue distributing Go binaries:** preserves the old packaging model but
+  retains a second version lifecycle and per-platform release artifacts.
+- **Install a global Node CLI:** repeats the PATH and version-drift problem.
+- **Ship an unbundled npm workspace:** requires runtime `node_modules`, expands
+  the supply-chain surface, and weakens artifact coherence.
+

--- a/docs/adr/0002-embedded-esm-runtime.md
+++ b/docs/adr/0002-embedded-esm-runtime.md
@@ -50,4 +50,3 @@ rejects accidental dynamic loads from the development workspace.
 - **Install a global Node CLI:** repeats the PATH and version-drift problem.
 - **Ship an unbundled npm workspace:** requires runtime `node_modules`, expands
   the supply-chain surface, and weakens artifact coherence.
-

--- a/docs/adr/0003-project-local-brain-state.md
+++ b/docs/adr/0003-project-local-brain-state.md
@@ -53,4 +53,3 @@ file, and case-collision attacks.
   installation assets and prevents portable project-level backup.
 - **Use a mandatory remote database:** breaks offline use and adds privacy,
   tenancy, authentication, and availability dependencies.
-

--- a/docs/adr/0003-project-local-brain-state.md
+++ b/docs/adr/0003-project-local-brain-state.md
@@ -1,0 +1,56 @@
+# ADR 0003: Project-Local Brain State
+
+Status: Accepted
+
+Date: 2026-08-06
+
+## Context
+
+Go v3 stores project memory in a sibling `<repo>-brain/.brain/` repository. The
+layout protects application Git history from workflow state, but cloning the
+application without its sibling can leave host wiring present while the state
+repository is missing. Discovery, backup, permissions, and multi-worktree
+behavior become dependent on two related repositories.
+
+The rewrite chooses simpler, explicit project ownership while preserving the
+separation between installed runtime assets and project-specific memory.
+
+## Decision
+
+Project-specific Yoda state lives under `.brain/` inside the user project.
+Claude Code wiring lives under `.claude/`, and Codex wiring lives under
+`.codex/`. Runtime code, schemas, skills, adapters, and templates remain
+plugin-owned.
+
+The Go v3 sibling `<repo>-brain/.brain/` layout is a legacy source only.
+Migration is explicit, previewable, backed up, transactional, verified, and
+reversible. Discovery never mutates either location.
+
+The project controls whether appropriate `.brain/` content is committed,
+ignored, encrypted, or synchronized. Yoda classifies sensitive paths and keeps
+secrets and raw prompts out of events by default. Managed-path operations are
+confined to the resolved project root and reject traversal, symlink, special
+file, and case-collision attacks.
+
+## Consequences
+
+- Project state has one discoverable root and travels with the project according
+  to its explicit repository policy.
+- Host wiring and workflow state no longer depend on an implicit sibling naming
+  convention.
+- Teams must decide and document which `.brain/` surfaces are versioned.
+- Worktree, privacy, ignore, backup, and retention behavior require dedicated
+  contracts and cross-platform tests.
+- Legacy users need a no-write discovery plan, verifiable backup, incremental
+  schema conversion, replay validation, and rollback before Go retirement.
+- The plugin cannot overwrite user-owned host configuration during reconciliation.
+
+## Alternatives rejected
+
+- **Keep the sibling Brain repository:** retains two-repository operational
+  failure modes and conflicts with the chosen public architecture.
+- **Store state inside the plugin:** mixes project memory with replaceable
+  installation assets and prevents portable project-level backup.
+- **Use a mandatory remote database:** breaks offline use and adds privacy,
+  tenancy, authentication, and availability dependencies.
+

--- a/docs/adr/0004-host-adapter-boundary.md
+++ b/docs/adr/0004-host-adapter-boundary.md
@@ -1,0 +1,52 @@
+# ADR 0004: Host-Neutral Core and Thin Adapters
+
+Status: Accepted
+
+Date: 2026-08-06
+
+## Context
+
+Claude Code and OpenAI Codex expose different invocation, instruction,
+capability, hook, and model-observation surfaces. Encoding those differences in
+the state machine would create host-specific workflow semantics. Reducing the
+core to the weakest host would also discard useful enforcement where a stronger
+host surface exists.
+
+Mestre Yoda must provide the same deterministic decisions on both hosts while
+reporting capability differences honestly.
+
+## Decision
+
+The decision engine, reducers, contracts, state services, and result semantics
+are host-neutral. Claude Code and Codex integrate through thin adapters that
+translate invocation, capability discovery, observed identity, and response
+rendering. Adapters never own transition policy and never mutate canonical state
+directly.
+
+Both adapters must pass one shared conformance suite. A future host is added by
+implementing the same versioned adapter protocol rather than branching the core.
+
+Host capabilities are normalized as explicit data. A missing preventive hook
+does not remove the runtime's authoritative completion checks. When a host
+cannot provide trustworthy observed identity or another optional signal, the
+result and event record the limitation instead of substituting configured or
+model-reported identity.
+
+## Consequences
+
+- Shared scenarios produce equivalent decisions and reason codes across hosts.
+- Host-specific wiring remains small, reviewable, and replaceable.
+- Capability gaps are visible and testable without weakening common policy.
+- Shared conformance tests are necessary but insufficient; each adapter also
+  needs real host contract and end-to-end tests.
+- New host support requires protocol compatibility rather than core forks.
+- Adapter and runtime versions must be bound by the plugin manifest.
+
+## Alternatives rejected
+
+- **Separate runtimes per host:** invites divergent policy and duplicated fixes.
+- **Put host branching throughout the core:** obscures deterministic behavior
+  and makes conformance difficult to prove.
+- **Restrict all hosts to the weakest capability set:** sacrifices preventive
+  controls without improving the authoritative runtime checks.
+

--- a/docs/adr/0004-host-adapter-boundary.md
+++ b/docs/adr/0004-host-adapter-boundary.md
@@ -49,4 +49,3 @@ model-reported identity.
   and makes conformance difficult to prove.
 - **Restrict all hosts to the weakest capability set:** sacrifices preventive
   controls without improving the authoritative runtime checks.
-

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+Architecture Decision Records preserve the context, selected choice,
+consequences, and rejected alternatives for structural Mestre Yoda decisions.
+The canonical architecture specification defines the whole system; these records
+explain why its foundational boundaries exist.
+
+## Accepted decisions
+
+- [ADR 0001: Event-Sourced Project History](0001-event-sourced-project-history.md)
+  makes the append-only event stream authoritative and snapshots derived.
+- [ADR 0002: Embedded Self-Contained ESM Runtime](0002-embedded-esm-runtime.md)
+  binds TypeScript development to a single plugin-owned JavaScript artifact.
+- [ADR 0003: Project-Local Brain State](0003-project-local-brain-state.md)
+  places project memory in `.brain/` and defines the legacy migration boundary.
+- [ADR 0004: Host-Neutral Core and Thin Adapters](0004-host-adapter-boundary.md)
+  keeps Claude Code and Codex integration outside deterministic workflow policy.
+
+## Lifecycle
+
+Accepted ADRs are immutable historical records. A changed structural decision
+adds a new ADR that supersedes the old one, and both records link to each other.
+Implementation pull requests that change a structural boundary cite the
+governing ADR and explain compatibility, state, migration, and security impact.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,4 +22,3 @@ Accepted ADRs are immutable historical records. A changed structural decision
 adds a new ADR that supersedes the old one, and both records link to each other.
 Implementation pull requests that change a structural boundary cite the
 governing ADR and explain compatibility, state, migration, and security impact.
-

--- a/docs/architecture/verification.md
+++ b/docs/architecture/verification.md
@@ -124,7 +124,7 @@ Placeholder and whitespace checks:
 
 ```bash
 rg -n '\b(T[O]DO|T[B]D|F[I]XME|X[X]X)\b' README.md docs .github || true
-git diff --check
+git diff --check origin/main...HEAD
 ```
 
 Expected result: zero lint issues, zero actionlint findings, zero failed links,

--- a/docs/architecture/verification.md
+++ b/docs/architecture/verification.md
@@ -129,3 +129,13 @@ git diff --check origin/main...HEAD
 
 Expected result: zero lint issues, zero actionlint findings, zero failed links,
 no placeholder matches, and no whitespace errors.
+
+## Rendered document review
+
+The integration PR's first Documentation workflow completed successfully. The
+two Mermaid blocks were also parsed and rendered with the official Mermaid CLI
+11.16.0 into a sequence-diagram image and a state-diagram image. Manual image
+inspection confirmed that participants, transitions, labels, branches, and
+terminal states are visible and preserve the source order without a syntax or
+layout failure. An independent read-only review then reported no remaining
+Critical, Important, or Minor findings.

--- a/docs/architecture/verification.md
+++ b/docs/architecture/verification.md
@@ -1,0 +1,131 @@
+# Architecture Verification Evidence
+
+Date: 2026-08-06
+
+Scope: [Yoda Observable Architecture Specification](../superpowers/specs/2026-08-06-yoda-observable-architecture-design.md)
+
+This record satisfies the architecture issue's required manual trace. It traces
+one successful content-bound spec approval and one rejected gate token from host
+invocation to user response. It verifies component boundaries and state effects;
+the Compatibility Contract milestone owns final JSON Schema property enums and
+the complete reason/exit-code catalog.
+
+## Preconditions
+
+- A Yoda project is initialized with project-owned `.brain/` state.
+- Run `0001-login` is at `AwaitingSpecApproval` after valid `research`, `prd`,
+  `spec`, and `review` phases.
+- `prd-output.json` and `spec-output.json` validate against their recorded
+  contract versions.
+- The current PRD and spec canonical hashes match the reviewed artifacts.
+- The run event chain and snapshot cursor verify successfully.
+- No active write lease owns the run.
+- Policy permits the transition and there are no unresolved business-gap or
+  partition checkpoints.
+
+## Successful trace
+
+Input from Claude Code or Codex:
+
+```text
+continue --gate aprovacao_spec
+```
+
+The legacy-compatible gate identifier remains stable until the Compatibility
+Contract publishes a versioned replacement.
+
+1. **Host adapter:** The adapter records the host capability context and observed
+   identity available from the host. It normalizes the invocation without
+   selecting a phase or mutating `.brain/`.
+2. **Command boundary:** The parser recognizes `continue`, validates the exact
+   gate argument, rejects extra phase-selection arguments, and produces a typed
+   operation.
+3. **Project locator:** The runtime resolves the repository root and confines all
+   managed paths to `.brain/`. It rejects traversal and symlink substitution
+   before reading state.
+4. **Lock and state loader:** The runtime obtains a fenced write lease, validates
+   configuration and contract versions, verifies the event hash chain, and
+   reconciles `state.json` with its event cursor.
+5. **Decision engine:** The pure engine receives validated state, hashes,
+   policies, and normalized input. It confirms that the current human gate is
+   exactly `aprovacao_spec`, the reviewed PRD/spec lineage is current, and the
+   legal resulting lifecycle state is `Code`.
+6. **Effect planner:** The runtime produces an ordered plan to record approval,
+   bind it to the PRD/spec hashes and policy version, append the decision event,
+   and advance the snapshot. No application source file is part of the plan.
+7. **Transaction manager:** The runtime stages the approval and new snapshot,
+   appends the event through the recoverable transaction boundary, durably
+   publishes the state, and releases the fenced lease. An interruption leaves a
+   transaction marker for deterministic recovery.
+8. **Event store:** The approval event records the normalized operation, prior
+   and resulting state identities, contract and policy versions, stable reason
+   code, PRD/spec digests, human-approval evidence reference, effect summary,
+   and observed host/model identity when available. Sensitive artifact content
+   is not copied into the event.
+9. **Result renderer:** The host receives a successful structured result with
+   exit code 0, `stateChanged: true`, approval/event evidence references, and
+   recovery semantics indicating that no retry is required. The human summary
+   states that the current spec is approved and the next runtime-selected phase
+   is `code`.
+10. **Host response:** Claude Code or Codex relays the result. Neither adapter
+    edits state, reinterprets the decision, nor claims that a model approved the
+    spec.
+
+The trace maps to specification Sections 6, 7.2, 7.3, and 8. It preserves the
+Go v3 invariant that no code starts before content-bound human approval.
+
+## Negative trace
+
+Input while the current gate is `aprovacao_spec`:
+
+```text
+continue --gate gaps_abertos
+```
+
+The command boundary and state loader perform the same safe validation steps.
+The decision engine rejects the mismatched token deterministically. The result
+is blocked, `stateChanged` is false, and recovery names the exact current gate.
+No approval record, lifecycle transition, or other state-changing event is
+committed. A diagnostic observation may be emitted only if its event contract
+cannot be confused with an accepted transition.
+
+## Architecture assertions
+
+- The host adapter translates; it does not decide.
+- The pure decision engine decides; it does not perform effects.
+- The transaction boundary commits state and event evidence together.
+- The event stream proves the observed decision history; the snapshot and
+  Markdown views remain derived.
+- Approval is human, explicit, exact-gate, and bound to reviewed content.
+- The same normalized input and validated state produce the same outcome on
+  Claude Code and Codex.
+
+## Reproducible documentation checks
+
+Markdown lint:
+
+```bash
+npx --yes markdownlint-cli2@0.23.2 '**/*.md'
+```
+
+Workflow semantics:
+
+```bash
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/docs.yml
+```
+
+Link validation uses Lychee 0.24.2 from its immutable release archive:
+
+```bash
+lychee --config .lychee.toml './**/*.md'
+```
+
+Placeholder and whitespace checks:
+
+```bash
+rg -n '\b(T[O]DO|T[B]D|F[I]XME|X[X]X)\b' README.md docs .github || true
+git diff --check
+```
+
+Expected result: zero lint issues, zero actionlint findings, zero failed links,
+no placeholder matches, and no whitespace errors.

--- a/docs/superpowers/plans/2026-08-06-yoda-observable-architecture.md
+++ b/docs/superpowers/plans/2026-08-06-yoda-observable-architecture.md
@@ -210,7 +210,7 @@ max_retries = 3
 retry_wait_time = 2
 timeout = 20
 max_concurrency = 8
-accept = ["200..=204", "429"]
+accept = ["200..=204"]
 include_fragments = "full"
 include_mail = false
 ```

--- a/docs/superpowers/plans/2026-08-06-yoda-observable-architecture.md
+++ b/docs/superpowers/plans/2026-08-06-yoda-observable-architecture.md
@@ -1,0 +1,420 @@
+# Yoda Observable Architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete issue #2 with an approved canonical architecture specification, four accepted ADRs, documentation CI, and reproducible lint, link, and manual-trace evidence.
+
+**Architecture:** Keep the approved canonical specification at `docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md`, record each structural choice in one focused ADR, and make the README the navigation entrypoint. Add one least-privilege documentation workflow now; later TypeScript, platform, security, compatibility, nightly, and release workflows remain owned by their dependency-ordered backlog issues.
+
+**Tech Stack:** Markdown, Mermaid, GitHub Actions, markdownlint-cli2 0.23.2, Lychee 0.24.2, actionlint 1.7.7, Bash verification commands
+
+## Global Constraints
+
+- All repository content, workflow names, comments, commit messages, and PR text are English-only.
+- Preserve the Go v3 phase order `research -> prd -> spec -> review -> code -> eval -> done`.
+- Preserve PRD Problem Discovery, adaptive 5 Whys, 5W2H, structured output, blocking/open question semantics, lineage, and content-bound human approval.
+- Runtime development is TypeScript, but distribution is one self-contained ESM JavaScript artifact with no global Yoda binary and no runtime `node_modules`.
+- Project state lives under project-owned `.brain/`; host wiring lives under `.claude/` and `.codex/`; runtime, schemas, skills, adapters, and templates remain plugin-owned.
+- No runtime implementation code is part of issue #2.
+- Third-party GitHub Actions are pinned to immutable commit SHAs, workflow permissions are read-only, and jobs have explicit timeouts and fork-safe behavior.
+- The documentation workflow must not claim to validate TypeScript, platform, compatibility, security, or release behavior before those suites exist.
+
+---
+
+## File map
+
+- `docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md`: canonical architecture and milestone traceability.
+- `docs/adr/0001-event-sourced-project-history.md`: event log authority and derived snapshots.
+- `docs/adr/0002-embedded-esm-runtime.md`: TypeScript development and self-contained ESM distribution.
+- `docs/adr/0003-project-local-brain-state.md`: in-project `.brain/` ownership and legacy migration boundary.
+- `docs/adr/0004-host-adapter-boundary.md`: host-neutral core and Claude Code/Codex adapters.
+- `docs/adr/README.md`: ADR index and lifecycle rules.
+- `docs/architecture/verification.md`: required manual end-to-end trace and reproducible evidence commands.
+- `.markdownlint-cli2.jsonc`: repository Markdown policy.
+- `.lychee.toml`: deterministic link-check policy and retry behavior.
+- `.github/workflows/docs.yml`: documentation quality workflow.
+- `README.md`: links to the canonical architecture, ADR index, and verification evidence.
+
+### Task 1: Record the four architecture decisions
+
+**Files:**
+
+- Create: `docs/adr/0001-event-sourced-project-history.md`
+- Create: `docs/adr/0002-embedded-esm-runtime.md`
+- Create: `docs/adr/0003-project-local-brain-state.md`
+- Create: `docs/adr/0004-host-adapter-boundary.md`
+- Create: `docs/adr/README.md`
+
+**Interfaces:**
+
+- Consumes: Sections 4–7 and 11 of the canonical architecture specification.
+- Produces: Five stable relative paths used by the README, verification document, and future implementation issues.
+
+- [ ] **Step 1: Run the ADR presence check and observe failure**
+
+Run:
+
+```bash
+for file in \
+  docs/adr/0001-event-sourced-project-history.md \
+  docs/adr/0002-embedded-esm-runtime.md \
+  docs/adr/0003-project-local-brain-state.md \
+  docs/adr/0004-host-adapter-boundary.md; do
+  test -s "$file" || { echo "missing: $file"; exit 1; }
+done
+```
+
+Expected: FAIL on `docs/adr/0001-event-sourced-project-history.md`.
+
+- [ ] **Step 2: Write ADR 0001**
+
+Create `docs/adr/0001-event-sourced-project-history.md` with status `Accepted`, the context that mutable state alone cannot prove why a decision occurred, and this exact decision:
+
+```markdown
+## Decision
+
+Each run owns an append-only, hash-linked event stream as its authoritative history. A validated `state.json` snapshot accelerates startup but is derived from the event cursor and hash. Markdown checkboxes, status pages, dashboards, and summaries are regenerable views.
+
+Every committed decision event records normalized inputs, contract and policy versions, prior and resulting state identities, stable reason code, effect summary, artifact digests, and observed host/model identity when available. Events reference sensitive evidence by digest. The hash chain detects mutation; it does not authenticate an author.
+```
+
+Record consequences: deterministic replay, auditable recovery, additional transaction discipline, explicit corruption handling, and future signed attestations remaining separate.
+
+- [ ] **Step 3: Write ADR 0002**
+
+Create `docs/adr/0002-embedded-esm-runtime.md` with status `Accepted` and this exact decision:
+
+```markdown
+## Decision
+
+Develop the runtime and supporting packages in strict TypeScript and distribute the executable runtime as one self-contained JavaScript ESM file at `runtime/yoda.mjs` inside the installed plugin. Runtime execution must not require TypeScript sources, a global `yoda` binary, project-local dependencies, a runtime `node_modules`, or network access.
+
+The plugin manifest binds the plugin, runtime, schema, skill, adapter, and template versions. Black-box tests execute the final bundle from a clean fixture before release.
+```
+
+Record consequences: version coherence and easy installation, a required bundling/package-verification pipeline, source maps handled as release artifacts, and rejection of global Go/Node CLI and unbundled package alternatives.
+
+- [ ] **Step 4: Write ADR 0003**
+
+Create `docs/adr/0003-project-local-brain-state.md` with status `Accepted` and this exact decision:
+
+```markdown
+## Decision
+
+Project-specific Yoda state lives under `.brain/` inside the user project. Claude Code wiring lives under `.claude/`, and Codex wiring lives under `.codex/`. Runtime code, schemas, skills, adapters, and templates remain plugin-owned.
+
+The Go v3 sibling `<repo>-brain/.brain/` layout is a legacy source only. Migration is explicit, previewable, backed up, transactional, verified, and reversible. Discovery never mutates either location.
+```
+
+Record consequences: portable project state and simpler discovery, explicit repository privacy/ignore policy, managed-path confinement, and a migration obligation before Go retirement.
+
+- [ ] **Step 5: Write ADR 0004**
+
+Create `docs/adr/0004-host-adapter-boundary.md` with status `Accepted` and this exact decision:
+
+```markdown
+## Decision
+
+The decision engine, reducers, contracts, state services, and result semantics are host-neutral. Claude Code and Codex integrate through thin adapters that translate invocation, capability discovery, observed identity, and response rendering. Adapters never own transition policy and never mutate canonical state directly.
+
+Both adapters must pass one shared conformance suite. A future host is added by implementing the same versioned adapter protocol rather than branching the core.
+```
+
+Record consequences: behavioral parity across hosts, explicit capability gaps, no lowest-common-denominator weakening, and host-specific E2E tests in addition to shared conformance tests.
+
+- [ ] **Step 6: Write the ADR index**
+
+Create `docs/adr/README.md` with an `# Architecture Decision Records` heading, links and one-sentence summaries for ADRs 0001–0004, and lifecycle rules: accepted ADRs are immutable; superseding decisions add a new ADR and link both directions; structural implementation PRs cite the governing ADR.
+
+- [ ] **Step 7: Re-run the ADR presence and decision checks**
+
+Run:
+
+```bash
+for file in docs/adr/000{1,2,3,4}-*.md; do
+  test -s "$file"
+  rg -q '^Status: Accepted$' "$file"
+  rg -q '^## Decision$' "$file"
+  rg -q '^## Consequences$' "$file"
+done
+```
+
+Expected: PASS with exit code 0.
+
+- [ ] **Step 8: Commit the ADRs**
+
+```bash
+git add docs/adr
+git commit -m "docs: record foundational architecture decisions"
+```
+
+### Task 2: Add documentation quality automation
+
+**Files:**
+
+- Create: `.markdownlint-cli2.jsonc`
+- Create: `.lychee.toml`
+- Create: `.github/workflows/docs.yml`
+- Modify: `docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md`
+
+**Interfaces:**
+
+- Consumes: Markdown files and HTTP/file links in the repository.
+- Produces: Required `Documentation` workflow check and local commands identical to CI tool versions.
+
+- [ ] **Step 1: Run Markdown lint without repository configuration**
+
+Run:
+
+```bash
+npx --yes markdownlint-cli2@0.23.2 '**/*.md'
+```
+
+Expected: FAIL on existing intentional formatting such as long lines or inline HTML, proving the check is active before policy configuration.
+
+- [ ] **Step 2: Add the Markdown policy**
+
+Create `.markdownlint-cli2.jsonc`:
+
+```jsonc
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": {
+      "siblings_only": true
+    },
+    "MD033": {
+      "allowed_elements": [
+        "p",
+        "img"
+      ]
+    }
+  },
+  "globs": [
+    "**/*.md",
+    "!node_modules"
+  ]
+}
+```
+
+This keeps structural rules enabled while allowing the README's centered image and prose that must preserve literal commands and URLs.
+
+- [ ] **Step 3: Add the link policy**
+
+Create `.lychee.toml`:
+
+```toml
+no_progress = true
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+max_concurrency = 8
+accept = ["200..=204", "429"]
+include_fragments = "full"
+include_mail = false
+```
+
+- [ ] **Step 4: Add the documentation workflow**
+
+Create `.github/workflows/docs.yml`:
+
+```yaml
+name: Documentation
+
+on:
+  pull_request:
+    branches: [developer, main]
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".lychee.toml"
+      - ".github/workflows/docs.yml"
+  push:
+    branches: [developer, main]
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".lychee.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  documentation:
+    name: Markdown and links
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
+        with:
+          globs: |
+            **/*.md
+            #node_modules
+      - name: Check links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: --config .lychee.toml './**/*.md'
+          fail: true
+          failIfEmpty: true
+          jobSummary: true
+```
+
+- [ ] **Step 5: Run Markdown lint and fix only reported violations**
+
+Run:
+
+```bash
+npx --yes markdownlint-cli2@0.23.2 '**/*.md'
+```
+
+Expected: PASS with `Summary: 0 error(s)` after minimal formatting fixes.
+
+- [ ] **Step 6: Validate workflow semantics**
+
+Run:
+
+```bash
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/docs.yml
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 7: Check links with the pinned Lychee release**
+
+Run Lychee 0.24.2 against `./**/*.md` using `.lychee.toml`. Expected: PASS with zero excluded broken local links and zero failed links. If an external service returns a reproducible rate-limit response, configure only that exact host/status behavior and document the reason; do not add a blanket URL exclusion.
+
+- [ ] **Step 8: Commit documentation automation**
+
+```bash
+git add .github/workflows/docs.yml .markdownlint-cli2.jsonc .lychee.toml docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
+git commit -m "ci: validate project documentation"
+```
+
+### Task 3: Add trace evidence and navigation
+
+**Files:**
+
+- Create: `docs/architecture/verification.md`
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md`
+
+**Interfaces:**
+
+- Consumes: The canonical command flow, state model, event contract, and ADR links.
+- Produces: A reproducible host-to-response trace and discoverable public architecture entrypoints.
+
+- [ ] **Step 1: Prove navigation and trace evidence are absent**
+
+Run:
+
+```bash
+test -s docs/architecture/verification.md && \
+rg -q 'Yoda Observable Architecture Specification' README.md && \
+rg -q 'Architecture Decision Records' README.md
+```
+
+Expected: FAIL because `docs/architecture/verification.md` does not exist.
+
+- [ ] **Step 2: Write the manual trace evidence**
+
+Create `docs/architecture/verification.md` with:
+
+- scope and date;
+- preconditions: initialized project, active run at valid PRD/spec approval boundary, no lock owner, valid event chain;
+- input: Codex or Claude Code requests `continue --gate aprovacao_spec`;
+- numbered observations for adapter normalization, command/schema validation, project resolution, fenced lease, state/event verification, pure decision, transaction, `spec_approved` event, state snapshot, and structured response;
+- expected event fields: normalized operation, prior/resulting state identities, policy/contract versions, PRD/spec hashes, human-approval evidence reference, reason code, and effect summary;
+- expected response: success, state changed, evidence references, and next action `code` without exposing sensitive content;
+- negative trace: wrong gate token returns deterministic blocked result, appends no state-changing event, and instructs the exact current gate;
+- exact lint, link, actionlint, placeholder, and `git diff --check` commands used for issue evidence.
+
+- [ ] **Step 3: Link ADRs from the canonical specification**
+
+Add a `## 17. Architecture decision records` section linking ADRs 0001–0004 by relative path and stating that the specification defines the system while ADRs preserve the reason and consequences of each structural choice.
+
+- [ ] **Step 4: Add README navigation**
+
+In the README Architecture section, add links to:
+
+```markdown
+The canonical [Yoda Observable Architecture Specification](docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md) defines the runtime, state, security, migration, testing, and rollout contracts. Structural choices and their consequences are indexed in the [Architecture Decision Records](docs/adr/README.md), and the required end-to-end architecture trace is recorded in [verification evidence](docs/architecture/verification.md).
+```
+
+- [ ] **Step 5: Run the complete documentation verification**
+
+Run:
+
+```bash
+npx --yes markdownlint-cli2@0.23.2 '**/*.md'
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/docs.yml
+rg -n '\b(T[O]DO|T[B]D|F[I]XME|X[X]X)\b' README.md docs .github || true
+git diff --check
+```
+
+Expected: Markdown lint and actionlint pass; placeholder scan prints no matches; `git diff --check` prints no errors. Run Lychee 0.24.2 with `.lychee.toml` and expect zero failed links.
+
+- [ ] **Step 6: Perform the manual trace review**
+
+Read `docs/architecture/verification.md` in order and verify each transition appears in canonical specification Section 6 or 7, every persisted field is named in Section 6, the approval/hash behavior appears in Section 7.3, and response semantics appear in Section 8. Expected: every trace step maps to the specification without an invented component or state mutation.
+
+- [ ] **Step 7: Commit navigation and evidence**
+
+```bash
+git add README.md docs/architecture/verification.md docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
+git commit -m "docs: add architecture verification evidence"
+```
+
+### Task 4: Final issue and publication evidence
+
+**Files:**
+
+- Verify: all files changed on `docs/issue-2-yoda-observable`
+
+**Interfaces:**
+
+- Consumes: Commits from Tasks 1–3 and the initial canonical-spec commit.
+- Produces: A reviewable PR linked to issue #2 and closure evidence.
+
+- [ ] **Step 1: Check issue acceptance coverage**
+
+Run commands that assert the motto, ownership directories, TypeScript/ESM decision, all required architecture section headings, all nine milestone rows, and four accepted ADR links exist. Expected: all assertions exit 0.
+
+- [ ] **Step 2: Run the complete verification suite from a clean worktree state**
+
+Run Markdown lint, Lychee, actionlint, placeholder scan, `git diff --check`, and `git status --short`. Expected: all checks pass and only intentional committed changes exist.
+
+- [ ] **Step 3: Review the branch diff**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --check origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected: only architecture documentation, documentation policy/workflow, and README navigation changes; no runtime implementation.
+
+- [ ] **Step 4: Publish a draft PR targeting the available integration branch**
+
+Push `docs/issue-2-yoda-observable` and open a PR that links `Closes #2`, explains PRD compatibility and the intentional state/distribution changes, states security and migration impact, and lists exact verification commands and results. Target `developer` if it exists; otherwise target `main` and explicitly note that issue #60 will establish the future integration branch.
+
+- [ ] **Step 5: Confirm CI and complete maintainer review**
+
+Wait for the Documentation workflow to pass. Review the rendered GitHub Markdown, Mermaid diagrams, workflow annotations, and changed-files list. Record maintainer approval on the PR; the user's explicit autonomous-approval instruction authorizes the recommended design, but CI and rendered-document review still must provide objective evidence.
+
+- [ ] **Step 6: Merge and close issue #2**
+
+Merge only after CI is green and the PR has no unresolved review findings. Confirm GitHub closes issue #2 through `Closes #2`, then proceed to issue #3 in dependency order.

--- a/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
@@ -1,10 +1,10 @@
 # Yoda Observable Architecture Specification
 
-- Status: Ready for Review
+- Status: Approved
 - Decision date: 2026-08-06
 - Scope: TypeScript rewrite of Mestre Yoda
 - Tracking issue: [#2](https://github.com/thiagocorreanet/mestre-yoda/issues/2)
-- Approval path: Maintainer review and green documentation CI on the integration PR
+- Approval evidence: Maintainer-authorized autonomous review on [PR #69](https://github.com/thiagocorreanet/mestre-yoda/pull/69), green [documentation CI](https://github.com/thiagocorreanet/mestre-yoda/actions/runs/31138521049), independent review with no findings, and successful Mermaid rendering
 
 ## 1. Purpose and authority
 

--- a/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
@@ -507,4 +507,3 @@ adapters and a shared conformance contract. The Go v3 SDD process—especially
 PRD discovery, structured output, lineage, independent review, and human
 approval—remains the compatibility baseline. Distribution and observability
 change; workflow meaning does not.
-

--- a/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
@@ -1,10 +1,10 @@
 # Yoda Observable Architecture Specification
 
-- Status: Approved
+- Status: Ready for Review
 - Decision date: 2026-08-06
 - Scope: TypeScript rewrite of Mestre Yoda
 - Tracking issue: [#2](https://github.com/thiagocorreanet/mestre-yoda/issues/2)
-- Approval basis: Maintainer-authorized autonomous design approval
+- Approval path: Maintainer review and green documentation CI on the integration PR
 
 ## 1. Purpose and authority
 
@@ -93,13 +93,32 @@ implementation architecture or code. Its process is equivalent to Go v3:
 10. Separate blocking questions, which stop the trail, from open questions,
     which the spec phase must resolve explicitly.
 
-The PRD producer emits both the human-readable `00-prd.md` view and a structured
-`prd-output.json`. The structured result identifies the producing role,
-completion status, next action, feature, written artifacts, discovery outcome,
-open questions, and blocking questions. A completed PRD is usable only when its
-structured output validates against the versioned schema, reports completion,
-and names at least one artifact. Missing or invalid PRD output is a deterministic
-checkpoint, not a human gate and not something a model may waive.
+Before choosing an outcome, the PRD researcher consumes the original demand and
+relayed interview answers, reads the project's stack profile and known-gotcha
+memory when present, and explores related code structure, naming, and existing
+features when code exists. It asks only questions whose answers cannot be
+inferred safely from that evidence. It never invents a missing answer. The PRD
+language follows the project's `documentationLanguage`; when the project has no
+language policy, it defaults to English while preserving domain terms and proper
+nouns.
+
+The two PRD outcomes remain observably distinct:
+
+| Condition | Human-facing behavior | Structured result | Filesystem effect |
+| --- | --- | --- | --- |
+| Context is insufficient | Return only the blocking `OPEN QUESTIONS`, with concise options when useful, and stop for relayed user input | `status: needs_input`, `next_action: needs_input`, the current feature, empty `artifacts`, and non-empty `blocking_questions` | Do not create or modify `00-prd.md` or another PRD artifact |
+| Context is sufficient | Write the complete WHAT/WHY PRD, return its path plus a three-line problem/goal/scope summary, and proceed to spec | `status: completed`, `next_action: proceed`, the current feature, at least one artifact, completed discovery fields, deferred `open_questions`, and empty `blocking_questions` | Write `00-prd.md` under the active feature through the managed transaction boundary |
+
+Both outcomes emit the versioned machine result through the host's structured
+output channel, separate from user-facing prose. This separation preserves the
+legacy `OPEN QUESTIONS` ending without forcing the runtime to parse free text.
+Re-invocation after answers repeats context validation rather than assuming that
+the prior questions made the PRD complete.
+
+A completed PRD is usable only when its structured output validates against the
+versioned schema, reports completion, and names at least one artifact. Missing,
+invalid, or `needs_input` PRD output is a deterministic checkpoint, not a human
+gate and not something a model may waive.
 
 Schema version 1 from Go v3 is the compatibility baseline. The compatibility
 contract may publish a successor, but it must retain the semantics above and
@@ -169,7 +188,7 @@ plugin/
 - Skills explain how agents collaborate with the runtime.
 - Schemas are versioned public contracts embedded in the bundle.
 - Templates generate managed project surfaces.
-- The manifest binds plugin, runtime, schema, and template versions.
+- The manifest binds plugin, runtime, schema, skill, adapter, and template versions.
 
 Runtime execution must not require a global `yoda` binary, a project-local
 `node_modules`, TypeScript sources, or network access.

--- a/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
@@ -1,0 +1,510 @@
+# Yoda Observable Architecture Specification
+
+Status: Approved  
+Decision date: 2026-08-06  
+Scope: TypeScript rewrite of Mestre Yoda  
+Tracking issue: [#2](https://github.com/thiagocorreanet/mestre-yoda/issues/2)
+
+## 1. Purpose and authority
+
+This document is the canonical architecture specification for the Mestre Yoda
+rewrite. It defines the product invariants, ownership boundaries, component
+model, command and state flow, failure semantics, security posture, test
+strategy, migration policy, and rollout constraints that implementation must
+preserve.
+
+The frozen Go v3 implementation in `mestre-yoda-old` is the behavioral baseline.
+The rewrite may change implementation language, distribution, project-state
+placement, observability, and host integration, but it must not silently change
+the SDD process. In particular, the PRD process and its machine-readable
+contract remain behaviorally equivalent. Any intentional compatibility change
+requires a versioned contract, a documented migration, differential evidence,
+and maintainer approval.
+
+When sources disagree, authority is resolved in this order:
+
+1. approved architecture decisions and versioned public contracts;
+2. this specification;
+3. the compatibility inventory and golden fixtures derived from Go v3;
+4. implementation details;
+5. prompts and generated views.
+
+Prompts may guide work, but they never redefine runtime policy.
+
+## 2. Product principle
+
+> **The model proposes. The runtime decides. The event log proves.**
+
+This motto assigns authority explicitly:
+
+- The model researches, reasons, proposes artifacts, and performs work permitted
+  by its host.
+- The runtime validates inputs, selects legal transitions, applies policy,
+  commits state, and explains blocked work deterministically.
+- The event log records what the runtime observed and decided, with enough
+  lineage to audit and replay the decision.
+
+The same validated state, configuration, contracts, and inputs must produce the
+same decision. A model statement is evidence only when a contract explicitly
+accepts it; it is never proof that a deterministic gate passed.
+
+## 3. Non-negotiable behavioral invariants
+
+### 3.1 Single agent-driven trail
+
+The user-facing trail remains agent-driven. Its primary operations are
+`objective`, `start`, `continue`, and `done`. Manual phase jumping is not part
+of the public workflow. Operational commands such as `status`, `doctor`,
+`explain`, `evidence`, `handoff`, `stats`, and `budgets` inspect or support the
+trail without becoming alternate transition paths.
+
+The planning and delivery phases remain ordered as follows:
+
+```text
+research -> prd -> spec -> review -> code -> eval -> done
+```
+
+Every transition is selected by the runtime from persisted state. An agent may
+request an operation, but it may not select the next phase directly.
+
+### 3.2 The PRD contract is preserved
+
+The PRD remains the authoritative **WHAT and WHY** artifact. It must not contain
+implementation architecture or code. Its process is equivalent to Go v3:
+
+1. Preserve the initial demand verbatim.
+2. Classify it as a problem, proposed solution, bug, improvement, refactor, or
+   external obligation.
+3. Apply adaptive Problem Discovery. Use the 5 Whys when the demand is vague,
+   recurring, or solution-first; stop when the probable root cause is clear.
+   When the technique is not useful, record the reason instead of fabricating
+   five answers.
+4. State a probable root cause in terms of a process, system, rule, flow,
+   communication, architecture, or context. Never assign personal blame.
+5. Separate the validated problem from the proposed solution.
+6. Record a solution hypothesis without treating it as an approved design.
+7. Define success evidence tied to the validated problem and record the risk
+   that the root-cause hypothesis may be wrong.
+8. After the problem is clear, apply 5W2H action framing when it adds value.
+   Otherwise record why it was skipped.
+9. Define the problem, users, goals, non-goals, in-scope and out-of-scope work,
+   success metrics, and open questions.
+10. Separate blocking questions, which stop the trail, from open questions,
+    which the spec phase must resolve explicitly.
+
+The PRD producer emits both the human-readable `00-prd.md` view and a structured
+`prd-output.json`. The structured result identifies the producing role,
+completion status, next action, feature, written artifacts, discovery outcome,
+open questions, and blocking questions. A completed PRD is usable only when its
+structured output validates against the versioned schema, reports completion,
+and names at least one artifact. Missing or invalid PRD output is a deterministic
+checkpoint, not a human gate and not something a model may waive.
+
+Schema version 1 from Go v3 is the compatibility baseline. The compatibility
+contract may publish a successor, but it must retain the semantics above and
+provide explicit migration and differential fixtures.
+
+### 3.3 Spec, tasks, and acceptance criteria
+
+The spec remains the authoritative **HOW** artifact. It resolves PRD open
+questions, describes architecture and contracts, compares trade-offs, and
+produces an executable task plan. Tasks are grouped into numbered sprints and
+declare affected files, implementation steps, explicit exclusions, and
+machine-verifiable acceptance criteria.
+
+Acceptance-criterion identifiers retain the Go v3 shape
+`AC-<sprint>.<task>.<number>` and `AC-<sprint>.<task>.E<number>` for edge cases.
+They are stable audit identifiers and are never renumbered after approval. Their
+canonical status lives in structured state written by the runtime; Markdown
+checkboxes are derived views.
+
+### 3.4 Independent review and human authority
+
+The actor that implements work does not judge its own result. Planner, executor,
+and judge are distinct roles with observed identity recorded where the host can
+provide it. Probabilistic review may contribute evidence, but only deterministic
+runtime policy changes workflow state.
+
+Spec approval and final delivery acceptance are always human decisions. Approval
+is content-bound: the runtime snapshots canonical hashes of the PRD and spec.
+Changing an approved parent artifact invalidates descendants and reopens the
+appropriate review and approval path. A stale approval never authorizes changed
+content.
+
+The four human gates remain behaviorally equivalent to Go v3:
+
+- `gaps_abertos`: unresolved business gaps require decisions by stable ID;
+- `particionamento`: measured scope exceeds configured limits and requires an
+  explicit partition decision;
+- `aprovacao_spec`: code cannot begin before the current PRD/spec lineage is
+  approved;
+- `aceitacao_final`: the runtime cannot accept its own delivery.
+
+Other stops are deterministic checkpoints, validation failures, recovery
+requirements, or budget controls. They do not become human gates merely because
+an agent cannot proceed.
+
+## 4. Ownership and filesystem boundaries
+
+### 4.1 Plugin-owned, immutable-at-runtime assets
+
+The installed, version-coherent plugin owns:
+
+```text
+plugin/
+├── runtime/yoda.mjs
+├── adapters/
+│   ├── claude-code/
+│   └── codex/
+├── skills/
+├── schemas/
+├── templates/
+└── manifest.json
+```
+
+- `runtime/yoda.mjs` is one self-contained ESM JavaScript artifact.
+- Adapters translate host invocation and response conventions without owning
+  workflow policy.
+- Skills explain how agents collaborate with the runtime.
+- Schemas are versioned public contracts embedded in the bundle.
+- Templates generate managed project surfaces.
+- The manifest binds plugin, runtime, schema, and template versions.
+
+Runtime execution must not require a global `yoda` binary, a project-local
+`node_modules`, TypeScript sources, or network access.
+
+### 4.2 Project-owned state and integration surfaces
+
+The user project owns:
+
+```text
+project/
+├── .brain/
+│   ├── config/
+│   ├── features/
+│   ├── runs/
+│   │   └── <run-id>/
+│   │       ├── state.json
+│   │       ├── events.jsonl
+│   │       ├── artifacts/
+│   │       └── transactions/
+│   ├── evidence/
+│   ├── locks/
+│   └── migrations/
+├── .claude/
+├── .codex/
+└── application source
+```
+
+- `.brain/` contains project configuration, canonical workflow state, events,
+  artifacts, evidence, locks, migration records, and derived views.
+- `.claude/` contains only Claude Code project instructions and wiring.
+- `.codex/` contains only Codex project instructions and wiring.
+- Application source remains owned by the project and is modified only through
+  the host's normal permissions plus Yoda's explicit scope policy.
+
+The plugin may update managed project files only through a versioned,
+previewable reconciliation operation. It must preserve user-owned content or
+fail with a conflict that names the recovery action. Host directories must not
+duplicate runtime policy or contain independent state machines.
+
+This in-project `.brain/` boundary intentionally replaces the Go v3 sibling
+`<repo>-brain` placement. Migration is explicit and transactional; discovery
+alone never moves or rewrites legacy state.
+
+## 5. Runtime components
+
+Each component has one authority and communicates through typed, versioned
+interfaces.
+
+| Component | Responsibility | Must not do |
+| --- | --- | --- |
+| Host adapter | Translate host calls, discover host capabilities, relay structured results | Decide policy or mutate state directly |
+| Command parser | Parse and validate command syntax and inputs | Read project state or perform effects |
+| Project locator | Resolve the repository root and managed paths safely | Follow untrusted paths outside the project boundary |
+| Contract registry | Load embedded schemas and compatibility versions | Infer contracts from prose |
+| State loader | Verify configuration, snapshots, event integrity, and migrations | Repair corruption silently |
+| Decision engine | Produce a pure decision from validated inputs and state | Perform filesystem, Git, network, or host effects |
+| Effect planner | Convert a decision into an ordered, previewable effect plan | Commit partial effects |
+| Transaction manager | Apply filesystem changes atomically and recover interrupted work | Hide incomplete transactions |
+| Event store | Append canonical, hash-linked events and rebuild derived state | Rewrite accepted history in place |
+| Git service | Classify repository state and calculate approved scope deltas | Shell-interpolate untrusted values |
+| Lock service | Serialize mutations with leases and fencing tokens | Treat an expired owner as authoritative |
+| Output renderer | Render one universal structured result and localized prose | Change the underlying reason or recovery semantics |
+
+The decision engine and reducers are portable and host-neutral. Every host
+adapter must pass the same conformance suite.
+
+## 6. Command flow
+
+All mutating operations follow the same order:
+
+```mermaid
+sequenceDiagram
+    participant H as Host adapter
+    participant C as Command boundary
+    participant L as Lock and state loader
+    participant D as Decision engine
+    participant T as Transaction and event store
+    participant R as Result renderer
+
+    H->>C: Invocation plus observed host context
+    C->>C: Parse and validate
+    C->>L: Resolve project and acquire fenced lease
+    L->>L: Verify config, contracts, snapshot, and event chain
+    L->>D: Validated state plus normalized input
+    D-->>L: Decision plus effect plan
+    L->>T: Apply atomic effects
+    T->>T: Append decision event and advance snapshot
+    T-->>R: Committed outcome and evidence references
+    R-->>H: Structured result plus human explanation
+```
+
+Read-only operations use the same validation boundary but do not acquire a
+write lease unless they materialize an artifact. Dry-run returns the exact
+ordered effect plan without committing state. If validation fails before a
+decision, no state changes. If a process stops during commit, a durable
+transaction marker makes the next invocation recover or roll back deterministically.
+
+The persisted event records normalized inputs, contract and policy versions,
+prior state identity, decision and reason code, effect summary, artifact hashes,
+observed host/model identity when available, and resulting state identity. It
+references evidence by digest instead of duplicating sensitive content.
+
+## 7. State and transition model
+
+### 7.1 Sources of truth
+
+The append-only event stream is the authoritative history. `state.json` is a
+validated snapshot derived from that stream for fast startup. Markdown status,
+task checkboxes, dashboards, and summaries are regenerable views. A snapshot
+that cannot be reconciled with its event cursor and hash is rejected and must be
+rebuilt through an explicit audit or repair operation.
+
+### 7.2 Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Initialized
+    Initialized --> ObjectiveDefined: objective
+    ObjectiveDefined --> Research: start
+    Research --> PRD: continue
+    PRD --> Spec: valid PRD checkpoint
+    Spec --> Review: valid spec output
+    Review --> AwaitingSpecApproval: deterministic checks pass
+    AwaitingSpecApproval --> Spec: revise
+    AwaitingSpecApproval --> Code: human approval
+    Code --> Eval: sprint implementation complete
+    Eval --> Code: changes required or next sprint
+    Eval --> AwaitingFinalAcceptance: all acceptance criteria pass
+    AwaitingFinalAcceptance --> Code: changes requested
+    AwaitingFinalAcceptance --> Done: human acceptance
+```
+
+Business-gap and partition gates may pause planning before spec approval. Budget,
+integrity, migration, lock, or recovery conditions may block any operation at
+their defined boundary. The runtime records the current gate or checkpoint and
+requires an exact matching operation; an unrelated `--gate` token is rejected.
+
+Objective declaration is idempotent for identical text. Replacing a different
+objective requires an explicit replace operation that preserves the former
+objective in append-only history before writing the new value.
+
+### 7.3 Lineage and invalidation
+
+Canonical JSON is hashed so whitespace and object-key order do not create false
+drift. Approval records bind the PRD hash, spec hash, policy version, approver,
+and timestamp. A changed or missing parent artifact creates lineage drift and
+invalidates the approval and affected descendants. Repair never fabricates an
+old hash or suppresses drift.
+
+## 8. Error and result semantics
+
+Every command returns one structured result shape with:
+
+- status and process exit code;
+- stable reason code;
+- concise summary and ordered explanation;
+- evidence references;
+- whether state changed;
+- whether retry is safe;
+- one actionable recovery instruction.
+
+Success, deterministic blocking, invalid invocation, contract failure,
+operational failure, integrity failure, and internal defect remain distinct.
+Human-readable text may be localized later, but scripts match only the stable
+structured fields. Unknown state, contract versions, policy modes, or corrupted
+managed files fail closed inside an initialized Yoda project. Outside a Yoda
+project, integrations remain inert unless the user explicitly invokes an
+initialization command.
+
+Exact reason-code and exit-code catalogs are owned by the Compatibility Contract
+milestone. Until that contract is approved, implementations must preserve the
+observable Go v3 distinctions and must not publish new stable values ad hoc.
+
+## 9. Security model
+
+### 9.1 Trust boundaries
+
+Project files, Git metadata, host payloads, model output, migrated legacy data,
+and environment variables are untrusted inputs. Embedded schemas and the
+verified plugin bundle are trusted only for the installed version recorded in
+the plugin manifest. Human approval proves authorization for specific content;
+it does not prove that the content is safe or correct.
+
+### 9.2 Required controls
+
+- Confine managed paths to the resolved project root and reject symlink,
+  traversal, special-file, and case-collision attacks.
+- Parse commands without shell interpolation and pass arguments as data.
+- Use atomic writes, durable transaction markers, lock leases, and fencing
+  tokens for all state mutations.
+- Validate every external and persisted object against a versioned schema before
+  using it in a decision.
+- Default to no telemetry and no network dependency at runtime.
+- Exclude secrets, raw prompts, source contents, and sensitive absolute paths
+  from events and evidence unless an explicit, reviewed contract requires them.
+- Treat the hash chain as tamper evidence, not as identity or authenticity.
+- Keep GitHub Actions read-only by default, fork-safe, time-bounded, and pinned
+  to immutable third-party action revisions.
+- Verify plugin artifacts, checksums, provenance, compatibility, and rollback
+  before an update becomes authoritative.
+- Record observed host and model identity when available; never claim stronger
+  identity evidence than the host supplies.
+
+Security-sensitive failures preserve minimal diagnostics and a safe recovery
+path without echoing the rejected secret or payload.
+
+## 10. Testing architecture
+
+Testing is layered so probabilistic evaluation is never used where deterministic
+evidence can answer the question.
+
+| Layer | Primary evidence |
+| --- | --- |
+| Pure unit | Policies, reducers, parsers, reason codes, canonical hashing |
+| Contract | JSON Schemas, public result shapes, host adapter protocol |
+| Property and model based | State-machine invariants and transition sequences |
+| Compatibility | Go v3 versus TypeScript differential results and golden scenarios |
+| Filesystem and Git integration | Real repositories, path safety, atomicity, ignored files |
+| Fault and concurrency | Crash points, lock expiry, fencing, replay, recovery |
+| Security | Malformed inputs, traversal, symlinks, injection, secret redaction, supply chain |
+| Bundle black box | Final `yoda.mjs` without repository dependencies or `node_modules` |
+| Platform | Native Linux, Windows, and macOS across the supported Node policy |
+| Host conformance | Identical Claude Code and Codex decisions for shared scenarios |
+| Migration | Discovery, preview, byte-level backup, conversion, rollback, idempotence |
+| Behavioral evaluation | Model behavior only where deterministic tests cannot decide |
+
+PR validation stays fast and cancels superseded commits. Nightly, compatibility,
+security, platform, and release workflows run deeper campaigns with bounded
+artifact retention and minimal reproduction evidence.
+
+Documentation changes run Markdown lint and link validation. Architecture
+changes additionally run a manual trace from host invocation through runtime
+decision, persisted event, and user response.
+
+## 11. Migration from Go v3
+
+Migration is a user-invoked transaction, never a side effect of discovery:
+
+1. Detect the legacy sibling `<repo>-brain/.brain/` and classify its version
+   without writing either repository.
+2. Produce a migration plan listing source, destination, contract upgrades,
+   conflicts, sensitive data handling, and rollback location.
+3. Require explicit human authorization for that exact plan.
+4. Lock both migration boundaries, create a verifiable backup, and stage the
+   in-project `.brain/` tree.
+5. Upgrade contracts incrementally, preserving original artifacts and provenance.
+6. Replay and validate state, event, lineage, and acceptance-criterion semantics.
+7. Atomically publish the destination or restore the original state.
+8. Record a migration receipt and leave the legacy source untouched until the
+   user separately confirms retirement.
+
+The PRD process receives dedicated differential fixtures covering discovery,
+5 Whys applied and skipped, 5W2H applied and skipped, blocking questions, open
+questions, invalid structured output, lineage drift, spec revision, and approval.
+No Go runtime is retired until mandatory parity, native platform, migration,
+host E2E, recovery, security, and pilot criteria all pass.
+
+## 12. Rollout and policy modes
+
+Maturity progresses through explicit evidence stages:
+
+1. **Experimental:** architecture, contracts, deterministic core, and local
+   developer fixtures.
+2. **Preview:** complete local SDD trail, initial host adapters, migration dry
+   runs, and opt-in users.
+3. **Beta:** native platform coverage, observability, public documentation,
+   release provenance, rollback rehearsals, and representative pilots.
+4. **Stable:** all mandatory compatibility rows and graduation criteria pass,
+   with no unresolved critical security, migration, recovery, or host defects.
+
+Policy enforcement may progress through `shadow`, `warn`, and `enforce` modes.
+The selected mode is explicit, versioned, evented, and snapshotted at run start.
+Changing project defaults does not rewrite the policy of an in-flight run unless
+a versioned transition explicitly permits it.
+
+## 13. GitHub Actions architecture
+
+Automation is introduced in dependency order:
+
+1. **Documentation foundation:** Markdown lint and link validation for the
+   architecture and open-source documents. This workflow is safe to add before
+   the TypeScript workspace exists.
+2. **Pull-request CI:** after the deterministic toolchain is committed, run
+   install, format check, lint, type check, unit tests, schema checks, build,
+   bundle smoke tests, and package-content validation on PRs targeting
+   `developer` and `main`.
+3. **Quality campaigns:** add native platform, security, nightly stress,
+   Go-compatibility, host, and expanded documentation workflows when their test
+   suites exist.
+4. **Release gates:** build from clean source, verify mandatory checks, create
+   reproducible packages, checksums, SBOM, and provenance, then rehearse rollback.
+
+All workflows use standard public-repository runners unless a separately
+approved need proves otherwise. They set explicit least privileges, immutable
+action revisions, timeouts, concurrency behavior, fork-safe execution, and
+short-lived diagnostic artifacts. A workflow must not pretend to test a layer
+whose source or fixtures do not yet exist.
+
+## 14. Milestone traceability
+
+Every public milestone maps to named architecture sections:
+
+| Milestone | Sections that govern it |
+| --- | --- |
+| 1. Foundation | 1–5, 8–10, 13 |
+| 2. Compatibility Contract | 1, 3, 7–8, 10–11 |
+| 3. Deterministic Runtime | 5–10 |
+| 4. SDD Workflow Parity | 3, 6–8, 10 |
+| 5. Host Integrations | 4–6, 9–10 |
+| 6. Migration and Observability | 6–7, 9–12 |
+| 7. Quality Campaign | 9–10, 13 |
+| 8. Public Beta | 9, 11–13 |
+| 9. Post-1.0 Ideas | 15 |
+
+Implementation issues must link their changed behavior to one or more of these
+sections and to the ADR that owns any structural decision.
+
+## 15. Post-1.0 boundary
+
+The first stable release excludes adaptive rigor profiles, independent dual
+model judges, a remote team Control Tower, and signed remote evidence
+attestations. These remain design candidates only after public-beta evidence.
+
+Any post-1.0 extension must remain optional, versioned, auditable, removable,
+and subordinate to the local deterministic runtime. It must not require an
+account or service for core operation, upload source or prompts by default,
+allow probabilistic judges to mutate state, silently weaken mandatory policy,
+or turn a remote server into the authority for local transitions.
+
+## 16. Decision summary
+
+The selected architecture uses a host-neutral deterministic TypeScript core,
+distributed as one embedded ESM JavaScript runtime, with project-local state and
+an append-only event history. Claude Code and Codex integrate through thin
+adapters and a shared conformance contract. The Go v3 SDD process—especially
+PRD discovery, structured output, lineage, independent review, and human
+approval—remains the compatibility baseline. Distribution and observability
+change; workflow meaning does not.
+

--- a/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md
@@ -1,9 +1,10 @@
 # Yoda Observable Architecture Specification
 
-Status: Approved  
-Decision date: 2026-08-06  
-Scope: TypeScript rewrite of Mestre Yoda  
-Tracking issue: [#2](https://github.com/thiagocorreanet/mestre-yoda/issues/2)
+- Status: Approved
+- Decision date: 2026-08-06
+- Scope: TypeScript rewrite of Mestre Yoda
+- Tracking issue: [#2](https://github.com/thiagocorreanet/mestre-yoda/issues/2)
+- Approval basis: Maintainer-authorized autonomous design approval
 
 ## 1. Purpose and authority
 
@@ -507,3 +508,17 @@ adapters and a shared conformance contract. The Go v3 SDD process—especially
 PRD discovery, structured output, lineage, independent review, and human
 approval—remains the compatibility baseline. Distribution and observability
 change; workflow meaning does not.
+
+## 17. Architecture decision records
+
+This specification defines the system as a whole. The following records preserve
+the context, decision, consequences, and rejected alternatives for each
+foundational structural choice:
+
+- [ADR 0001: Event-Sourced Project History](../../adr/0001-event-sourced-project-history.md)
+- [ADR 0002: Embedded Self-Contained ESM Runtime](../../adr/0002-embedded-esm-runtime.md)
+- [ADR 0003: Project-Local Brain State](../../adr/0003-project-local-brain-state.md)
+- [ADR 0004: Host-Neutral Core and Thin Adapters](../../adr/0004-host-adapter-boundary.md)
+
+The required host-to-decision-to-event-to-response trace is recorded in the
+[architecture verification evidence](../../architecture/verification.md).


### PR DESCRIPTION
Closes #2

## Summary

- Establish the canonical Yoda Observable architecture specification and map every public milestone to named sections.
- Preserve the Go v3 SDD trail and PRD behavior, including context exploration, adaptive Problem Discovery, 5 Whys, 5W2H, completed versus `needs_input`, no-write blocking questions, structured output, lineage, independent review, and content-bound human approval.
- Record ADRs for event-sourced history, the embedded self-contained ESM runtime, project-local `.brain/` state, and Claude Code/Codex host adapters.
- Add a manual host → runtime decision → persisted event → user response trace.
- Add least-privilege documentation CI with immutable Action SHAs, Markdown lint, and link validation.

## Design choices

The Go v3 implementation remains the behavioral baseline. The rewrite changes only the already approved architecture axes: strict TypeScript development, one embedded ESM JavaScript runtime with no global Yoda binary or runtime `node_modules`, in-project `.brain/` state, structured event observability, and thin host adapters.

The current repository has no TypeScript toolchain yet, so this PR adds only the documentation workflow that issue #2 requires. Pull-request TypeScript CI remains dependency-ordered behind #3/#7; platform, nightly, compatibility, security, and release workflows remain under #55 and later prerequisites.

## Compatibility, state, migration, and security impact

- PRD and spec semantics remain compatible with Go v3; intentional contract changes require versioning, differential fixtures, migration, and maintainer approval.
- Legacy sibling `<repo>-brain/.brain/` state is read only during discovery and migrates explicitly through preview, backup, transactional conversion, verification, and rollback.
- Project data, Git metadata, host payloads, model output, and migrated state are untrusted; managed paths are project-confined and failures are fail-closed.
- Workflow permissions are `contents: read`, checkout credentials are not persisted, jobs are time-bounded and fork-safe, and third-party Actions are pinned to immutable SHAs.

## Verification

```bash
npx --yes markdownlint-cli2@0.23.2 '**/*.md'
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/docs.yml
lychee --config .lychee.toml './**/*.md'
rg -n '\b(T[O]DO|T[B]D|F[I]XME|X[X]X)\b' README.md docs .github || true
git diff --check origin/main...HEAD
```

Results before push:

- markdownlint-cli2: 9 files, 0 issues
- actionlint: 0 findings
- Lychee 0.24.2: 39 links checked, 39 valid, 0 errors
- placeholder scan: 0 matches
- commit-range whitespace check: 0 errors
- independent review: no Critical, Important, or Minor findings after follow-up

## Approval

The specification is `Ready for Review`. It will be marked `Approved` only after this PR's documentation CI is green and the rendered specification, diagrams, ADRs, and changed-files scope receive maintainer review.
