### PR TITLE
docs: add open-source governance and security policies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default ownership for all repository content.
+* @thiagocorreanet
+
+# Protect repository automation, ownership, governance, and security policy.
+/.github/ @thiagocorreanet
+/GOVERNANCE.md @thiagocorreanet
+/SECURITY.md @thiagocorreanet

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,100 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+Report a possible project-specific violation confidentially through GitHub's
+[private reporting form](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new)
+with a title beginning `CODE OF CONDUCT`. Do not include vulnerability details
+unless the same report also concerns a security issue. For content hosted by
+GitHub, you may also use GitHub's platform-level content reporting tools.
+
+The Project Lead acts as Community Moderator. If the Project Lead is involved in
+a report, they must recuse themselves and appoint an uninvolved maintainer or
+request platform assistance. Reports are reviewed promptly and fairly. The
+moderator protects reporter privacy, shares information only as necessary to
+investigate and repair harm, and avoids public enforcement details unless a safe
+community statement is appropriate.
+
+## Addressing and Repairing Harm
+
+If an investigation finds a violation, this enforcement ladder guides a
+proportionate response. Depending on severity, lower steps may be skipped.
+
+1. **Warning**
+   - Event: a violation involving a single incident or series of incidents.
+   - Consequence: a private, written warning from the Community Moderator.
+   - Repair: examples include an apology, acknowledgement of responsibility, and
+     clarification of expectations.
+2. **Temporarily Limited Activities**
+   - Event: a repeated violation after warning, or a more serious first incident.
+   - Consequence: a private warning with a time-limited cooldown for specified
+     channels or interactions.
+   - Repair: examples include reflection, apology, and thoughtful re-entry.
+3. **Temporary Suspension**
+   - Event: repeated violations not repaired by warnings, or one serious violation.
+   - Consequence: temporary removal from community spaces with conditions for return.
+   - Repair: respect the suspension, meet its conditions, and reintegrate carefully.
+4. **Permanent Ban**
+   - Event: a severe violation or pattern that cannot be repaired while keeping
+     the community safe.
+   - Consequence: access to project spaces and communication channels is removed.
+   - Repair: no return is available at this level.
+
+The ladder is a guideline and does not prevent action necessary to protect the
+community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and when an individual
+officially represents the community in public or other spaces, including using
+an official account or acting as an appointed representative at an event.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and
+licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+Its enforcement ladder was inspired by the work of
+[Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,100 +1,138 @@
-# Contributor Covenant 3.0 Code of Conduct
+# Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
-We pledge to make our community welcoming, safe, and equitable for all.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
-We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-## Encouraged Behaviors
+## Our Standards
 
-While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
-1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
-2. Engaging **kindly and honestly** with others.
-3. Respecting **different viewpoints** and experiences.
-4. **Taking responsibility** for our actions and contributions.
-5. Gracefully giving and accepting **constructive feedback**.
-6. Committing to **repairing harm** when it occurs.
-7. Behaving in other ways that promote and sustain the **well-being of our community**.
+Examples of unacceptable behavior include:
 
-## Restricted Behaviors
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
-We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+## Enforcement Responsibilities
 
-1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
-2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
-3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
-4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
-5. **Violating confidentiality.** Sharing or acting on someone's personal or private information without their permission.
-6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
-7. Behaving in other ways that **threaten the well-being** of our community.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-### Other Restrictions
-
-1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
-2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
-3. **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the community.
-4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
-
-## Reporting an Issue
-
-Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
-
-Report a possible project-specific violation confidentially through GitHub's
-[private reporting form](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new)
-with a title beginning `CODE OF CONDUCT`. Do not include vulnerability details
-unless the same report also concerns a security issue. For content hosted by
-GitHub, you may also use GitHub's platform-level content reporting tools.
-
-The Project Lead acts as Community Moderator. If the Project Lead is involved in
-a report, they must recuse themselves and appoint an uninvolved maintainer or
-request platform assistance. Reports are reviewed promptly and fairly. The
-moderator protects reporter privacy, shares information only as necessary to
-investigate and repair harm, and avoids public enforcement details unless a safe
-community statement is appropriate.
-
-## Addressing and Repairing Harm
-
-If an investigation finds a violation, this enforcement ladder guides a
-proportionate response. Depending on severity, lower steps may be skipped.
-
-1. **Warning**
-   - Event: a violation involving a single incident or series of incidents.
-   - Consequence: a private, written warning from the Community Moderator.
-   - Repair: examples include an apology, acknowledgement of responsibility, and
-     clarification of expectations.
-2. **Temporarily Limited Activities**
-   - Event: a repeated violation after warning, or a more serious first incident.
-   - Consequence: a private warning with a time-limited cooldown for specified
-     channels or interactions.
-   - Repair: examples include reflection, apology, and thoughtful re-entry.
-3. **Temporary Suspension**
-   - Event: repeated violations not repaired by warnings, or one serious violation.
-   - Consequence: temporary removal from community spaces with conditions for return.
-   - Repair: respect the suspension, meet its conditions, and reintegrate carefully.
-4. **Permanent Ban**
-   - Event: a severe violation or pattern that cannot be repaired while keeping
-     the community safe.
-   - Consequence: access to project spaces and communication channels is removed.
-   - Repair: no return is available at this level.
-
-The ladder is a guideline and does not prevent action necessary to protect the
-community.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
 This Code of Conduct applies within all community spaces and when an individual
-officially represents the community in public or other spaces, including using
-an official account or acting as an appointed representative at an event.
+officially represents the community in public spaces. Examples include using an
+official email address, posting through an official social media account, or
+acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+When the Project Lead is not involved in an incident, report it confidentially
+through GitHub's
+[private reporting form](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new)
+with a title beginning `CODE OF CONDUCT`. Do not include vulnerability details
+unless the same report also concerns a security issue. The Project Lead acts as
+Community Moderator and keeps the report private, sharing information only as
+necessary to investigate and repair harm.
+
+If a report concerns the Project Lead, **do not use the repository private
+reporting form**, because repository administrators can access it. For behavior
+or content on GitHub, use GitHub's independent
+[abuse-reporting process](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam)
+and choose **Report abuse to GitHub Support**, not reporting to repository
+administrators. For an incident in another official project space, use that
+platform's or event organizer's confidential moderation channel.
+
+The project currently has no appointed independent moderator and will not claim
+that a channel controlled by the Project Lead is independent. The Project Lead
+must not seek access to an external report against them and will comply with
+platform enforcement. A future independent moderator must be appointed publicly
+under [GOVERNANCE.md](GOVERNANCE.md) before the project advertises an internal
+escalation route.
+
+All complaints will be reviewed and investigated promptly and fairly by the
+responsible moderator or platform. Community leaders must respect the privacy
+and security of reporters.
+
+## Enforcement Guidelines
+
+Community leaders use these Community Impact Guidelines to determine the
+consequences for actions that violate this Code of Conduct.
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity about the behavior and why it was inappropriate. A public apology may be
+requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of actions.
+
+**Consequence:** A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period. Violating these
+terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from interaction or public communication with
+the community for a specified period. No public or private interaction with the
+people involved or those enforcing the Code of Conduct is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact:** A pattern of violations, sustained harassment, or
+aggression toward or disparagement of individuals or classes of people.
+
+**Consequence:** A permanent ban from public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/).
+This Code of Conduct uses GitHub's recognized Contributor Covenant template,
+adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.0, available at the
+[permanent version URL](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
 
-Contributor Covenant is stewarded by the Organization for Ethical Source and
-licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
-Its enforcement ladder was inspired by the work of
-[Mozilla's code of conduct team](https://github.com/mozilla/inclusion).
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+The [Contributor Covenant FAQ](https://www.contributor-covenant.org/faq) and
+[translations](https://www.contributor-covenant.org/translations) provide
+additional context.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to Mestre Yoda
+
+Thank you for helping build Mestre Yoda. The project is experimental, public,
+and contract-first. Contributions are welcome when their behavior, provenance,
+and verification can be reviewed safely.
+
+By participating, you agree to the [Code of Conduct](CODE_OF_CONDUCT.md), the
+[governance model](GOVERNANCE.md), and the [Developer Certificate of Origin](DCO).
+Security-sensitive reports follow [SECURITY.md](SECURITY.md), not public issues.
+
+## Normative language
+
+English is the normative language for source code, comments, tests, fixtures,
+errors, documentation, issues, reviews, commit messages, and pull requests.
+Translations may be submitted as clearly labeled informational copies that link
+to the English original. If they differ, the English policy controls.
+
+Maintainers will respond respectfully to accessibility or language needs and
+may help translate an initial report, but durable project decisions are recorded
+in English.
+
+## Before starting
+
+1. Search the [public backlog](https://github.com/thiagocorreanet/mestre-yoda/issues)
+   for an existing issue and read its epic, dependencies, and architecture links.
+2. For a new public contract or structural change, open a focused issue before
+   implementation. Do not use an issue for confidential vulnerabilities.
+3. Keep one issue and one coherent outcome per pull request.
+4. Use the repository Superpowers process: brainstorming for features,
+   systematic debugging for bugs, a written implementation plan, test-driven
+   development, independent review, and evidence before completion.
+5. Read the [architecture specification](docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md)
+   and applicable [ADRs](docs/adr/README.md). Structural decisions require an
+   ADR or approved design; they cannot live only in a commit message.
+
+## Development workflow
+
+Use Node.js `24.18.0` and npm `11.16.0` exactly. The complete environment and
+command contract is in the [deterministic toolchain guide](docs/development/toolchain.md).
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c <type>/<issue-and-short-name>
+npm ci
+npm run verify
+```
+
+Start with a failing test for behavior or a failing contract test for policy and
+configuration. Run focused checks while iterating, then the complete suite. Do
+not modify unrelated files, weaken deterministic gates, or introduce public
+behavior outside the tracking issue.
+
+## Developer Certificate of Origin
+
+Every commit must certify the [DCO 1.1](DCO). Sign off with your real name and a
+reachable email address:
+
+```bash
+git commit -s -m "type: concise English summary"
+```
+
+The resulting commit contains:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The sign-off certifies that you have the right to submit the contribution under
+the repository's license; it is not a copyright assignment. Do not sign for
+another person. If one of your commits lacks a valid sign-off, amend or rebase
+your own commits and force-push your contribution branch safely. Maintainers do
+not add certification on a contributor's behalf.
+
+## Intellectual-property provenance checklist
+
+Access to private material does not grant permission to publish or relicense it.
+Include this completed checklist in any pull request that uses legacy or
+third-party code, prompts, schemas, fixtures, tests, or documentation:
+
+- [ ] I identified every legacy or third-party source used by this change.
+- [ ] I recorded whether each source is public or private and its owner/license.
+- [ ] I classified the contribution as original, behavioral clean-room, adapted, or verbatim.
+- [ ] Adapted/verbatim material has reviewable MIT-compatible publication authority.
+- [ ] Required notices and attribution are preserved.
+- [ ] No secrets, credentials, customer/personal data, private infrastructure, or confidential business information are included.
+
+For the private Go Yoda, BetaUp, and MWTC material, the safe default is a
+**behavioral clean-room** contribution: record externally observable inputs,
+outputs, ordering, gates, reason codes, and edge cases, then write new English
+TypeScript and tests without copying private source or prose. The predecessor is
+the compatibility oracle for PRD/spec behavior, not automatic relicensing
+authority.
+
+Adapted or verbatim private material requires evidence in the pull request that
+the rights holder authorized publication under MIT. Secrets and customer or
+confidential data are never accepted. **Unclear provenance blocks merge.**
+
+## Pull requests
+
+A pull request must:
+
+- link its issue with `Closes #<number>` when it completes that issue;
+- explain the design choice and alternatives when judgment was required;
+- describe public-contract, compatibility, state, migration, and security impact;
+- list exact verification commands and current results;
+- include useful failure evidence from the test-first cycle;
+- complete the provenance checklist when legacy or third-party material was used;
+- contain only signed-off commits and English repository content;
+- leave no unresolved placeholder or unrelated opportunistic refactor.
+
+Review feedback is evaluated technically and resolved with tests or evidence.
+All available required checks must pass before merge. The Project Lead or a
+delegated owner makes the final merge decision under [GOVERNANCE.md](GOVERNANCE.md).
+
+## Where to ask for help
+
+Use [SUPPORT.md](SUPPORT.md) to choose the correct public or confidential path.
+Never include vulnerability details, credentials, private customer information,
+or proprietary BetaUp/MWTC material in a public issue.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,33 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,60 @@
+# Governance
+
+Mestre Yoda uses a lead-maintainer model while the public rewrite is
+experimental. Authority is explicit, decisions are reviewable, and access is
+limited to what each role needs.
+
+## Roles
+
+- **Project Lead: `@thiagocorreanet`.** Accountable for project direction,
+  governance, releases, security response, maintainer appointments, ownership,
+  and final tie-breaking.
+- **Maintainers.** Contributors explicitly appointed through a public governance
+  pull request after sustained, trusted work. Their review, triage, and merge
+  authority is limited to documented ownership and repository permissions.
+- **Contributors.** Everyone who participates under the
+  [Code of Conduct](CODE_OF_CONDUCT.md), follows the
+  [contribution guide](CONTRIBUTING.md), and certifies commits under DCO 1.1.
+
+Write access alone does not silently appoint a maintainer, code owner, security
+contact, or Project Lead. Appointment requires a governance change that names
+the role, scope, and effective date.
+
+## Decision process
+
+Routine, reversible changes use lazy consensus through issues and pull request
+review. Maintainers should state objections with concrete technical or community
+impact and a viable alternative.
+
+The following require a written design or ADR as applicable and explicit
+approval from the Project Lead or a delegated code owner:
+
+- public schemas, commands, reason codes, and compatibility contracts;
+- architecture, security boundaries, supply-chain policy, and state ownership;
+- migrations, legacy-parity exceptions, and irreversible data changes;
+- release/support policy, governance, licensing, and ownership changes.
+
+Security and conduct investigations are handled privately to protect reporters
+and affected people. Maintainers publish only information safe for coordinated
+disclosure or an agreed community outcome. When consensus cannot be reached,
+the Project Lead documents the considered alternatives and makes the final
+decision.
+
+## Appointing and removing maintainers
+
+A nomination is a public governance pull request describing sustained
+contributions, demonstrated review judgment, security/provenance awareness, the
+proposed ownership scope, and any conflicts of interest. The Project Lead
+approves appointments after community review.
+
+Maintainers may step down at any time. Access may be suspended or removed for
+security, inactivity, role change, or Code of Conduct enforcement. Inactivity
+never transfers credentials or authority automatically. Repository permissions
+are reviewed for least privilege and revoked when no longer necessary.
+
+## Changing governance
+
+This document changes only through a focused pull request with public rationale,
+community review, and Project Lead approval. Emergency security restrictions may
+be applied immediately, but the safe rationale and durable policy change must be
+recorded when disclosure no longer creates risk.

--- a/README.md
+++ b/README.md
@@ -250,23 +250,27 @@ complete validation sequence from a clean checkout.
 
 Mestre Yoda is being developed in the open, and thoughtful contributions are welcome.
 
-The project is still establishing its foundation. The best way to participate today is to:
+Start with the [Contribution guide](CONTRIBUTING.md), then use the
+[Code of Conduct](CODE_OF_CONDUCT.md), [Governance](GOVERNANCE.md), and
+[Support policy](SUPPORT.md) for their respective paths.
+
+The best way to participate today is to:
 
 1. Read the relevant [epic and implementation issues](https://github.com/thiagocorreanet/mestre-yoda/issues).
 2. Join an existing design or compatibility discussion before implementing a public contract.
 3. Keep changes focused on one issue and include reproducible test evidence.
 4. Preserve deterministic behavior and document compatibility, state, migration, and security impact.
 5. Use English for source code, comments, tests, fixtures, errors, documentation, issues, commits, and pull requests.
-
-Contribution guidelines, governance, the code of conduct, and the security policy are tracked in [the open-source foundation issue](https://github.com/thiagocorreanet/mestre-yoda/issues/4).
+6. Sign every commit under DCO 1.1 and complete the legacy/third-party IP provenance checklist when applicable.
 
 The planned development flow uses short-lived `feature/*`, `fix/*`, `docs/*`, and `refactor/*` branches targeting `developer`. Approved release changes then move from `developer` to the protected `main` branch. This policy is tracked in [issue #60](https://github.com/thiagocorreanet/mestre-yoda/issues/60).
 
 ## Security
 
-Please do not publish suspected vulnerabilities, secrets, or exploit details in a public issue. A private disclosure process will be published as part of the repository foundation. Until that policy is available, avoid sharing sensitive vulnerability details in this repository.
-
-Security policy implementation is tracked in [issue #4](https://github.com/thiagocorreanet/mestre-yoda/issues/4).
+Read the [Security policy](SECURITY.md) and use GitHub's private
+[Report a vulnerability](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new)
+form. Do not publish suspected vulnerabilities, secrets, or exploit details in a
+public issue, pull request, discussion, or paste before coordinated disclosure.
 
 ## Frequently asked questions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,86 @@
+# Security Policy
+
+Mestre Yoda is an experimental development harness that can inspect repositories,
+write project state, invoke tooling, and influence agent workflows. Please report
+security problems privately so maintainers can triage and coordinate a fix before
+details expose users.
+
+## Supported versions
+
+No public release is supported yet.
+
+| Version | Supported |
+| --- | --- |
+| `main` | Yes |
+| Public tags/releases | None published |
+| Private Go predecessor | No |
+| Third-party forks | No |
+
+When releases begin, this table will list each supported line explicitly.
+Support is never inferred from the existence of a tag, branch, fork, or private
+legacy installation.
+
+## Report a vulnerability
+
+Use GitHub's private
+[Report a vulnerability](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new)
+form. **Do not open a public issue**, pull request, discussion, or paste containing
+suspected vulnerability, secret, or exploit details before maintainers complete
+private triage and agree on coordinated disclosure.
+
+Include when available:
+
+- affected version, tag, or commit;
+- impact and realistic attack scenario;
+- prerequisites and affected platforms/hosts;
+- minimal safe reproduction steps or proof of concept;
+- logs with secrets, personal data, and private paths removed;
+- suggested remediation and disclosure constraints;
+- how you would like to be credited.
+
+If the private form is temporarily unavailable, open a public issue asking only
+for a private security contact. Do not include a vulnerability title, affected
+component, reproduction clue, or other sensitive detail in that issue.
+
+## Response expectations
+
+These are good-faith targets measured in business days, not a paid support SLA:
+
+- acknowledge a report within 3 business days;
+- provide initial severity and scope triage within 7 business days;
+- send a private status update at least every 14 days while the report is active;
+- when feasible, target remediation for critical issues within 7 days and high
+  issues within 30 days; other timing depends on impact and fix complexity.
+
+Maintainers will privately accept, request information, identify a duplicate, or
+explain why a report is invalid/out of scope. Valid reports are coordinated
+through a fix, tests, an advisory, reporter credit, and a CVE request when
+appropriate. Public disclosure waits until affected users have a reasonable
+remediation path and timing is coordinated with the reporter.
+
+## Safe research rules
+
+Do not:
+
+- access, retain, or publish data that is not yours;
+- place real secrets, customer data, personal data, or proprietary material in a
+  report or proof of concept;
+- disrupt services, degrade availability, or perform destructive testing;
+- use social engineering, phishing, credential attacks, or attacks against
+  systems you do not own or lack permission to test;
+- expand beyond the minimum access needed to demonstrate the issue;
+- publish details before private triage and coordinated disclosure.
+
+Stop testing when you encounter sensitive data or risk harm. Report the minimum
+redacted evidence necessary for maintainers to reproduce the problem safely.
+
+## Security scope examples
+
+Useful reports include path traversal or unsafe symlink handling, command or
+prompt injection that crosses a documented trust boundary, secret disclosure,
+supply-chain compromise, signature/hash/evidence bypass, unauthorized state
+mutation, unsafe migration, concurrency/fencing failure with integrity impact,
+or plugin installation/update compromise.
+
+General support questions, expected experimental limitations, and bugs without
+security impact belong in the public paths described by [SUPPORT.md](SUPPORT.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support
+
+Mestre Yoda is an experimental open-source rewrite. The project welcomes useful
+reports and questions, but currently provides **no production support SLA** and
+does not promise compatibility or response times beyond the good-faith security
+targets in [SECURITY.md](SECURITY.md).
+
+## Choose the correct path
+
+| Need | Channel |
+| --- | --- |
+| Reproducible public bug | Search, then open a [GitHub issue](https://github.com/thiagocorreanet/mestre-yoda/issues) |
+| Feature or design proposal | Search the backlog and open a focused public issue |
+| Contribution workflow | Read [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Suspected vulnerability or exposed secret | Use the private [security report](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new) |
+| Code of Conduct incident | Follow the confidential route in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
+| Proprietary BetaUp, MWTC, customer system, or private predecessor deployment | Contact that system's owner; it is outside this public project's support scope |
+
+Before opening a public issue, check the README, architecture documents, open
+issues, and milestones. Include the expected behavior, actual behavior, minimal
+reproduction, Mestre Yoda commit/version, operating system, Node/npm versions,
+and redacted logs. Use normative English so the public record can be reviewed by
+the whole community.
+
+Never place credentials, tokens, personal/customer information, vulnerability
+details, private source, or confidential business/infrastructure data in a
+public support request. If unsure whether a report is security-sensitive, use
+the private security channel.

--- a/docs/governance/verification.md
+++ b/docs/governance/verification.md
@@ -3,7 +3,7 @@
 - Verification date: 2026-08-06 (America/Sao_Paulo)
 - Tracking issue: [#4](https://github.com/thiagocorreanet/mestre-yoda/issues/4)
 - Branch: `docs/issue-4-governance`
-- Policy commit: `430685a`
+- Policy commit: `dc6e40d`
 - Status: Pre-merge evidence complete; post-merge GitHub recognition required
 
 ## Contribution path dry run
@@ -28,6 +28,10 @@ Signed-off-by: Example Contributor <contributor@example.com>
 
 This proves the documented trailer form is recognized by Git. It does not claim
 automated enforcement, which remains owned by issues #6 and #7.
+
+Every commit in the issue #4 branch was then inspected with
+`git interpret-trailers --parse` and contains exactly one valid
+`Signed-off-by` trailer from its author.
 
 ## Vulnerability path dry run
 

--- a/docs/governance/verification.md
+++ b/docs/governance/verification.md
@@ -60,8 +60,8 @@ Using Node.js `v24.18.0` and npm `11.16.0`:
 | `npm run test:coverage` | Pass, 100% configured runtime statements/branches/functions/lines |
 | `npm run build` | Pass, one 386-byte ESM artifact |
 | `npm run package:verify` | Pass, isolated exact help/version |
-| markdownlint | Pass, 21 Markdown files and zero errors |
-| Lychee | Pass, 86 links and zero errors |
+| markdownlint | Pass, 22 Markdown files and zero errors |
+| Lychee | Pass, 90 links and zero errors |
 | `git diff --check` | Pass |
 
 The community-health contract specifically checks seven policy/navigation

--- a/docs/governance/verification.md
+++ b/docs/governance/verification.md
@@ -1,0 +1,78 @@
+# Governance and Community-Path Verification
+
+- Verification date: 2026-08-06 (America/Sao_Paulo)
+- Tracking issue: [#4](https://github.com/thiagocorreanet/mestre-yoda/issues/4)
+- Branch: `docs/issue-4-governance`
+- Policy commit: `430685a`
+- Status: Pre-merge evidence complete; post-merge GitHub recognition required
+
+## Contribution path dry run
+
+The README links the contribution guide, Code of Conduct, governance, support,
+and security policies directly. The contribution guide then links DCO 1.1, the
+pinned development toolchain, architecture/ADR rules, support routing, and the
+mandatory intellectual-property provenance checklist. Every required policy is
+reachable from README in one or two links.
+
+The DCO trailer parser was exercised without creating a commit:
+
+```bash
+printf '%s\n' 'Example commit' '' 'Signed-off-by: Example Contributor <contributor@example.com>' | git interpret-trailers --parse
+```
+
+Observed output:
+
+```text
+Signed-off-by: Example Contributor <contributor@example.com>
+```
+
+This proves the documented trailer form is recognized by Git. It does not claim
+automated enforcement, which remains owned by issues #6 and #7.
+
+## Vulnerability path dry run
+
+Private vulnerability reporting was enabled through the GitHub repository API.
+The read-only state check returned:
+
+```json
+{"enabled":true}
+```
+
+The documented `security/advisories/new` URL resolved with HTTP 200. No report,
+draft advisory, vulnerability detail, or notification was created. README,
+SECURITY, SUPPORT, and the Code of Conduct all route confidential matters to the
+enabled private form and prohibit premature public details.
+
+## Repository verification
+
+Using Node.js `v24.18.0` and npm `11.16.0`:
+
+| Check | Result |
+| --- | --- |
+| `npm run format:check` | Pass |
+| `npm run lint` | Pass, zero warnings |
+| `npm run typecheck` | Pass, strict/no emit |
+| `npm test` | Pass, 4 files and 16 tests |
+| `npm run test:coverage` | Pass, 100% configured runtime statements/branches/functions/lines |
+| `npm run build` | Pass, one 386-byte ESM artifact |
+| `npm run package:verify` | Pass, isolated exact help/version |
+| markdownlint | Pass, 21 Markdown files and zero errors |
+| Lychee | Pass, 86 links and zero errors |
+| `git diff --check` | Pass |
+
+The community-health contract specifically checks seven policy/navigation
+behaviors, required file presence, DCO/provenance rules, confidential security
+routing, support boundaries, conduct attribution, governance, CODEOWNERS, and
+unfilled-template rejection.
+
+## Post-merge closure checks
+
+After the policy files reach `main`, issue #4 remains open until maintainers
+verify:
+
+1. GitHub's community profile recognizes contribution, conduct, license, and
+   security artifacts;
+2. GitHub's CODEOWNERS error endpoint returns an empty error list;
+3. private vulnerability reporting remains enabled;
+4. the Documentation workflow passes on the merged content;
+5. the issue is closed with links to the PR and this evidence.

--- a/docs/superpowers/plans/2026-08-06-open-source-governance.md
+++ b/docs/superpowers/plans/2026-08-06-open-source-governance.md
@@ -1,0 +1,264 @@
+# Open-Source Governance and Security Policies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish GitHub-recognized contribution, conduct, governance, security, support, ownership, DCO, and IP-provenance policies with tested navigation and confidential reporting.
+
+**Architecture:** Root community health files form a linked policy graph entered from README, while `.github/CODEOWNERS` protects repository ownership and GitHub private vulnerability reporting supplies the confidential channel. A Vitest contract prevents missing files, placeholders, or drift in critical policy clauses; manual API checks prove GitHub recognition and reporting state.
+
+**Tech Stack:** Markdown, Contributor Covenant 3.0, Developer Certificate of Origin 1.1, GitHub community health/private vulnerability reporting/CODEOWNERS APIs, Vitest 4.1.10, markdownlint, Lychee.
+
+## Global Constraints
+
+- All normative repository artifacts and contributor communication are English.
+- Treat private Go Yoda, BetaUp, and MWTC material as behavioral clean-room input unless explicit MIT-compatible relicensing evidence exists.
+- Never publish secrets, customer/personal data, exploit details, or private infrastructure information.
+- Use GitHub private vulnerability reporting; do not invent an email address or submit a real vulnerability during verification.
+- Assign only the verified repository owner/administrator `@thiagocorreanet` in CODEOWNERS.
+- Preserve Contributor Covenant 3.0 attribution and DCO 1.1 verbatim terms.
+- Keep issue/PR templates and DCO automation in issue #6 and Node CI in issue #7.
+- Do not change SDD runtime or legacy PRD/spec behavior.
+
+---
+
+### Task 1: Define failing community-health contracts
+
+**Files:**
+
+- Create: `tests/community-health.test.ts`
+
+**Interfaces:**
+
+- Consumes: repository root resolved from `import.meta.url`.
+- Produces: executable expectations for `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `SECURITY.md`, `SUPPORT.md`, `DCO`, `.github/CODEOWNERS`, and README navigation.
+
+- [ ] **Step 1: Write the missing-file and policy-contract tests**
+
+Use `readFile` from `node:fs/promises` and Vitest. Assert all required paths can
+be read, then assert:
+
+```typescript
+expect(readme).toContain("[Contribution guide](CONTRIBUTING.md)");
+expect(readme).toContain("[Security policy](SECURITY.md)");
+expect(contributing).toContain("git commit -s");
+expect(contributing).toContain("Signed-off-by: Your Name <your.email@example.com>");
+expect(contributing).toContain("Intellectual-property provenance checklist");
+expect(security).toContain("Report a vulnerability");
+expect(security).toContain("Do not open a public issue");
+expect(codeowners).toContain("* @thiagocorreanet");
+expect(codeowners).toContain("/.github/CODEOWNERS @thiagocorreanet");
+```
+
+Scan the six policy documents for common unfinished-work markers, unfilled
+template instructions, and missing enforcement contacts. Assert the DCO
+identifies version 1.1 and the code of conduct identifies/attributes Contributor
+Covenant 3.0.
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `npm test -- tests/community-health.test.ts`
+
+Expected: FAIL with `ENOENT` for `CONTRIBUTING.md`.
+
+- [ ] **Step 3: Commit only after the policy implementation makes this test GREEN**
+
+The failing test remains uncommitted until Tasks 2–3 add the required policies;
+then commit it with the policy set so every commit on the branch remains usable.
+
+### Task 2: Publish contribution, DCO, governance, and ownership policies
+
+**Files:**
+
+- Create: `DCO`
+- Create: `CONTRIBUTING.md`
+- Create: `GOVERNANCE.md`
+- Create: `.github/CODEOWNERS`
+
+**Interfaces:**
+
+- Consumes: DCO 1.1 official text, pinned toolchain guide, architecture/ADR rules, verified owner `@thiagocorreanet`.
+- Produces: signed contribution workflow, IP provenance gate, decision model, maintainer roles, and review ownership.
+
+- [ ] **Step 1: Add DCO 1.1 verbatim**
+
+Copy the official DCO 1.1 text from `https://developercertificate.org/` without
+editing its terms, including its copyright/copy permission and clauses (a)–(d).
+
+- [ ] **Step 2: Write the operational contribution guide**
+
+Include prerequisites, issue selection, Superpowers feature/bug paths, branch
+and scope rules, `npm ci`/`npm run verify`, English, DCO sign-off and amendment,
+PR evidence, reviews, architecture/ADR triggers, security routing, and this
+mandatory checklist:
+
+```markdown
+### Intellectual-property provenance checklist
+
+- [ ] I identified every legacy or third-party source used by this change.
+- [ ] I recorded whether each source is public or private and its owner/license.
+- [ ] I classified the contribution as original, behavioral clean-room, adapted, or verbatim.
+- [ ] Adapted/verbatim material has reviewable MIT-compatible publication authority.
+- [ ] Required notices and attribution are preserved.
+- [ ] No secrets, credentials, customer/personal data, private infrastructure, or confidential business information are included.
+```
+
+State that unclear provenance blocks merge and that private legacy access alone
+is not relicensing permission.
+
+- [ ] **Step 3: Write governance roles and decision rules**
+
+Define Project Lead `@thiagocorreanet`, explicitly appointed maintainers, and
+contributors; lazy consensus for routine changes; design/ADR plus explicit owner
+approval for contracts/security/compatibility/migration/governance; private
+security/conduct decisions; documented tie-breaking; public governance PRs;
+least-privilege access and no automatic role transfer.
+
+- [ ] **Step 4: Add secure default ownership**
+
+Create `.github/CODEOWNERS` with:
+
+```text
+# Default ownership for all repository content.
+* @thiagocorreanet
+
+# Protect repository automation, ownership, governance, and security policy.
+/.github/ @thiagocorreanet
+/GOVERNANCE.md @thiagocorreanet
+/SECURITY.md @thiagocorreanet
+```
+
+The `.github/` rule protects CODEOWNERS itself and later automation.
+
+### Task 3: Publish conduct, security, support, and README navigation
+
+**Files:**
+
+- Create: `CODE_OF_CONDUCT.md`
+- Create: `SECURITY.md`
+- Create: `SUPPORT.md`
+- Modify: `README.md`
+
+**Interfaces:**
+
+- Consumes: Contributor Covenant 3.0, GitHub private-reporting URL, issue/support boundaries.
+- Produces: recognized community policies and one-click README entrypoints.
+
+- [ ] **Step 1: Adopt Contributor Covenant 3.0**
+
+Use the official 3.0 Markdown and replace its reporting note with a confidential
+route to `https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new`.
+Require title prefix `CODE OF CONDUCT`, allow GitHub platform reporting for
+hosted-content violations, preserve confidentiality and the CC BY-SA 4.0
+attribution.
+
+- [ ] **Step 2: Write the security policy**
+
+List only `main` as supported before releases; exclude the private predecessor
+and forks. Require private GitHub reporting, forbid public pre-triage details,
+request safe reproduction/impact/version, define prohibited testing, set 3/7/14
+business-day response targets and feasible critical/high remediation targets,
+and explain coordinated disclosure, credit, advisories, and CVEs.
+
+- [ ] **Step 3: Write support boundaries**
+
+Route public reproducible bugs/features to Issues, security and conduct to their
+confidential routes, and explicitly exclude proprietary BetaUp/MWTC/customer
+systems. State experimental status, no SLA/production support, English, and no
+secrets/private data.
+
+- [ ] **Step 4: Replace provisional README policy text**
+
+Make the Contributing section link `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
+`GOVERNANCE.md`, and `SUPPORT.md`. Make Security link `SECURITY.md` and its
+private report path. A contributor reaches every policy directly or through the
+contribution guide within two clicks.
+
+- [ ] **Step 5: Run the focused contract and confirm GREEN**
+
+```bash
+npm test -- tests/community-health.test.ts
+npm run typecheck
+npm run lint
+```
+
+Expected: all community-health tests pass; static checks exit 0 without warnings.
+
+- [ ] **Step 6: Commit the tested policy graph**
+
+```bash
+git add DCO CONTRIBUTING.md CODE_OF_CONDUCT.md GOVERNANCE.md SECURITY.md SUPPORT.md README.md .github/CODEOWNERS tests/community-health.test.ts
+git commit -m "docs: add open-source governance policies"
+```
+
+### Task 4: Enable and prove the contribution/security paths
+
+**Files:**
+
+- Create: `docs/governance/verification.md`
+- Modify: `docs/superpowers/plans/2026-08-06-open-source-governance.md`
+
+**Interfaces:**
+
+- Consumes: merged/pushed policy files and GitHub repository administration API.
+- Produces: reproducible local/API evidence without a fake vulnerability or project commit.
+
+- [ ] **Step 1: Enable private vulnerability reporting**
+
+Run the GitHub API operation that enables private vulnerability reporting for
+`thiagocorreanet/mestre-yoda`, then verify read-only state:
+
+```bash
+gh api --method PUT repos/thiagocorreanet/mestre-yoda/private-vulnerability-reporting
+gh api repos/thiagocorreanet/mestre-yoda/private-vulnerability-reporting
+```
+
+Expected JSON: `{"enabled":true}`. This setting is the only external mutation in
+the issue and is required to make the documented confidential route real.
+
+- [ ] **Step 2: Dry-run DCO and navigation locally**
+
+Parse, without committing, a sample trailer:
+
+```bash
+printf '%s\n' 'Signed-off-by: Example Contributor <contributor@example.com>' | git interpret-trailers --parse
+```
+
+Expected: the identical valid trailer. Follow every README/policy relative link
+with Lychee and record the resolved contribution, conduct, governance, support,
+and security paths.
+
+- [ ] **Step 3: Record pre-merge evidence**
+
+Document date, branch/commit, private-reporting enabled state, sample DCO parse,
+test counts, Markdown/link results, and that the reporting page was opened
+without submitting a report. Mark post-merge community-profile and CODEOWNERS
+recognition as a required closure check rather than claiming it early.
+
+- [ ] **Step 4: Run complete verification**
+
+```bash
+npm run verify
+npx --yes markdownlint-cli2@0.20.0 "README.md" "*.md" "docs/**/*.md" "schemas/**/*.md" "fixtures/**/*.md"
+lychee --config .lychee.toml README.md CONTRIBUTING.md CODE_OF_CONDUCT.md GOVERNANCE.md SECURITY.md SUPPORT.md docs schemas fixtures
+git diff --check
+```
+
+Expected: toolchain suite passes; all policy tests pass; Markdown has zero
+errors; links have zero failures; diff check is empty.
+
+- [ ] **Step 5: Review, publish, and close**
+
+Request independent review against issue #4 and IP/security risks. Resolve
+validated findings, rerun verification, push `docs/issue-4-governance`, and open
+a PR with `Closes #4`, design rationale, compatibility impact, exact evidence,
+and the private-reporting setting change. After green checks and merge, verify:
+
+```bash
+gh api repos/thiagocorreanet/mestre-yoda/community/profile
+gh api repos/thiagocorreanet/mestre-yoda/codeowners/errors
+gh issue view 4 --repo thiagocorreanet/mestre-yoda --json state,closedAt
+```
+
+Expected: community profile recognizes contribution, conduct, license, and
+security files; CODEOWNERS reports no errors; issue #4 is closed. Add this
+post-merge evidence to the issue before moving to #5.

--- a/docs/superpowers/plans/2026-08-06-open-source-governance.md
+++ b/docs/superpowers/plans/2026-08-06-open-source-governance.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Root community health files form a linked policy graph entered from README, while `.github/CODEOWNERS` protects repository ownership and GitHub private vulnerability reporting supplies the confidential channel. A Vitest contract prevents missing files, placeholders, or drift in critical policy clauses; manual API checks prove GitHub recognition and reporting state.
 
-**Tech Stack:** Markdown, Contributor Covenant 3.0, Developer Certificate of Origin 1.1, GitHub community health/private vulnerability reporting/CODEOWNERS APIs, Vitest 4.1.10, markdownlint, Lychee.
+**Tech Stack:** Markdown, GitHub-recognized Contributor Covenant 2.0 template, Developer Certificate of Origin 1.1, GitHub community health/private vulnerability reporting/CODEOWNERS APIs, Vitest 4.1.10, markdownlint, Lychee.
 
 ## Global Constraints
 
@@ -15,7 +15,7 @@
 - Never publish secrets, customer/personal data, exploit details, or private infrastructure information.
 - Use GitHub private vulnerability reporting; do not invent an email address or submit a real vulnerability during verification.
 - Assign only the verified repository owner/administrator `@thiagocorreanet` in CODEOWNERS.
-- Preserve Contributor Covenant 3.0 attribution and DCO 1.1 verbatim terms.
+- Preserve Contributor Covenant 2.0 attribution and DCO 1.1 verbatim terms.
 - Keep issue/PR templates and DCO automation in issue #6 and Node CI in issue #7.
 - Do not change SDD runtime or legacy PRD/spec behavior.
 
@@ -51,8 +51,8 @@ expect(codeowners).toContain("/.github/CODEOWNERS @thiagocorreanet");
 
 Scan the six policy documents for common unfinished-work markers, unfilled
 template instructions, and missing enforcement contacts. Assert the DCO
-identifies version 1.1 and the code of conduct identifies/attributes Contributor
-Covenant 3.0.
+identifies version 1.1 and the code of conduct identifies/attributes GitHub's
+recognized Contributor Covenant 2.0 template.
 
 - [x] **Step 2: Run the focused test and confirm RED**
 
@@ -140,16 +140,18 @@ The `.github/` rule protects CODEOWNERS itself and later automation.
 
 **Interfaces:**
 
-- Consumes: Contributor Covenant 3.0, GitHub private-reporting URL, issue/support boundaries.
+- Consumes: GitHub's Contributor Covenant 2.0 template, private-reporting URL, independent GitHub abuse reporting, and support boundaries.
 - Produces: recognized community policies and one-click README entrypoints.
 
-- [x] **Step 1: Adopt Contributor Covenant 3.0**
+- [x] **Step 1: Adopt GitHub's recognized Contributor Covenant template**
 
-Use the official 3.0 Markdown and replace its reporting note with a confidential
-route to `https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new`.
-Require title prefix `CODE OF CONDUCT`, allow GitHub platform reporting for
-hosted-content violations, preserve confidentiality and the CC BY-SA 4.0
-attribution.
+Use the Contributor Covenant 2.0 body returned by GitHub's
+`codes_of_conduct/contributor_covenant` API and replace its contact placeholder.
+When the Project Lead is uninvolved, use the private repository form with title
+prefix `CODE OF CONDUCT`. When the Lead is involved, require GitHub Support's
+independent abuse route for GitHub-hosted conduct or the relevant external
+platform/event confidential moderator; never route that complaint to repository
+administrators. Preserve the template attribution.
 
 - [x] **Step 2: Write the security policy**
 

--- a/docs/superpowers/plans/2026-08-06-open-source-governance.md
+++ b/docs/superpowers/plans/2026-08-06-open-source-governance.md
@@ -220,7 +220,7 @@ the issue and is required to make the documented confidential route real.
 Parse, without committing, a sample trailer:
 
 ```bash
-printf '%s\n' 'Signed-off-by: Example Contributor <contributor@example.com>' | git interpret-trailers --parse
+printf '%s\n' 'Example commit' '' 'Signed-off-by: Example Contributor <contributor@example.com>' | git interpret-trailers --parse
 ```
 
 Expected: the identical valid trailer. Follow every README/policy relative link

--- a/docs/superpowers/plans/2026-08-06-open-source-governance.md
+++ b/docs/superpowers/plans/2026-08-06-open-source-governance.md
@@ -32,7 +32,7 @@
 - Consumes: repository root resolved from `import.meta.url`.
 - Produces: executable expectations for `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `SECURITY.md`, `SUPPORT.md`, `DCO`, `.github/CODEOWNERS`, and README navigation.
 
-- [ ] **Step 1: Write the missing-file and policy-contract tests**
+- [x] **Step 1: Write the missing-file and policy-contract tests**
 
 Use `readFile` from `node:fs/promises` and Vitest. Assert all required paths can
 be read, then assert:
@@ -54,13 +54,13 @@ template instructions, and missing enforcement contacts. Assert the DCO
 identifies version 1.1 and the code of conduct identifies/attributes Contributor
 Covenant 3.0.
 
-- [ ] **Step 2: Run the focused test and confirm RED**
+- [x] **Step 2: Run the focused test and confirm RED**
 
 Run: `npm test -- tests/community-health.test.ts`
 
 Expected: FAIL with `ENOENT` for `CONTRIBUTING.md`.
 
-- [ ] **Step 3: Commit only after the policy implementation makes this test GREEN**
+- [x] **Step 3: Commit only after the policy implementation makes this test GREEN**
 
 The failing test remains uncommitted until Tasks 2–3 add the required policies;
 then commit it with the policy set so every commit on the branch remains usable.
@@ -79,12 +79,12 @@ then commit it with the policy set so every commit on the branch remains usable.
 - Consumes: DCO 1.1 official text, pinned toolchain guide, architecture/ADR rules, verified owner `@thiagocorreanet`.
 - Produces: signed contribution workflow, IP provenance gate, decision model, maintainer roles, and review ownership.
 
-- [ ] **Step 1: Add DCO 1.1 verbatim**
+- [x] **Step 1: Add DCO 1.1 verbatim**
 
 Copy the official DCO 1.1 text from `https://developercertificate.org/` without
 editing its terms, including its copyright/copy permission and clauses (a)–(d).
 
-- [ ] **Step 2: Write the operational contribution guide**
+- [x] **Step 2: Write the operational contribution guide**
 
 Include prerequisites, issue selection, Superpowers feature/bug paths, branch
 and scope rules, `npm ci`/`npm run verify`, English, DCO sign-off and amendment,
@@ -94,18 +94,18 @@ mandatory checklist:
 ```markdown
 ### Intellectual-property provenance checklist
 
-- [ ] I identified every legacy or third-party source used by this change.
-- [ ] I recorded whether each source is public or private and its owner/license.
-- [ ] I classified the contribution as original, behavioral clean-room, adapted, or verbatim.
-- [ ] Adapted/verbatim material has reviewable MIT-compatible publication authority.
-- [ ] Required notices and attribution are preserved.
-- [ ] No secrets, credentials, customer/personal data, private infrastructure, or confidential business information are included.
+- [x] I identified every legacy or third-party source used by this change.
+- [x] I recorded whether each source is public or private and its owner/license.
+- [x] I classified the contribution as original, behavioral clean-room, adapted, or verbatim.
+- [x] Adapted/verbatim material has reviewable MIT-compatible publication authority.
+- [x] Required notices and attribution are preserved.
+- [x] No secrets, credentials, customer/personal data, private infrastructure, or confidential business information are included.
 ```
 
 State that unclear provenance blocks merge and that private legacy access alone
 is not relicensing permission.
 
-- [ ] **Step 3: Write governance roles and decision rules**
+- [x] **Step 3: Write governance roles and decision rules**
 
 Define Project Lead `@thiagocorreanet`, explicitly appointed maintainers, and
 contributors; lazy consensus for routine changes; design/ADR plus explicit owner
@@ -113,7 +113,7 @@ approval for contracts/security/compatibility/migration/governance; private
 security/conduct decisions; documented tie-breaking; public governance PRs;
 least-privilege access and no automatic role transfer.
 
-- [ ] **Step 4: Add secure default ownership**
+- [x] **Step 4: Add secure default ownership**
 
 Create `.github/CODEOWNERS` with:
 
@@ -143,7 +143,7 @@ The `.github/` rule protects CODEOWNERS itself and later automation.
 - Consumes: Contributor Covenant 3.0, GitHub private-reporting URL, issue/support boundaries.
 - Produces: recognized community policies and one-click README entrypoints.
 
-- [ ] **Step 1: Adopt Contributor Covenant 3.0**
+- [x] **Step 1: Adopt Contributor Covenant 3.0**
 
 Use the official 3.0 Markdown and replace its reporting note with a confidential
 route to `https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new`.
@@ -151,7 +151,7 @@ Require title prefix `CODE OF CONDUCT`, allow GitHub platform reporting for
 hosted-content violations, preserve confidentiality and the CC BY-SA 4.0
 attribution.
 
-- [ ] **Step 2: Write the security policy**
+- [x] **Step 2: Write the security policy**
 
 List only `main` as supported before releases; exclude the private predecessor
 and forks. Require private GitHub reporting, forbid public pre-triage details,
@@ -159,21 +159,21 @@ request safe reproduction/impact/version, define prohibited testing, set 3/7/14
 business-day response targets and feasible critical/high remediation targets,
 and explain coordinated disclosure, credit, advisories, and CVEs.
 
-- [ ] **Step 3: Write support boundaries**
+- [x] **Step 3: Write support boundaries**
 
 Route public reproducible bugs/features to Issues, security and conduct to their
 confidential routes, and explicitly exclude proprietary BetaUp/MWTC/customer
 systems. State experimental status, no SLA/production support, English, and no
 secrets/private data.
 
-- [ ] **Step 4: Replace provisional README policy text**
+- [x] **Step 4: Replace provisional README policy text**
 
 Make the Contributing section link `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`,
 `GOVERNANCE.md`, and `SUPPORT.md`. Make Security link `SECURITY.md` and its
 private report path. A contributor reaches every policy directly or through the
 contribution guide within two clicks.
 
-- [ ] **Step 5: Run the focused contract and confirm GREEN**
+- [x] **Step 5: Run the focused contract and confirm GREEN**
 
 ```bash
 npm test -- tests/community-health.test.ts
@@ -183,7 +183,7 @@ npm run lint
 
 Expected: all community-health tests pass; static checks exit 0 without warnings.
 
-- [ ] **Step 6: Commit the tested policy graph**
+- [x] **Step 6: Commit the tested policy graph**
 
 ```bash
 git add DCO CONTRIBUTING.md CODE_OF_CONDUCT.md GOVERNANCE.md SECURITY.md SUPPORT.md README.md .github/CODEOWNERS tests/community-health.test.ts
@@ -202,7 +202,7 @@ git commit -m "docs: add open-source governance policies"
 - Consumes: merged/pushed policy files and GitHub repository administration API.
 - Produces: reproducible local/API evidence without a fake vulnerability or project commit.
 
-- [ ] **Step 1: Enable private vulnerability reporting**
+- [x] **Step 1: Enable private vulnerability reporting**
 
 Run the GitHub API operation that enables private vulnerability reporting for
 `thiagocorreanet/mestre-yoda`, then verify read-only state:
@@ -215,7 +215,7 @@ gh api repos/thiagocorreanet/mestre-yoda/private-vulnerability-reporting
 Expected JSON: `{"enabled":true}`. This setting is the only external mutation in
 the issue and is required to make the documented confidential route real.
 
-- [ ] **Step 2: Dry-run DCO and navigation locally**
+- [x] **Step 2: Dry-run DCO and navigation locally**
 
 Parse, without committing, a sample trailer:
 
@@ -227,14 +227,14 @@ Expected: the identical valid trailer. Follow every README/policy relative link
 with Lychee and record the resolved contribution, conduct, governance, support,
 and security paths.
 
-- [ ] **Step 3: Record pre-merge evidence**
+- [x] **Step 3: Record pre-merge evidence**
 
 Document date, branch/commit, private-reporting enabled state, sample DCO parse,
 test counts, Markdown/link results, and that the reporting page was opened
 without submitting a report. Mark post-merge community-profile and CODEOWNERS
 recognition as a required closure check rather than claiming it early.
 
-- [ ] **Step 4: Run complete verification**
+- [x] **Step 4: Run complete verification**
 
 ```bash
 npm run verify

--- a/docs/superpowers/specs/2026-08-06-open-source-governance-design.md
+++ b/docs/superpowers/specs/2026-08-06-open-source-governance-design.md
@@ -1,0 +1,238 @@
+# Open-Source Governance, Security, and Contribution Design
+
+- Status: Approved
+- Decision date: 2026-08-06
+- Tracking issue: [#4](https://github.com/thiagocorreanet/mestre-yoda/issues/4)
+- Depends on: [#2](https://github.com/thiagocorreanet/mestre-yoda/issues/2)
+- Approval basis: Maintainer-authorized autonomous recommendation
+
+## 1. Outcome
+
+A first-time contributor can move from the README to an actionable contribution,
+support, conduct, governance, or private vulnerability path in at most two links.
+Every contribution certifies provenance through DCO 1.1, English is normative,
+and private BetaUp/MWTC material cannot enter the MIT repository without explicit
+rights evidence.
+
+The repository uses GitHub-native community health locations and private
+vulnerability reporting. Policies are durable repository artifacts rather than
+oral convention or external-only pages.
+
+## 2. Approaches considered
+
+| Approach | Advantages | Costs | Decision |
+| --- | --- | --- | --- |
+| Minimal custom policy files | Short and project-specific | Easy to omit enforcement, attribution, recognition, and reporting details | Rejected |
+| Standards-first repository policies plus GitHub private reporting | Recognized by GitHub, familiar to contributors, versioned with the project, private disclosure without inventing an email | Requires maintaining several linked documents and one repository setting | Selected |
+| Link only to external policies | Little repository content | External content can drift; offline clones lack rules; project-specific IP controls disappear | Rejected |
+
+## 3. Standards and placement
+
+The repository adopts:
+
+- [GitHub community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)
+  in supported root locations;
+- [Developer Certificate of Origin 1.1](https://developercertificate.org/)
+  verbatim in `DCO`;
+- [Contributor Covenant 3.0](https://www.contributor-covenant.org/version/3/0/code_of_conduct/)
+  in `CODE_OF_CONDUCT.md`, with its required attribution;
+- [GitHub private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository)
+  as the primary confidential channel;
+- `.github/CODEOWNERS`, the location GitHub recommends for protecting ownership
+  rules themselves.
+
+The root owns `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`,
+`SECURITY.md`, `SUPPORT.md`, and `DCO`. GitHub recognizes the community files
+there, and cloned/downloaded source retains the complete policies.
+
+`.github/CODEOWNERS` assigns the verified repository owner and administrator
+`@thiagocorreanet` as the default owner. A collaborator's write permission alone
+does not silently grant a governance or security role. Future owners require an
+explicit governance change and sufficient GitHub permission.
+
+## 4. Contribution workflow
+
+`CONTRIBUTING.md` is the operational entrypoint. It directs contributors to:
+
+1. search the backlog and discuss public-contract changes before implementation;
+2. branch from the current default branch and keep one issue per change;
+3. follow the repository's Superpowers process: brainstorming for features,
+   systematic debugging for bugs, written plans, TDD, review, and verification;
+4. use the pinned toolchain and run `npm ci` plus `npm run verify`;
+5. keep source, tests, docs, issues, commits, and PRs in normative English;
+6. complete the IP provenance checklist;
+7. sign every commit with `git commit -s` under DCO 1.1;
+8. open a PR that links its issue, explains compatibility/security impact, and
+   supplies exact evidence.
+
+Unsigned commits are not accepted. Contributors amend/rebase their own commits
+rather than maintainers adding certification on their behalf. A sign-off records
+the contributor's real name and reachable email in the standard
+`Signed-off-by: Name <email>` trailer; it is not a copyright assignment.
+
+Issue/PR forms and automated DCO enforcement remain owned by issue #6 and CI
+enforcement by issue #7. This issue defines the normative rules and testable
+repository artifacts those later workflows consume.
+
+## 5. Intellectual-property provenance
+
+Access to private material is not permission to relicense it. Every PR that uses
+legacy code, prompts, fixtures, schemas, tests, or documentation answers a
+provenance checklist:
+
+- exact source and whether it is public or private;
+- original author/copyright owner;
+- applicable license or written relicensing authorization;
+- contribution method: original, behaviorally reimplemented, adapted, or
+  verbatim;
+- whether customer, employee, secret, credential, internal-infrastructure, or
+  confidential business data is present;
+- evidence that any third-party notices and attribution are preserved.
+
+The safe default for the private Go Yoda, BetaUp, and MWTC material is
+**behavioral clean-room reimplementation**: document externally observable
+inputs, outputs, ordering, gates, reason codes, and edge cases, then write new
+English TypeScript/tests without copying private source or prose. The old
+repository remains the compatibility oracle for PRD/spec behavior, but that
+does not itself authorize copying implementation text.
+
+Verbatim or adapted private material may enter only when the PR carries
+reviewable evidence that the rights holder authorized publication under MIT.
+Unclear provenance blocks merge. Secrets and customer/confidential data are
+never accepted, regardless of copyright permission.
+
+## 6. Normative language
+
+English is normative for repository artifacts and contributor communication:
+source, comments, tests, fixtures, errors, documentation, issues, discussions,
+commit messages, reviews, and pull requests. This creates one reviewable public
+record and matches the architecture language contract.
+
+Community translations are welcome only as clearly labeled informational
+copies that link to the English original. When translations differ, English
+controls. Personal accessibility needs are handled respectfully; maintainers
+may help translate an initial report, but the durable repository decision is
+recorded in English.
+
+## 7. Governance and decisions
+
+The project starts with a lead-maintainer model appropriate for its experimental
+stage:
+
+- **Project Lead:** `@thiagocorreanet`, accountable for vision, releases,
+  security, governance, owner appointments, and final tie-breaking;
+- **Maintainers:** contributors explicitly appointed through a public governance
+  PR after sustained trusted work; they triage, review, and merge within their
+  documented ownership;
+- **Contributors:** everyone participating under the code of conduct and DCO.
+
+Routine reversible changes use lazy consensus through issues and PR review.
+Public contracts, architecture, security boundaries, compatibility, migrations,
+and governance require a written design/ADR as applicable and explicit Project
+Lead or delegated owner approval. Security and conduct cases are decided
+privately to protect reporters; only safe outcomes are published. The Project
+Lead resolves deadlock after documenting the rationale.
+
+Governance amendments use a PR, public rationale, and Project Lead approval.
+Maintainer inactivity never transfers credentials automatically; access is
+reviewed and revoked when no longer necessary.
+
+## 8. Security policy
+
+Until public releases exist, only the current `main` branch is supported. The
+private Go predecessor and third-party forks are not supported through this
+public repository. Once releases begin, each supported line must be listed
+explicitly rather than inferred.
+
+Reports use GitHub's **Report a vulnerability** flow. The repository setting is
+enabled and verified without creating a real report. Reporters must not open a
+public issue, PR, discussion, or paste with vulnerability details before triage
+and coordinated disclosure.
+
+The policy requests impact, affected version/commit, prerequisites, safe
+reproduction, proof of concept where appropriate, and suggested remediation.
+It prohibits real secrets, personal/customer data, destructive testing, service
+disruption, social engineering, and attacks against systems not owned by the
+reporter.
+
+Response targets, measured in business days, are:
+
+- acknowledgement within 3 days;
+- initial severity/scope triage within 7 days;
+- private status updates at least every 14 days while active;
+- remediation/disclosure timing agreed from severity and fix complexity, with
+  critical issues targeted for 7 days and high issues for 30 days when feasible.
+
+These are good-faith targets, not a paid support SLA. Maintainers coordinate a
+fix, advisory, credit, CVE request where appropriate, and disclosure only after
+affected users have a reasonable remediation path. Duplicate, invalid, or
+out-of-scope reports receive a private explanation.
+
+## 9. Conduct and support
+
+Contributor Covenant 3.0 applies to repository spaces and official project
+representation. Conduct incidents use a confidential maintainer channel: the
+same GitHub private reporting form with a `CODE OF CONDUCT` title when private
+contact is needed, or GitHub's platform reporting tools for content governed by
+GitHub. Conduct reports and vulnerability reports remain separately triaged.
+
+`SUPPORT.md` distinguishes:
+
+- public, reproducible bugs and feature proposals in GitHub Issues;
+- usage questions only when enough public context exists to answer safely;
+- confidential vulnerabilities through private reporting;
+- conduct reports through the confidential route;
+- proprietary BetaUp/MWTC/customer systems as unsupported and out of scope.
+
+The project is experimental and offers no guaranteed response time or production
+support. Support requests must contain no secrets or private customer data.
+
+## 10. Automated and manual verification
+
+`tests/community-health.test.ts` fails first while the required artifacts are
+absent, then permanently checks:
+
+- all required files and `.github/CODEOWNERS` exist;
+- README links contribution, security, support, conduct, and governance paths;
+- DCO sign-off, English, verification, and IP provenance rules are present;
+- supported-version and confidential-reporting requirements are present;
+- no template placeholders remain in policy files;
+- CODEOWNERS assigns the verified owner and protects its own path.
+
+Documentation lint and link checks cover every Markdown policy. The manual dry
+run records:
+
+1. README-to-contribution navigation and all contributor decision branches;
+2. parsing a sample DCO trailer without creating a project commit;
+3. private vulnerability reporting enabled via the GitHub API;
+4. the reporting URL resolves without submitting a vulnerability;
+5. after merge, GitHub's community profile recognizes contribution, conduct,
+   license, and security files, and the CODEOWNERS error API reports no errors.
+
+The post-merge recognition checks may complete after the implementation PR is
+merged; their evidence is recorded in the issue before closure.
+
+## 11. Scope boundaries
+
+This issue does not add issue/PR templates, labels, a DCO bot, branch rules,
+Node CI, release support promises, legal ownership not backed by evidence, or
+public behavior from the old runtime. Those changes remain in their dependency-
+ordered issues.
+
+No SDD runtime, PRD/spec workflow, schema, reason code, migration, or host
+behavior changes. The legacy PRD compatibility requirement remains exactly as
+approved in the observable architecture specification.
+
+## 12. Acceptance mapping
+
+| Issue requirement | Design section |
+| --- | --- |
+| Contribution, conduct, governance, security, support, CODEOWNERS | 3–9 |
+| DCO workflow and sign-off | 4 |
+| Disclosure channel, supported versions, response, no premature public details | 8 |
+| Normative English | 6 |
+| Legacy/private IP provenance checklist | 5 |
+| GitHub recognition | 3, 10 |
+| Clean-room versus authorized MIT relicensing | 5 |
+| README discoverability within two links | 1, 4, 10 |
+| Lint/link checks and manual dry runs | 10 |

--- a/docs/superpowers/specs/2026-08-06-open-source-governance-design.md
+++ b/docs/superpowers/specs/2026-08-06-open-source-governance-design.md
@@ -34,8 +34,9 @@ The repository adopts:
   in supported root locations;
 - [Developer Certificate of Origin 1.1](https://developercertificate.org/)
   verbatim in `DCO`;
-- [Contributor Covenant 3.0](https://www.contributor-covenant.org/version/3/0/code_of_conduct/)
-  in `CODE_OF_CONDUCT.md`, with its required attribution;
+- GitHub's recognized Contributor Covenant 2.0 template, obtained from the
+  `codes_of_conduct/contributor_covenant` API and adapted only for actionable
+  enforcement routes, in `CODE_OF_CONDUCT.md` with required attribution;
 - [GitHub private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository)
   as the primary confidential channel;
 - `.github/CODEOWNERS`, the location GitHub recommends for protecting ownership
@@ -170,11 +171,14 @@ out-of-scope reports receive a private explanation.
 
 ## 9. Conduct and support
 
-Contributor Covenant 3.0 applies to repository spaces and official project
-representation. Conduct incidents use a confidential maintainer channel: the
-same GitHub private reporting form with a `CODE OF CONDUCT` title when private
-contact is needed, or GitHub's platform reporting tools for content governed by
-GitHub. Conduct reports and vulnerability reports remain separately triaged.
+Contributor Covenant 2.0 applies to repository spaces and official project
+representation. When the Project Lead is not involved, conduct incidents use
+the GitHub private reporting form with a `CODE OF CONDUCT` title and remain
+separately triaged from vulnerabilities. A report involving the Project Lead
+must bypass repository administrators from the outset: GitHub-hosted conduct is
+reported directly to GitHub Support, and other official spaces use their
+independent platform/event moderation channel. The project does not advertise
+an internal independent route until a moderator is publicly appointed.
 
 `SUPPORT.md` distinguishes:
 

--- a/tests/community-health.test.ts
+++ b/tests/community-health.test.ts
@@ -1,0 +1,105 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const requiredPolicyPaths = [
+  "CONTRIBUTING.md",
+  "CODE_OF_CONDUCT.md",
+  "GOVERNANCE.md",
+  "SECURITY.md",
+  "SUPPORT.md",
+  "DCO",
+  ".github/CODEOWNERS",
+] as const;
+
+type PolicyPath = (typeof requiredPolicyPaths)[number];
+type PolicyFiles = Record<PolicyPath, string>;
+
+let policies: PolicyFiles;
+let readme: string;
+
+beforeAll(async () => {
+  const contents = await Promise.all(
+    requiredPolicyPaths.map(async (path) => [
+      path,
+      await readFile(join(repositoryRoot, path), "utf8"),
+    ]),
+  );
+  policies = Object.fromEntries(contents) as PolicyFiles;
+  readme = await readFile(join(repositoryRoot, "README.md"), "utf8");
+});
+
+describe("community health policies", () => {
+  it("keeps every required repository policy", () => {
+    for (const path of requiredPolicyPaths) {
+      expect(policies[path].trim().length, path).toBeGreaterThan(0);
+    }
+  });
+
+  it("makes every community path discoverable from README", () => {
+    expect(readme).toContain("[Contribution guide](CONTRIBUTING.md)");
+    expect(readme).toContain("[Code of Conduct](CODE_OF_CONDUCT.md)");
+    expect(readme).toContain("[Governance](GOVERNANCE.md)");
+    expect(readme).toContain("[Support policy](SUPPORT.md)");
+    expect(readme).toContain("[Security policy](SECURITY.md)");
+  });
+
+  it("requires DCO sign-off and intellectual-property provenance", () => {
+    const contributing = policies["CONTRIBUTING.md"];
+
+    expect(contributing).toContain("git commit -s");
+    expect(contributing).toContain(
+      "Signed-off-by: Your Name <your.email@example.com>",
+    );
+    expect(contributing).toContain("Intellectual-property provenance checklist");
+    expect(contributing).toContain("behavioral clean-room");
+    expect(contributing).toContain("Unclear provenance blocks merge");
+    expect(policies.DCO).toContain("Developer's Certificate of Origin 1.1");
+  });
+
+  it("defines a confidential vulnerability path and support boundary", () => {
+    const security = policies["SECURITY.md"];
+
+    expect(security).toContain("Report a vulnerability");
+    expect(security).toContain("Do not open a public issue");
+    expect(security).toContain("| `main` | Yes |");
+    expect(security).toContain("within 3 business days");
+    expect(policies["SUPPORT.md"]).toContain("no production support SLA");
+  });
+
+  it("adopts attributed conduct rules and explicit governance", () => {
+    expect(policies["CODE_OF_CONDUCT.md"]).toContain(
+      "Contributor Covenant 3.0",
+    );
+    expect(policies["CODE_OF_CONDUCT.md"]).toContain("CC BY-SA 4.0");
+    expect(policies["GOVERNANCE.md"]).toContain(
+      "Project Lead: `@thiagocorreanet`",
+    );
+  });
+
+  it("protects repository ownership", () => {
+    const codeowners = policies[".github/CODEOWNERS"];
+
+    expect(codeowners).toContain("* @thiagocorreanet");
+    expect(codeowners).toContain("/.github/ @thiagocorreanet");
+    expect(codeowners).toContain("/SECURITY.md @thiagocorreanet");
+  });
+
+  it("contains no unfilled policy templates", () => {
+    const unfinishedMarkers = [
+      "T" + "BD",
+      "TO" + "DO",
+      "[" + "INSERT",
+      "[" + "NOTE",
+    ];
+
+    for (const path of requiredPolicyPaths) {
+      for (const marker of unfinishedMarkers) {
+        expect(policies[path], `${path} contains ${marker}`).not.toContain(marker);
+      }
+    }
+  });
+});

--- a/tests/community-health.test.ts
+++ b/tests/community-health.test.ts
@@ -54,7 +54,9 @@ describe("community health policies", () => {
     expect(contributing).toContain(
       "Signed-off-by: Your Name <your.email@example.com>",
     );
-    expect(contributing).toContain("Intellectual-property provenance checklist");
+    expect(contributing).toContain(
+      "Intellectual-property provenance checklist",
+    );
     expect(contributing).toContain("behavioral clean-room");
     expect(contributing).toContain("Unclear provenance blocks merge");
     expect(policies.DCO).toContain("Developer's Certificate of Origin 1.1");
@@ -98,7 +100,9 @@ describe("community health policies", () => {
 
     for (const path of requiredPolicyPaths) {
       for (const marker of unfinishedMarkers) {
-        expect(policies[path], `${path} contains ${marker}`).not.toContain(marker);
+        expect(policies[path], `${path} contains ${marker}`).not.toContain(
+          marker,
+        );
       }
     }
   });

--- a/tests/community-health.test.ts
+++ b/tests/community-health.test.ts
@@ -74,9 +74,12 @@ describe("community health policies", () => {
 
   it("adopts attributed conduct rules and explicit governance", () => {
     expect(policies["CODE_OF_CONDUCT.md"]).toContain(
-      "Contributor Covenant 3.0",
+      "GitHub's recognized Contributor Covenant template",
     );
-    expect(policies["CODE_OF_CONDUCT.md"]).toContain("CC BY-SA 4.0");
+    expect(policies["CODE_OF_CONDUCT.md"]).toContain("version 2.0");
+    expect(policies["CODE_OF_CONDUCT.md"]).toMatch(
+      /do not use the repository private\s+reporting form/,
+    );
     expect(policies["GOVERNANCE.md"]).toContain(
       "Project Lead: `@thiagocorreanet`",
     );


### PR DESCRIPTION
Closes #4

## Outcome

Publishes the open-source community and safety foundation:

- GitHub-recognized `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `SECURITY.md`, and `SUPPORT.md`;
- DCO 1.1 with mandatory author sign-off on every commit;
- secure default ownership in `.github/CODEOWNERS`;
- normative English policy and a complete legacy/third-party IP provenance checklist;
- explicit behavioral clean-room rules for private Go Yoda, BetaUp, and MWTC material;
- private vulnerability reporting, supported-version and response targets;
- independent GitHub Support/platform escalation when a conduct report implicates the Project Lead;
- README navigation that reaches each community path in one or two links;
- executable community-health tests and reproducible dry-run evidence.

## Design choices

- Root community files are retained in clones and recognized by GitHub.
- The code of conduct uses GitHub's recognized Contributor Covenant 2.0 template rather than the newer 3.0 text because issue #4 explicitly requires community-profile recognition.
- The repository's private reporting feature is the confidential vulnerability channel, avoiding an invented or unmonitored email address.
- Reports involving the sole Project Lead bypass repository-admin channels from the outset and use independent platform moderation.
- Access to private legacy material is not treated as relicensing permission. Behavioral compatibility can be reimplemented; adapted/verbatim material requires reviewable MIT-compatible authority.

## External repository setting

Enabled GitHub private vulnerability reporting and verified it read-only:

```json
{"enabled":true}
```

The documented report URL returned HTTP 200. No vulnerability report, draft advisory, or notification was created.

## Compatibility and scope

This changes governance and contribution policy only. It does not change runtime behavior, schemas, `.brain/` state, host adapters, migration, or the approved legacy PRD/spec compatibility contract. Issue #6 still owns templates/DCO workflow integration; issue #7 owns CI enforcement.

## Test-first and review evidence

- The community-health test initially failed with `ENOENT` because `CONTRIBUTING.md` did not exist.
- Seven policy/navigation contracts passed after the policy graph was implemented.
- Independent review found unsigned branch commits, a non-independent conduct path, and a Contributor Covenant version GitHub would not recognize.
- The branch was rebased so all 7 commits have exactly one author `Signed-off-by` trailer.
- Conduct escalation and the GitHub-recognized template were corrected; re-review reports no Critical or Important findings.

## Verification

Using Node `v24.18.0` and npm `11.16.0`:

```text
DCO range check                 PASS, 7 commits / 0 invalid sign-offs
npm run verify                  PASS
format                          PASS
lint                            PASS, zero warnings
typecheck                       PASS, strict/no emit
tests                           PASS, 4 files / 16 tests
coverage                        100% configured runtime surface
bundle                          PASS, one 386-byte standalone ESM artifact
markdownlint                    PASS, 22 files / 0 errors
Lychee                          PASS, 90 links / 0 errors
CODEOWNERS branch API           PASS, {"errors":[]}
private reporting API           PASS, {"enabled":true}
DCO trailer parser dry run      PASS
reporting URL dry run           HTTP 200, no submission
git diff --check                PASS
```

Post-merge, the issue will remain open until the community profile, CODEOWNERS errors, private reporting state, merged Documentation workflow, and issue closure are verified and recorded.
