### PR TITLE
docs: publish honest README and maturity roadmap

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,43 @@
+{
+  "version": "0.2",
+  "language": "en,en-GB,en-US",
+  "useGitignore": true,
+  "ignorePaths": [
+    "coverage/**",
+    "dist/**",
+    "node_modules/**",
+    "package-lock.json"
+  ],
+  "words": [
+    "abertos",
+    "aceitacao",
+    "aprovacao",
+    "BetaUp",
+    "CODEOWNERS",
+    "Codex",
+    "CSpell",
+    "ENOENT",
+    "esbuild",
+    "ESM",
+    "evented",
+    "lockfiles",
+    "Lychee",
+    "lycheeverse",
+    "markdownlint",
+    "metafile",
+    "Mestre",
+    "mktemp",
+    "MWTC",
+    "oneline",
+    "particionamento",
+    "previewable",
+    "regenerable",
+    "relicensing",
+    "rhysd",
+    "thiagocorreanet",
+    "TypeScript",
+    "Vitest",
+    "worktree",
+    "Yoda"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **A deterministic, observable Spec-Driven Development harness for AI coding agents.**
 
-**The model proposes. The runtime decides. The event log proves.**
+**The model will propose. The runtime will decide. The event log will prove.**
 
 [![Project Status: Experimental](https://img.shields.io/badge/status-experimental-orange.svg)](#project-status)
 [![Documentation](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml)
@@ -15,7 +15,7 @@
 
 Mestre Yoda is an open-source **Spec-Driven Development (SDD) harness** designed to make AI-assisted software delivery more reliable, explainable, and auditable.
 
-Instead of trusting an AI coding agent to remember every rule, infer every gate, and declare its own work complete, Mestre Yoda places a deterministic runtime around the development workflow. Agents can propose actions, but the harness validates state, enforces policies, records evidence, requires human approval where necessary, and explains why work may or may not continue.
+Instead of trusting an AI coding agent to remember every rule, infer every gate, and declare its own work complete, Mestre Yoda is designed to place a deterministic runtime around the development workflow. In the target architecture, agents propose actions while the harness validates state, enforces policies, records evidence, requires human approval where necessary, and explains why work may or may not continue.
 
 The project is being built for **Claude Code** and **OpenAI Codex**, with a host-neutral core designed to support additional coding agents in the future.
 
@@ -84,9 +84,12 @@ Long-running engineering work introduces problems that conversational memory can
 - plugin and runtime versions can drift when distributed separately;
 - completion claims may not be backed by reproducible evidence.
 
-Mestre Yoda addresses these problems with a robust SDD workflow in which state transitions, gates, approvals, migrations, and recovery rules are enforced by software rather than left entirely to model behavior.
+The Mestre Yoda design addresses these problems with an SDD workflow in which state transitions, gates, approvals, migrations, and recovery rules will be enforced by software rather than left entirely to model behavior.
 
 ## Core principles
+
+These principles are target invariants for the rewrite, not claims that the
+current smoke bundle implements them.
 
 ### Deterministic decisions
 
@@ -114,9 +117,10 @@ The new runtime is developed in TypeScript and distributed as a self-contained J
 
 A workflow is not complete because an agent says it is complete. Required tests, gates, evidence, handoff information, and human acceptance must agree with the current state.
 
-## How the SDD trail works
+## How the planned SDD trail will work
 
-Mestre Yoda follows one agent-driven trail from intent to accepted delivery:
+Mestre Yoda is designed to follow one agent-driven trail from intent to accepted
+delivery:
 
 ```mermaid
 flowchart LR
@@ -132,19 +136,22 @@ flowchart LR
     A -->|Approved| D[Done]
 ```
 
-The runtime is expected to support the primary trail operations `objective`, `start`, `continue`, and `done`, together with operational capabilities such as `status`, `doctor`, `explain`, `evidence`, `handoff`, `stats`, and `budgets`.
+The future runtime is expected to support the primary trail operations `objective`, `start`, `continue`, and `done`, together with operational capabilities such as `status`, `doctor`, `explain`, `evidence`, `handoff`, `stats`, and `budgets`.
 
-Manual phase jumping is not part of the design. The runtime determines which transition is valid from the current state and explains any blocked transition.
+Manual phase jumping is not part of the design. Once implemented, the runtime
+will determine which transition is valid from the current state and explain any
+blocked transition.
 
 ## Architecture
 
-Mestre Yoda separates the portable decision engine from host-specific integration and project-specific state.
+The target Mestre Yoda architecture separates the portable decision engine from
+host-specific integration and project-specific state.
 
 The canonical [Yoda Observable Architecture Specification](docs/superpowers/specs/2026-08-06-yoda-observable-architecture-design.md) defines the runtime, state, security, migration, testing, and rollout contracts. Structural choices and their consequences are indexed in the [Architecture Decision Records](docs/adr/README.md), and the required end-to-end architecture trace is recorded in [verification evidence](docs/architecture/verification.md).
 
 ```mermaid
 flowchart TB
-    subgraph Plugin[Installed plugin]
+    subgraph Plugin[Future plugin package]
         CC[Claude Code adapter]
         CX[Codex adapter]
         RT[Bundled runtime/yoda.mjs]
@@ -170,7 +177,7 @@ flowchart TB
 The central boundary is deliberate:
 
 ```text
-installed plugin/
+future plugin package/
 ├── runtime/yoda.mjs       # self-contained deterministic runtime
 ├── adapters/              # host-specific integration
 ├── skills/                # agent-facing workflows
@@ -184,7 +191,8 @@ user project/
 └── ...                    # the user's application
 ```
 
-The plugin contains the motor. The project contains only the memory and configuration required for that project.
+The future plugin will contain the motor. The project will contain only the
+memory and configuration required for that project.
 
 ## Planned capabilities
 
@@ -283,7 +291,7 @@ validation, tests with coverage, and a standalone bundle smoke check. Follow the
 [deterministic toolchain guide](docs/development/toolchain.md) to reproduce the
 complete validation sequence from a clean checkout.
 
-Every command below works from a clean checkout using Node.js `24.18.0` and npm
+Run this block in order from a clean checkout using Node.js `24.18.0` and npm
 `11.16.0`:
 
 ```bash
@@ -297,6 +305,14 @@ npm run package:verify
 The build creates `dist/plugin/runtime/yoda.mjs`; package verification copies
 only that file outside the checkout and exercises help/version. Passing these
 commands proves the repository foundation, not SDD product readiness.
+
+- `npm ci` reproduces the exactly locked development dependencies.
+- `npm run spellcheck` checks the tracked English Markdown.
+- `npm run verify` runs formatting, spelling, lint, typecheck, tests, coverage,
+  build, and package verification in order.
+- `npm run build` creates the internal standalone smoke bundle.
+- `npm run package:verify` validates its inventory, hash, and exact help/version
+  behavior outside the checkout; it requires the preceding build.
 
 ## Contributing
 
@@ -335,7 +351,9 @@ after they pass against versioned release artifacts.
 
 ### Is this just a prompt collection?
 
-No. Skills and prompts guide agent behavior, but deterministic state transitions, gates, validation, concurrency, migrations, and recovery belong to the runtime.
+No. Skills and prompts will guide agent behavior, but the target architecture
+assigns deterministic state transitions, gates, validation, concurrency,
+migrations, and recovery to the future runtime.
 
 ### Why TypeScript and JavaScript instead of Go?
 
@@ -343,7 +361,10 @@ TypeScript provides a productive development model while a bundled JavaScript ru
 
 ### Will Mestre Yoda modify my source code automatically?
 
-AI coding agents may propose and perform project work under their own host permissions. Mestre Yoda's role is to control and explain the SDD workflow, validate transitions, preserve evidence, and enforce delivery gates. Exact permissions and managed paths will be documented before release.
+AI coding agents may propose and perform project work under their own host
+permissions. The future Mestre Yoda runtime is designed to control and explain
+the SDD workflow, validate transitions, preserve evidence, and enforce delivery
+gates. Exact permissions and managed paths will be documented before release.
 
 ### Where does project state live?
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 **The model proposes. The runtime decides. The event log proves.**
 
 [![Project Status: Experimental](https://img.shields.io/badge/status-experimental-orange.svg)](#project-status)
+[![Documentation](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Language: English](https://img.shields.io/badge/project_language-English-1f6feb.svg)](#contributing)
 
@@ -21,7 +22,11 @@ The project is being built for **Claude Code** and **OpenAI Codex**, with a host
 ## Project status
 
 > [!IMPORTANT]
-> Mestre Yoda is currently an **experimental rewrite under active development**. The architecture and public implementation backlog are available, but the new TypeScript runtime is not ready for production installation yet.
+> Mestre Yoda is an **experimental rewrite under active development**. There is
+> no supported installation method, public distribution, production runtime, or
+> usable SDD command today. The checked-in embedded ESM runtime is internal
+> foundation infrastructure: it supports only `--help` and `--version` to prove
+> the deterministic toolchain and standalone bundle. The project is not ready for production.
 
 This repository is intentionally public from the beginning so that its architecture, compatibility decisions, tests, and trade-offs can evolve in the open.
 
@@ -36,6 +41,34 @@ This repository is intentionally public from the beginning so that its architect
 | Public beta distribution | Planned |
 
 Follow the [public milestones](https://github.com/thiagocorreanet/mestre-yoda/milestones) or browse the [complete implementation backlog](https://github.com/thiagocorreanet/mestre-yoda/issues).
+
+## Installation
+
+There is no supported installation method for this public rewrite yet. Do not
+use installation or marketplace commands from the private Go predecessor: they
+refer to a different implementation and distribution boundary.
+
+The planned distribution will embed one self-contained `runtime/yoda.mjs` in
+thin Claude Code and Codex plugins. It will not install a global Yoda binary or
+project runtime `node_modules`. A supported installation path will be published
+only after [version-coherent distributions](https://github.com/thiagocorreanet/mestre-yoda/issues/61)
+exist and their install, update, compatibility, rollback, and uninstall flows
+pass release gates.
+
+Cloning this repository is currently useful only for contributing to and
+validating the rewrite; it does not install Mestre Yoda into an agent host.
+
+## Usage preview — not available yet
+
+The intended agent-driven trail begins with an objective, starts the next valid
+workflow, continues through runtime-selected gates, and reaches done only after
+evidence and human acceptance agree. Planned operational capabilities include
+status, doctor, explain, evidence, handoff, statistics, and budgets.
+
+These operations are architectural preview, not runnable in the current bundle.
+The compatibility contract and differential tests must freeze their exact
+inputs, outputs, reason codes, and recovery semantics before this README presents
+them as usable commands.
 
 ## Why Mestre Yoda exists
 
@@ -69,7 +102,9 @@ Critical approvals are explicit and bound to the content that was actually revie
 
 ### Local-first project state
 
-Project-specific state lives inside the project under `.brain/`. Host instructions live in `.claude/` and `.codex/`. The runtime remains owned by the installed plugin.
+The project-owned `.brain/` state lives inside the project. Host instructions live
+in `.claude/` and `.codex/`. The embedded ESM runtime remains owned by the
+installed plugin.
 
 ### No global Yoda binary
 
@@ -230,14 +265,16 @@ The final catalog and schemas will be defined through the [compatibility contrac
 
 ## Roadmap
 
-Development is organized into explicit maturity stages:
+Development uses four evidence-based maturity stages:
 
-1. **Experimental** — architecture, compatibility contract, and runtime foundation.
-2. **Preview** — complete local SDD trail with initial host integrations.
-3. **Beta** — migration, observability, platform coverage, documentation, and public pilots.
-4. **Stable** — mandatory parity, security, migration, host, and pilot criteria are satisfied.
+1. **Experimental (current)** — public architecture and foundations; not installable.
+2. **Preview** — complete compatible trail and host integrations for evaluation.
+3. **Beta** — migration, quality, documentation, and distribution gates passed.
+4. **Stable** — representative pilots and every mandatory release gate passed.
 
-The frozen Go implementation will not be retired merely because the rewrite appears feature-complete. Retirement requires measurable compatibility, migration, native platform, host E2E, recovery, and pilot evidence.
+See the [Objective maturity gates](ROADMAP.md) for promotion, regression,
+rollback, and private Go predecessor retirement criteria. No calendar date,
+feature count, or demo can replace the required evidence.
 
 ## Development
 
@@ -245,6 +282,21 @@ The repository now provides a pinned Node/npm workspace, strict TypeScript
 validation, tests with coverage, and a standalone bundle smoke check. Follow the
 [deterministic toolchain guide](docs/development/toolchain.md) to reproduce the
 complete validation sequence from a clean checkout.
+
+Every command below works from a clean checkout using Node.js `24.18.0` and npm
+`11.16.0`:
+
+```bash
+npm ci
+npm run spellcheck
+npm run verify
+npm run build
+npm run package:verify
+```
+
+The build creates `dist/plugin/runtime/yoda.mjs`; package verification copies
+only that file outside the checkout and exercises help/version. Passing these
+commands proves the repository foundation, not SDD product readiness.
 
 ## Contributing
 
@@ -276,7 +328,10 @@ public issue, pull request, discussion, or paste before coordinated disclosure.
 
 ### Is Mestre Yoda ready to install?
 
-Not yet. This repository currently contains the public design and implementation backlog for the new architecture. Installation instructions will be published only after they are tested against release artifacts.
+No. There is no supported installation method today. This repository contains
+the architecture, backlog, governance, deterministic toolchain, and an internal
+help/version smoke bundle. Installation instructions will be published only
+after they pass against versioned release artifacts.
 
 ### Is this just a prompt collection?
 
@@ -293,6 +348,18 @@ AI coding agents may propose and perform project work under their own host permi
 ### Where does project state live?
 
 The new architecture keeps project-specific state in `.brain/` inside the project. Host-specific project instructions live in `.claude/` and `.codex/`. The runtime stays inside the installed plugin.
+
+## Acknowledgements
+
+- The private Go Mestre Yoda v3 implementation is the behavioral oracle for
+  compatibility work. Its source and prose are not presumed MIT-licensed; every
+  migrated artifact remains subject to the repository's provenance policy.
+- Claude Code and OpenAI Codex motivate the first host adapters. Naming them
+  describes interoperability targets and does not imply endorsement.
+- The development foundation builds on Node.js, TypeScript, esbuild, ESLint,
+  Prettier, Vitest, CSpell, markdownlint, and Lychee.
+- Community policy builds on the Developer Certificate of Origin, Contributor
+  Covenant, and GitHub's open-source community tooling.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,10 @@ Preview, Beta, or Stable. The linked issues remain the detailed source of scope;
 this document is the promotion contract.
 
 No calendar date or feature demo promotes the project. Every criterion for the
-next stage must be backed by current, reproducible evidence. A waived criterion
-requires a public governance decision that explains the risk; marketing language
-cannot waive a safety or compatibility gate.
+next stage must be backed by current, reproducible evidence. Promotion criteria
+cannot be waived. If equivalent evidence does not exist, the project remains at
+its current maturity stage while maintainers revise scope or close the gap through
+a separately reviewed public change.
 
 ## Experimental
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,141 @@
+# Mestre Yoda Maturity Roadmap
+
+Mestre Yoda advances through evidence, not dates, feature counts, or demos. This
+roadmap defines when the public rewrite may describe itself as Experimental,
+Preview, Beta, or Stable. The linked issues remain the detailed source of scope;
+this document is the promotion contract.
+
+No calendar date or feature demo promotes the project. Every criterion for the
+next stage must be backed by current, reproducible evidence. A waived criterion
+requires a public governance decision that explains the risk; marketing language
+cannot waive a safety or compatibility gate.
+
+## Experimental
+
+**Current stage.** Experimental means the architecture and implementation are
+being developed publicly while contracts may still change. There is no supported
+installation or production-use promise.
+
+The delivery sequence is visible through these public epics:
+
+- [Foundation](https://github.com/thiagocorreanet/mestre-yoda/issues/1)
+- [Compatibility Contract](https://github.com/thiagocorreanet/mestre-yoda/issues/8)
+- [Deterministic Runtime](https://github.com/thiagocorreanet/mestre-yoda/issues/15)
+- [SDD Workflow Parity](https://github.com/thiagocorreanet/mestre-yoda/issues/24)
+- [Host Integrations](https://github.com/thiagocorreanet/mestre-yoda/issues/34)
+- [Migration and Observability](https://github.com/thiagocorreanet/mestre-yoda/issues/40)
+- [Quality Campaign](https://github.com/thiagocorreanet/mestre-yoda/issues/48)
+- [Public Beta](https://github.com/thiagocorreanet/mestre-yoda/issues/57)
+
+### Promotion to Preview
+
+All exit criteria in Foundation, Compatibility Contract, Deterministic Runtime,
+SDD Workflow Parity, and Host Integrations must pass. Evidence must show:
+
+- the authoritative Go v3 oracle is frozen, inventoried, licensed appropriately
+  for its role, and connected to a P0/P1 traceability matrix;
+- schemas, reason/exit codes, state versions, fixtures, and differential
+  comparison are versioned and reproducible;
+- the bundled TypeScript runtime executes the complete local objective-to-done
+  trail, and invalid transitions never mutate state;
+- deterministic gates, content-bound approvals, budgets, evidence, recovery,
+  lineage, and human acceptance pass differential and integration tests;
+- Claude Code and Codex pass the shared adapter contract and end-to-end trail;
+- host adapters remain thin, while `.brain/`, `.claude/`, and `.codex/` are the
+  only generated project-owned state/configuration surfaces;
+- the embedded ESM runtime works without a global Yoda binary, project runtime
+  dependency, network lookup, or separately versioned executable;
+- governance, security, contribution, package, and pull-request CI foundations
+  are public and green.
+
+## Preview
+
+Preview means a versioned build is available for evaluation by users who accept
+contract change and provide feedback. It is not a production-support promise.
+Known limitations and supported evaluation paths must be explicit.
+
+### Promotion to Beta
+
+All exit criteria in Migration and Observability and the Quality Campaign must
+pass. Public Beta documentation, release, developer-flow, and distribution work
+in issues #58–#61 must also pass. Evidence must show:
+
+- legacy discovery is no-write by default, and migration is transactional,
+  backed up, verified, idempotent, and reversible;
+- replay, integrity audit, divergence reporting, safe repair, evidence export,
+  and the local dashboard preserve provenance and privacy;
+- native supported platforms pass filesystem, Git, concurrency, failure-
+  injection, migration, bundle, installation, and update tests;
+- security, supply-chain, mutation, property/model, performance, and regression
+  campaigns meet their published thresholds;
+- Claude Code and Codex pass real host E2E tests against the final package;
+- a new user can follow complete English installation, initialization, trail,
+  diagnosis, update, migration, rollback, and uninstall documentation;
+- release artifacts are reproducible and carry checksums, SBOM, provenance, and
+  all required gate results;
+- plugin installation, update, compatibility checks, rollback, and uninstall are
+  atomic and version-coherent for both hosts;
+- no release-blocking critical security, integrity, migration, recovery,
+  compatibility, or host defect remains unresolved.
+
+## Beta
+
+Beta means the release is public, installable, documented, and supported within
+explicit boundaries. It may still make pre-1.0 contract changes with migration
+and release notes. Beta is the stage for representative pilot projects, not a
+shortcut around their evidence.
+
+### Promotion to Stable
+
+The public-beta pilot issue #62 and every architecture retirement gate must pass.
+Evidence must show:
+
+- representative pilot projects install, initialize, complete a real trail,
+  diagnose failures, update, migrate, roll back, and uninstall successfully;
+- P0/P1 differential parity remains current against the frozen Go oracle;
+- all supported operating systems and both host adapters pass release E2E using
+  the final immutable artifacts;
+- recovery, crash, concurrency, migration, and rollback drills demonstrate no
+  hidden data loss or stale authorization;
+- performance and regression budgets remain within published thresholds;
+- security gates pass with no unresolved critical blocker, and disclosure/
+  support procedures operate during pilots;
+- known limitations, supported versions, compatibility policy, release decision,
+  and rollback decision are public and accurate;
+- the Project Lead records human acceptance of the complete evidence set.
+
+## Stable
+
+Stable begins only after all Beta promotion gates pass. Stable establishes
+explicit supported versions, migration commitments, and compatibility promises.
+It does not mean the project stops evolving; changes continue through versioned
+contracts, deprecation, migration, review, and evidence.
+
+## Regression and rollback
+
+Promotion evidence must remain current. A failed security, integrity, parity,
+migration, recovery, package, platform, or host gate blocks promotion even when
+all planned features exist.
+
+If evidence becomes invalid after a release, maintainers mark the affected stage
+or version degraded, stop unsafe promotion/distribution, publish the safe impact,
+and use the tested rollback or remediation path. A stage label may be downgraded
+when its guarantees no longer hold. Restoring a label requires fresh evidence,
+not an assertion that the regression is probably harmless.
+
+## Go predecessor retirement
+
+The private Go v3 implementation remains the behavioral oracle until all of the
+following are proven:
+
+- the parity inventory covers every required surface with an owner and fixture;
+- P0/P1 differential parity and golden scenarios pass against the frozen oracle;
+- legacy migration, backup, verification, and rollback pass representative data;
+- Linux, Windows, macOS, Claude Code, and Codex release E2E pass as supported;
+- clean package install, update, crash recovery, and rollback are proven;
+- security and privacy gates have no unresolved retirement blocker;
+- representative pilot projects complete the full lifecycle successfully.
+
+A feature-complete TypeScript implementation, passing demo, or elapsed date does
+not retire the oracle. Private predecessor code, prompts, fixtures, and prose may
+enter the MIT repository only under the [provenance policy](CONTRIBUTING.md#intellectual-property-provenance-checklist).

--- a/docs/development/toolchain.md
+++ b/docs/development/toolchain.md
@@ -31,6 +31,7 @@ clean and CI installations. Changing a dependency requires Node `24.18.0`, npm
 | Command | Responsibility |
 | --- | --- |
 | `npm run format:check` | Check supported source and configuration formatting |
+| `npm run spellcheck` | Check tracked English Markdown with the project dictionary |
 | `npm run lint` | Run typed ESLint with zero warnings |
 | `npm run typecheck` | Run strict TypeScript 6 compatibility checking without emit |
 | `npm test` | Run unit and clean-room bundle tests once |
@@ -57,7 +58,8 @@ scripts/             deterministic build and package verification
 
 All npm packages are private ESM workspaces. The root has no production
 dependencies. Its exactly pinned development dependencies are compilers,
-linters, formatters, test/coverage tools, type declarations, and the bundler.
+linters, formatters, the CSpell documentation checker, test/coverage tools, type
+declarations, and the bundler.
 Only the exactly pinned esbuild installer is allowed to run a dependency
 lifecycle script. npm treats uncovered scripts as installation errors and
 explicitly denies the optional fsevents script recorded for macOS compatibility.

--- a/docs/roadmap/verification.md
+++ b/docs/roadmap/verification.md
@@ -1,0 +1,72 @@
+# README and Maturity Roadmap Verification
+
+- Verification date: 2026-08-06 (America/Sao_Paulo)
+- Tracking issue: [#5](https://github.com/thiagocorreanet/mestre-yoda/issues/5)
+- Branch: `docs/issue-5-readme-roadmap`
+- Reviewed implementation commit: `d246120`
+- Status: Ready for pull request
+
+## Command honesty
+
+The README's complete development block was executed in its documented order
+with Node.js `v24.18.0` and npm `11.16.0` from the exact lockfile.
+
+| Presented command | Observed result |
+| --- | --- |
+| `npm ci` | Pass; 257 development packages installed from the lockfile |
+| `npm run spellcheck` | Pass; 25 Markdown files and zero issues |
+| `npm run verify` | Pass; formatting, spelling, lint, typecheck, 30 tests, coverage, build, and package verification |
+| `npm run build` | Pass; one 386-byte embedded ESM smoke artifact |
+| `npm run package:verify` | Pass; exact inventory, SHA-256, help, and version outside the checkout |
+
+The package verification inventory was exactly `runtime/yoda.mjs`. Its SHA-256
+was `24293983cba88bb6e96ba4586bb5492b5e84bd18a8d5f0b7b536e8ad8d2108ee`;
+help was `Usage: yoda [--help | --version]`; version was
+`0.0.0-development`. These observations prove foundation packaging only, not an
+installable SDD product.
+
+## Documentation checks
+
+| Check | Observed result |
+| --- | --- |
+| CSpell 10.0.1 | 26 files, zero issues |
+| markdownlint-cli2 0.20.0 | 26 files, zero errors |
+| Lychee | 78 links checked, 55 unique, zero errors |
+| `git diff --check` | Pass |
+| DCO trailers | All four issue commits contain one `Signed-off-by` trailer |
+
+The README badge targets the real
+[`Documentation`](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml)
+workflow. Its most recent `main` run before publication was
+[successful](https://github.com/thiagocorreanet/mestre-yoda/actions/runs/31142000139).
+The pull-request run remains the publication gate.
+
+## Independent review
+
+The technical review compared the issue, design, plan, README contract test,
+roadmap gates, and package scripts. It initially found an open-ended maturity
+waiver and two command-test weaknesses. Promotion waivers were removed, ordered
+build prerequisites were made explicit, and the test now parses exact scripts
+and inventories all documented npm commands. The re-review reported no Critical,
+Important, or Minor findings.
+
+A clean-room reader received only README and ROADMAP. The first pass correctly
+identified the current maturity and installation boundary but found present-tense
+architecture copy that could imply delivery. All such copy was made explicitly
+future-facing. The final clean-room pass reported no Critical, Important, or
+Minor findings.
+
+| Reader question | Verified answer | Public evidence |
+| --- | --- | --- |
+| Current maturity | Experimental active rewrite | README `Project status`; ROADMAP `Experimental` |
+| Installation today | No supported method; clone is contribution-only | README `Installation` and FAQ |
+| Working commands | The five ordered development commands above | README `Development` |
+| Available runtime behavior | Internal bundle supports only help/version | README status and usage preview |
+| Project-owned state | `.brain/`, `.claude/`, and `.codex/` | README principles and architecture |
+| Runtime ownership | Future self-contained ESM inside the plugin package | README installation and architecture |
+| Preview promotion | Foundation through host integration evidence | ROADMAP `Promotion to Preview` |
+| Beta promotion | Migration, quality, documentation, and distribution evidence | ROADMAP `Promotion to Beta` |
+| Stable promotion | Representative pilots and every retirement/release gate | ROADMAP `Promotion to Stable` |
+
+No unavailable install or SDD command is presented as executable. Every
+promotion criterion requires current reproducible evidence and cannot be waived.

--- a/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
+++ b/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
@@ -1,0 +1,220 @@
+# Honest README and Maturity Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the front page impossible to mistake for an installable product and publish objective Experimental-to-Stable promotion gates with reproducible spelling/link validation.
+
+**Architecture:** README remains the concise project entrypoint and links a focused ROADMAP for evidence gates. A reader-contract test protects availability claims and command honesty; exactly pinned CSpell joins the deterministic development-only verification chain.
+
+**Tech Stack:** Markdown, Vitest 4.1.10, CSpell 10.0.1, markdownlint, Lychee, existing Documentation GitHub Action.
+
+## Global Constraints
+
+- Keep all public text and tool configuration English.
+- State that no supported installation, public distribution, production runtime, or usable SDD command exists today.
+- Identify the current ESM bundle as internal smoke infrastructure supporting only `--help` and `--version`.
+- Do not show planned install commands or private predecessor distribution commands.
+- Preserve no-global-binary and project-owned `.brain/`, `.claude/`, `.codex/` architecture.
+- Use only the real Documentation workflow badge; issue #7 owns the future Node workflow.
+- Pin CSpell exactly at `10.0.1` as development-only and retain zero external runtime dependencies.
+- Preserve the legacy PRD/spec parity and issue #4 provenance policy.
+- Sign every commit under DCO 1.1.
+
+---
+
+### Task 1: Define a failing clean-room reader contract
+
+**Files:**
+
+- Create: `tests/readme-honesty.test.ts`
+
+**Interfaces:**
+
+- Consumes: `README.md`, future `ROADMAP.md`, and `package.json` as text.
+- Produces: assertions for real badges, availability boundaries, working commands, architecture ownership, maturity gates, and acknowledgements.
+
+- [ ] **Step 1: Write the failing reader tests**
+
+Read the three files from the repository root. Assert README contains these exact
+boundaries:
+
+```typescript
+expect(readme).toContain("There is no supported installation method");
+expect(readme).toContain("supports only `--help` and `--version`");
+expect(readme).toContain("not runnable in the current bundle");
+expect(readme).toContain("[Objective maturity gates](ROADMAP.md)");
+expect(readme).toContain("actions/workflows/docs.yml/badge.svg?branch=main");
+expect(readme).not.toMatch(/claude plugin install|codex plugin add|npm install -g/);
+```
+
+Assert the README development shell block contains only `npm ci`,
+`npm run spellcheck`, `npm run verify`, `npm run build`, and
+`npm run package:verify`, and package text defines every named script. Assert
+roadmap contains all four stages, `Promotion to Preview`, `Promotion to Beta`,
+`Promotion to Stable`, every epic #1/#8/#15/#24/#34/#40/#48/#57, regression/
+rollback rules, pilots, P0/P1 parity, and predecessor retirement.
+
+- [ ] **Step 2: Confirm RED**
+
+Run: `npm test -- tests/readme-honesty.test.ts`
+
+Expected: FAIL because `ROADMAP.md` does not exist.
+
+### Task 2: Add deterministic English spelling validation
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Create: `.cspell.json`
+- Modify: `docs/development/toolchain.md`
+- Modify: `docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md`
+
+**Interfaces:**
+
+- Consumes: npm 11.16.0 strict install policy and tracked Markdown.
+- Produces: `npm run spellcheck` and a `verify` chain that fails on unknown documentation words.
+
+- [ ] **Step 1: Pin CSpell and add scripts**
+
+Add exact dev dependency `"cspell": "10.0.1"`, script
+`"spellcheck": "cspell --no-progress --show-suggestions \"**/*.md\""`, and run
+`npm run spellcheck` between formatting and lint in `verify`.
+
+- [ ] **Step 2: Configure narrow project vocabulary**
+
+Create `.cspell.json` with version `0.2`, language `en,en-GB,en-US`,
+`useGitignore: true`, explicit ignores for `node_modules`, `dist`, `coverage`,
+and a sorted words list containing legitimate names such as `BetaUp`, `CODEOWNERS`,
+`esbuild`, `metafile`, `MWTC`, `relicensing`, `TypeScript`, and `Vitest`. Do not
+ignore README, ROADMAP, or all-uppercase words broadly.
+
+- [ ] **Step 3: Regenerate and verify the strict lockfile**
+
+Using exact Node/npm:
+
+```bash
+npm install --package-lock-only
+npm ci
+npm run spellcheck
+```
+
+Expected: clean installation succeeds under strict lifecycle-script policy; the
+spellcheck initially reports only genuine vocabulary/configuration gaps, which
+are corrected narrowly until it passes.
+
+- [ ] **Step 4: Update toolchain documentation**
+
+List CSpell `10.0.1` in the exact development dependencies and add `spellcheck`
+to the command tables and clean verification sequence. State it scans tracked
+Markdown and remains absent from the runtime bundle.
+
+### Task 3: Publish the honest README and objective roadmap
+
+**Files:**
+
+- Modify: `README.md`
+- Create: `ROADMAP.md`
+
+**Interfaces:**
+
+- Consumes: issue #5 design, phase epic exit criteria, real Documentation workflow, current smoke CLI.
+- Produces: one entrypoint with truthful availability and one evidence-based maturity model.
+
+- [ ] **Step 1: Add the real workflow badge and current-state warning**
+
+Link the badge image
+`https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml/badge.svg?branch=main`
+to the real workflow page. Near the top state no installation/production/usable
+SDD commands and smoke-only help/version.
+
+- [ ] **Step 2: Add Installation and Usage preview sections**
+
+Installation contains no install command. Describe only the planned embedded
+plugin model and issue #61 gate. Usage preview lists planned operations in prose
+and labels them not runnable. Explicitly reject old private distribution
+instructions for this public rewrite.
+
+- [ ] **Step 3: Expand Development with only working commands**
+
+Show one shell block:
+
+```bash
+npm ci
+npm run spellcheck
+npm run verify
+npm run build
+npm run package:verify
+```
+
+Explain artifact path and that help/version prove packaging, not product readiness.
+
+- [ ] **Step 4: Write ROADMAP objective gates**
+
+Create current Experimental status and promotion sections for Preview, Beta, and
+Stable exactly as approved. Link the phase epics, define no-calendar/evidence-
+only policy, regression rollback/degradation, known release gates, and Go oracle
+retirement. Separate stage entry from promotion evidence.
+
+- [ ] **Step 5: Add acknowledgements and align FAQ/roadmap copy**
+
+Credit the predecessor as behavioral oracle subject to provenance, the agent
+hosts without endorsement implication, and Node/TypeScript/esbuild/ESLint/
+Prettier/Vitest/CSpell plus Contributor Covenant/DCO. Ensure FAQ repeats no
+installation and roadmap section links `[Objective maturity gates](ROADMAP.md)`.
+
+- [ ] **Step 6: Confirm GREEN and commit**
+
+```bash
+npm test -- tests/readme-honesty.test.ts
+npm run spellcheck
+npm run typecheck
+npm run lint
+git add README.md ROADMAP.md tests/readme-honesty.test.ts package.json package-lock.json .cspell.json docs/development/toolchain.md docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md
+git commit -s -m "docs: publish honest README and maturity roadmap"
+```
+
+Expected: reader contract, spelling, typecheck, and lint pass.
+
+### Task 4: Prove comprehension and publish
+
+**Files:**
+
+- Create: `docs/roadmap/verification.md`
+- Modify: `docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md`
+
+**Interfaces:**
+
+- Consumes: final README/ROADMAP and verification results.
+- Produces: clean-room reader evidence and issue closure.
+
+- [ ] **Step 1: Run complete local verification**
+
+```bash
+npm run verify
+npx --yes markdownlint-cli2@0.20.0 "README.md" "*.md" "docs/**/*.md" "schemas/**/*.md" "fixtures/**/*.md"
+lychee --config .lychee.toml README.md ROADMAP.md docs schemas fixtures
+git diff --check
+```
+
+Expected: all suites, spelling, Markdown, and links pass with zero errors.
+
+- [ ] **Step 2: Request two independent review lenses**
+
+The code review checks issue/spec acceptance and command truth. The clean-room
+reader receives only README/ROADMAP and answers: current maturity, whether/how it
+can be installed, what commands work, where state/runtime live, and what promotes
+each stage. Any answer that treats planned behavior as available is Important.
+
+- [ ] **Step 3: Record evidence**
+
+Document branch/commit, test/spell/link counts, real badge URL/status, all
+presented command executions, and both review outcomes. Include a table mapping
+each reader answer to the exact README/ROADMAP evidence.
+
+- [ ] **Step 4: Publish, merge, and close**
+
+Push `docs/issue-5-readme-roadmap`, open a DCO-signed PR with `Closes #5`, design/
+compatibility impact, failure evidence, and exact results. Wait for the real
+Documentation check, merge when green, confirm issue #5 closed, synchronize main,
+and only then begin #6.

--- a/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
+++ b/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
@@ -33,7 +33,7 @@
 - Consumes: `README.md`, future `ROADMAP.md`, and `package.json` as text.
 - Produces: assertions for real badges, availability boundaries, working commands, architecture ownership, maturity gates, and acknowledgements.
 
-- [ ] **Step 1: Write the failing reader tests**
+- [x] **Step 1: Write the failing reader tests**
 
 Read the three files from the repository root. Assert README contains these exact
 boundaries:
@@ -54,7 +54,7 @@ roadmap contains all four stages, `Promotion to Preview`, `Promotion to Beta`,
 `Promotion to Stable`, every epic #1/#8/#15/#24/#34/#40/#48/#57, regression/
 rollback rules, pilots, P0/P1 parity, and predecessor retirement.
 
-- [ ] **Step 2: Confirm RED**
+- [x] **Step 2: Confirm RED**
 
 Run: `npm test -- tests/readme-honesty.test.ts`
 
@@ -75,13 +75,13 @@ Expected: FAIL because `ROADMAP.md` does not exist.
 - Consumes: npm 11.16.0 strict install policy and tracked Markdown.
 - Produces: `npm run spellcheck` and a `verify` chain that fails on unknown documentation words.
 
-- [ ] **Step 1: Pin CSpell and add scripts**
+- [x] **Step 1: Pin CSpell and add scripts**
 
 Add exact dev dependency `"cspell": "10.0.1"`, script
 `"spellcheck": "cspell --no-progress --show-suggestions \"**/*.md\""`, and run
 `npm run spellcheck` between formatting and lint in `verify`.
 
-- [ ] **Step 2: Configure narrow project vocabulary**
+- [x] **Step 2: Configure narrow project vocabulary**
 
 Create `.cspell.json` with version `0.2`, language `en,en-GB,en-US`,
 `useGitignore: true`, explicit ignores for `node_modules`, `dist`, `coverage`,
@@ -89,7 +89,7 @@ and a sorted words list containing legitimate names such as `BetaUp`, `CODEOWNER
 `esbuild`, `metafile`, `MWTC`, `relicensing`, `TypeScript`, and `Vitest`. Do not
 ignore README, ROADMAP, or all-uppercase words broadly.
 
-- [ ] **Step 3: Regenerate and verify the strict lockfile**
+- [x] **Step 3: Regenerate and verify the strict lockfile**
 
 Using exact Node/npm:
 
@@ -103,7 +103,7 @@ Expected: clean installation succeeds under strict lifecycle-script policy; the
 spellcheck initially reports only genuine vocabulary/configuration gaps, which
 are corrected narrowly until it passes.
 
-- [ ] **Step 4: Update toolchain documentation**
+- [x] **Step 4: Update toolchain documentation**
 
 List CSpell `10.0.1` in the exact development dependencies and add `spellcheck`
 to the command tables and clean verification sequence. State it scans tracked
@@ -121,21 +121,21 @@ Markdown and remains absent from the runtime bundle.
 - Consumes: issue #5 design, phase epic exit criteria, real Documentation workflow, current smoke CLI.
 - Produces: one entrypoint with truthful availability and one evidence-based maturity model.
 
-- [ ] **Step 1: Add the real workflow badge and current-state warning**
+- [x] **Step 1: Add the real workflow badge and current-state warning**
 
 Link the badge image
 `https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml/badge.svg?branch=main`
 to the real workflow page. Near the top state no installation/production/usable
 SDD commands and smoke-only help/version.
 
-- [ ] **Step 2: Add Installation and Usage preview sections**
+- [x] **Step 2: Add Installation and Usage preview sections**
 
 Installation contains no install command. Describe only the planned embedded
 plugin model and issue #61 gate. Usage preview lists planned operations in prose
 and labels them not runnable. Explicitly reject old private distribution
 instructions for this public rewrite.
 
-- [ ] **Step 3: Expand Development with only working commands**
+- [x] **Step 3: Expand Development with only working commands**
 
 Show one shell block:
 
@@ -149,21 +149,21 @@ npm run package:verify
 
 Explain artifact path and that help/version prove packaging, not product readiness.
 
-- [ ] **Step 4: Write ROADMAP objective gates**
+- [x] **Step 4: Write ROADMAP objective gates**
 
 Create current Experimental status and promotion sections for Preview, Beta, and
 Stable exactly as approved. Link the phase epics, define no-calendar/evidence-
 only policy, regression rollback/degradation, known release gates, and Go oracle
 retirement. Separate stage entry from promotion evidence.
 
-- [ ] **Step 5: Add acknowledgements and align FAQ/roadmap copy**
+- [x] **Step 5: Add acknowledgements and align FAQ/roadmap copy**
 
 Credit the predecessor as behavioral oracle subject to provenance, the agent
 hosts without endorsement implication, and Node/TypeScript/esbuild/ESLint/
 Prettier/Vitest/CSpell plus Contributor Covenant/DCO. Ensure FAQ repeats no
 installation and roadmap section links `[Objective maturity gates](ROADMAP.md)`.
 
-- [ ] **Step 6: Confirm GREEN and commit**
+- [x] **Step 6: Confirm GREEN and commit**
 
 ```bash
 npm test -- tests/readme-honesty.test.ts
@@ -188,7 +188,7 @@ Expected: reader contract, spelling, typecheck, and lint pass.
 - Consumes: final README/ROADMAP and verification results.
 - Produces: clean-room reader evidence and issue closure.
 
-- [ ] **Step 1: Run complete local verification**
+- [x] **Step 1: Run complete local verification**
 
 ```bash
 npm run verify

--- a/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
+++ b/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
@@ -199,14 +199,14 @@ git diff --check
 
 Expected: all suites, spelling, Markdown, and links pass with zero errors.
 
-- [ ] **Step 2: Request two independent review lenses**
+- [x] **Step 2: Request two independent review lenses**
 
 The code review checks issue/spec acceptance and command truth. The clean-room
 reader receives only README/ROADMAP and answers: current maturity, whether/how it
 can be installed, what commands work, where state/runtime live, and what promotes
 each stage. Any answer that treats planned behavior as available is Important.
 
-- [ ] **Step 3: Record evidence**
+- [x] **Step 3: Record evidence**
 
 Document branch/commit, test/spell/link counts, real badge URL/status, all
 presented command executions, and both review outcomes. Include a table mapping

--- a/docs/superpowers/specs/2026-08-06-honest-readme-roadmap-design.md
+++ b/docs/superpowers/specs/2026-08-06-honest-readme-roadmap-design.md
@@ -1,0 +1,216 @@
+# Honest README, Roadmap, and Maturity Model Design
+
+- Status: Approved
+- Decision date: 2026-08-06
+- Tracking issue: [#5](https://github.com/thiagocorreanet/mestre-yoda/issues/5)
+- Depends on: [#2](https://github.com/thiagocorreanet/mestre-yoda/issues/2)
+- Approval basis: Maintainer-authorized autonomous recommendation
+
+## 1. Outcome
+
+The repository front page explains what Mestre Yoda is, what exists today, what
+does not exist, how contributors can validate the current source, and which
+objective evidence is required for Experimental, Preview, Beta, and Stable.
+
+A clean-room reader cannot mistake architectural intent, a usage preview, the
+minimal internal smoke CLI, or the private Go predecessor for an installable
+public product. Every displayed command works from a clean checkout at the
+commit that documents it.
+
+## 2. Approaches considered
+
+| Approach | Advantages | Costs | Decision |
+| --- | --- | --- | --- |
+| Replace README with a short landing page | Easy to scan | Loses architecture, reliability, and public backlog context already approved | Rejected |
+| Preserve the architecture narrative and add explicit availability boundaries plus a separate roadmap | Retains useful context, keeps front page honest, gives maturity gates room to be objective | Requires synchronized README/roadmap contract tests | Selected |
+| Document planned installation commands with warnings | Helps readers imagine future packaging | Commands are copied, indexed, and run without their warnings; violates acceptance | Rejected |
+
+## 3. README information architecture
+
+The README retains the existing problem, principles, SDD trail, architecture,
+planned capabilities, reliability, failure contract, community links, FAQ, and
+license. It adds or strengthens these front-page paths:
+
+1. **Real badges:** experimental status, the actual Documentation workflow on
+   `main`, MIT license, and normative English. The workflow badge links to the
+   workflow page and exposes its current pass/fail state.
+2. **Current status:** a warning that this is an active rewrite with no supported
+   installation, no production runtime, and no usable SDD commands. The checked-
+   in bundle supports only `--help` and `--version` for toolchain smoke testing.
+3. **Installation:** states that no supported method exists. It describes the
+   planned plugin-embedded distribution concept without a shell/npm/marketplace
+   command that could be mistaken for working installation.
+4. **Usage preview:** names the planned agent trail and operational capabilities
+   as conceptual interface only. It contains no runnable code block and clearly
+   says the current bundle cannot execute them.
+5. **Architecture:** preserves the no-global-binary model and conceptual
+   ownership of `.brain/`, `.claude/`, and `.codex/`.
+6. **Roadmap:** summarizes the four maturity stages and links `ROADMAP.md` for
+   evidence gates, rollback, and legacy retirement.
+7. **Development:** lists only clean-checkout commands that already work:
+   `npm ci`, `npm run spellcheck`, `npm run verify`, `npm run build`, and
+   `npm run package:verify`.
+8. **Acknowledgements:** credits the private predecessor as a behavioral oracle
+   without implying its source license, plus the open-source tools and community
+   standards the new repository uses.
+
+The README remains English and uses the exact architecture terms “embedded ESM
+runtime,” “project-owned state,” “event log,” “host adapter,” and “human
+acceptance.”
+
+## 4. Installation and preview honesty contract
+
+The strongest availability statement appears near the top and is repeated in
+Installation and FAQ:
+
+- there is no supported installation method or public distribution today;
+- the repository is not production-ready;
+- the existing ESM artifact is an internal foundation smoke artifact;
+- only `--help` and `--version` exist today;
+- `objective`, `start`, `continue`, `done`, and operational commands are planned,
+  not runnable;
+- legacy private Go installation/distribution instructions do not apply to this
+  public rewrite;
+- release installation instructions appear only after issue #61 supplies tested,
+  version-coherent artifacts.
+
+Planned distribution is described in prose: Claude Code and Codex receive thin
+host adapters plus the same embedded `runtime/yoda.mjs`; user projects receive
+only their `.brain/`, `.claude/`, and `.codex/` state/configuration surfaces.
+There is no global Yoda binary and no project runtime `node_modules`.
+
+## 5. Objective maturity model
+
+`ROADMAP.md` is evidence-based, has no dates, and links each public epic.
+
+### Experimental — current
+
+The project may change contracts and is not installable. Promotion to Preview
+requires all exit criteria of Foundation, Compatibility Contract, Deterministic
+Runtime, SDD Workflow Parity, and Host Integrations, including:
+
+- frozen Go oracle plus P0/P1 traceability and differential comparison;
+- complete local objective-to-done trail with invalid transitions non-mutating;
+- Claude Code and Codex shared adapter/E2E conformance;
+- standalone embedded bundle with no global/project runtime dependency;
+- published security, governance, contribution, and CI foundations.
+
+### Preview
+
+Preview is installable only for evaluation with change-tolerant users. Promotion
+to Beta requires Migration and Observability, the Quality Campaign, and public-
+beta documentation/release/distribution issues #58–#61:
+
+- transactional migration, backup, rollback, replay, audit, and privacy-reviewed
+  evidence;
+- native platform, security, bundle, installation/update, host E2E, mutation,
+  fault, concurrency, and performance gates at agreed thresholds;
+- complete English user/reference docs;
+- reproducible signed release artifacts with checksum, SBOM, and provenance;
+- tested atomic install/update/rollback for both hosts;
+- no unresolved release-blocking critical security, integrity, migration, or
+  compatibility defect.
+
+### Beta
+
+Beta is public and supportable but may still change before 1.0. Promotion to
+Stable requires issue #62 pilot evidence and all architecture retirement gates:
+
+- representative projects install, initialize, complete, diagnose, update,
+  migrate, roll back, and uninstall successfully;
+- P0/P1 differential parity is maintained against the frozen oracle;
+- supported native platforms and both hosts pass release E2E;
+- recovery and rollback drills prove no hidden data loss;
+- performance/regression budgets and security gates remain within thresholds;
+- support/security processes operate during pilots with no unresolved critical
+  blocker;
+- release/rollback decisions and known limitations are public.
+
+### Stable
+
+Stable begins only after all Beta gates pass. It establishes explicit supported
+versions and compatibility promises; it is not a declaration that the project
+will never change.
+
+Any regression in a promotion gate blocks promotion. A released stage may be
+marked degraded or rolled back when security, integrity, migration, parity, or
+host evidence becomes invalid. Marketing language never overrides gate evidence.
+
+## 6. Go predecessor retirement
+
+The private Go implementation remains the behavior oracle until the approved
+architecture retirement gates pass: inventory complete, P0/P1 differential
+parity, golden scenarios, migration/rollback, platform and host E2E, package
+recovery, security, and pilots. Feature completeness or a working demo is not
+retirement evidence.
+
+The roadmap describes behavior and evidence only. It does not copy or claim MIT
+rights over private predecessor source, prompts, fixtures, or documentation; the
+issue #4 provenance policy remains mandatory.
+
+## 7. Reproducible spelling check
+
+CSpell `10.0.1` becomes an exactly pinned root development dependency. Root
+script `spellcheck` scans tracked Markdown with `.cspell.json`; `verify` runs it
+after formatting and before lint. The configuration:
+
+- uses English dictionaries;
+- respects Git ignores and excludes generated/dependency output and lockfiles;
+- lists only legitimate project/tool names and stable domain vocabulary;
+- does not hide whole documents or use broad regex exclusions;
+- reports unknown words with suggestions and fails nonzero.
+
+This dependency remains development-only, does not enter the bundle, and does
+not change runtime install requirements. The deterministic toolchain docs and
+design are updated to list the command and exact dependency.
+
+## 8. Test-first reader contract
+
+`tests/readme-honesty.test.ts` fails before README/ROADMAP changes and then
+asserts:
+
+- Documentation badge points to `.github/workflows/docs.yml` and `main`;
+- README contains all required content categories and direct community links;
+- unavailability, smoke-only CLI, and conceptual preview statements are explicit;
+- no installation shell block or legacy private installation command exists;
+- every shell command presented by README is a current clean-checkout development
+  command found in `package.json` or standard `npm ci`;
+- no-global-binary and project state ownership match the architecture;
+- ROADMAP contains all stages, promotion headings, linked epics, objective gates,
+  regression/rollback behavior, and Go retirement criteria;
+- acknowledgements distinguish the predecessor's behavioral role and provenance.
+
+Independent review receives a clean-room-reader prompt: read README without issue
+context, state whether installation/production/maturity can be misunderstood,
+and cite any misleading line. “No findings” is required before merge.
+
+## 9. Actions boundary
+
+The only status workflow badge is Documentation because it exists and validates
+the files affected by this issue. Static badges may describe Experimental, MIT,
+and English but cannot imply build/runtime health.
+
+Issue #7 will add the fast Node pull-request workflow and may then add its real
+badge. Issue #55 owns later platform, nightly, compatibility, security, and
+release workflows. README must not display planned checks as if they run today.
+
+## 10. Scope and compatibility
+
+This issue changes public documentation, spelling validation, and tests only. It
+does not implement installation, SDD commands, adapters, schemas, migration,
+state, CI workflows, or releases. It does not alter the legacy PRD/spec parity
+contract.
+
+## 11. Acceptance mapping
+
+| Issue requirement | Design section |
+| --- | --- |
+| Problem, principles, architecture, status, installation, usage, development, community, security, license, acknowledgements | 3–4 |
+| Experimental → Preview → Beta → Stable objective roadmap | 5 |
+| Active rewrite until compatibility evidence | 3–6 |
+| No global binary and project-owned state | 3–4 |
+| Only working commands documented | 4, 8 |
+| Real workflow badges | 3, 9 |
+| English and architecture terminology | 3 |
+| Link and spelling checks | 7–8 |
+| Clean-room maturity/installation review | 8 |

--- a/docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md
+++ b/docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md
@@ -156,6 +156,7 @@ an exactly pinned root `devDependency`:
 - `prettier@3.9.6`;
 - `vitest@4.1.10`;
 - `@vitest/coverage-v8@4.1.10`;
+- `cspell@10.0.1`;
 - `esbuild@0.28.1`.
 
 Version ranges are not permitted in manifests. The lockfile is the complete
@@ -181,13 +182,14 @@ The root manifest exposes the following deterministic commands:
 | --- | --- |
 | `npm ci` | Install exactly the committed lockfile |
 | `npm run format:check` | Check supported source and configuration files with Prettier |
+| `npm run spellcheck` | Check tracked English Markdown with the narrow project dictionary |
 | `npm run lint` | Run ESLint with type-aware TypeScript rules and zero warnings |
 | `npm run typecheck` | Run `tsc6` with strict root configuration and no emit |
 | `npm test` | Run unit and clean-room bundle tests once with Vitest |
 | `npm run test:coverage` | Run deterministic coverage with configured thresholds |
 | `npm run build` | Clean and generate `dist/plugin/runtime/yoda.mjs` with esbuild |
 | `npm run package:verify` | Validate staged contents and execute help/version outside the checkout |
-| `npm run verify` | Run format, lint, typecheck, tests, coverage, build, and package verification in order |
+| `npm run verify` | Run format, spelling, lint, typecheck, tests, coverage, build, and package verification in order |
 
 Commands do not download tools after `npm ci`, mutate dependency versions,
 depend on a global package, or hide subprocess failures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@eslint/js": "10.0.1",
         "@types/node": "24.13.3",
         "@vitest/coverage-v8": "4.1.10",
+        "cspell": "10.0.1",
         "esbuild": "0.28.1",
         "eslint": "10.8.0",
         "prettier": "3.9.6",
@@ -84,6 +85,635 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@cspell/cspell-bundled-dicts": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.1.tgz",
+      "integrity": "sha512-WvkSDNX4Uyyj/ZgbPO6L38iFNMfK1EqsH1FteRiI2qLz6QZMXRFrIt12OqiWIplzZDDaVpBH9FCJOPJll0fjCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-ada": "^4.1.1",
+        "@cspell/dict-al": "^1.1.1",
+        "@cspell/dict-aws": "^4.0.17",
+        "@cspell/dict-bash": "^4.2.2",
+        "@cspell/dict-companies": "^3.2.11",
+        "@cspell/dict-cpp": "^7.0.2",
+        "@cspell/dict-cryptocurrencies": "^5.0.5",
+        "@cspell/dict-csharp": "^4.0.8",
+        "@cspell/dict-css": "^4.1.1",
+        "@cspell/dict-dart": "^2.3.2",
+        "@cspell/dict-data-science": "^2.0.13",
+        "@cspell/dict-django": "^4.1.6",
+        "@cspell/dict-docker": "^1.1.17",
+        "@cspell/dict-dotnet": "^5.0.13",
+        "@cspell/dict-elixir": "^4.0.8",
+        "@cspell/dict-en_us": "^4.4.33",
+        "@cspell/dict-en-common-misspellings": "^2.1.12",
+        "@cspell/dict-en-gb-mit": "^3.1.22",
+        "@cspell/dict-filetypes": "^3.0.18",
+        "@cspell/dict-flutter": "^1.1.1",
+        "@cspell/dict-fonts": "^4.0.6",
+        "@cspell/dict-fsharp": "^1.1.1",
+        "@cspell/dict-fullstack": "^3.2.9",
+        "@cspell/dict-gaming-terms": "^1.1.2",
+        "@cspell/dict-git": "^3.1.0",
+        "@cspell/dict-golang": "^6.0.26",
+        "@cspell/dict-google": "^1.0.9",
+        "@cspell/dict-haskell": "^4.0.6",
+        "@cspell/dict-html": "^4.0.15",
+        "@cspell/dict-html-symbol-entities": "^4.0.5",
+        "@cspell/dict-java": "^5.0.12",
+        "@cspell/dict-julia": "^1.1.1",
+        "@cspell/dict-k8s": "^1.0.12",
+        "@cspell/dict-kotlin": "^1.1.1",
+        "@cspell/dict-latex": "^5.1.0",
+        "@cspell/dict-lorem-ipsum": "^4.0.5",
+        "@cspell/dict-lua": "^4.0.8",
+        "@cspell/dict-makefile": "^1.0.5",
+        "@cspell/dict-markdown": "^2.0.16",
+        "@cspell/dict-monkeyc": "^1.0.12",
+        "@cspell/dict-node": "^5.0.9",
+        "@cspell/dict-npm": "^5.2.38",
+        "@cspell/dict-php": "^4.1.1",
+        "@cspell/dict-powershell": "^5.0.15",
+        "@cspell/dict-public-licenses": "^2.0.16",
+        "@cspell/dict-python": "^4.2.26",
+        "@cspell/dict-r": "^2.1.1",
+        "@cspell/dict-ruby": "^5.1.1",
+        "@cspell/dict-rust": "^4.1.2",
+        "@cspell/dict-scala": "^5.0.9",
+        "@cspell/dict-shell": "^1.1.2",
+        "@cspell/dict-software-terms": "^5.2.2",
+        "@cspell/dict-sql": "^2.2.1",
+        "@cspell/dict-svelte": "^1.0.7",
+        "@cspell/dict-swift": "^2.0.6",
+        "@cspell/dict-terraform": "^1.1.3",
+        "@cspell/dict-typescript": "^3.2.3",
+        "@cspell/dict-vue": "^3.0.5",
+        "@cspell/dict-zig": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-json-reporter": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.1.tgz",
+      "integrity": "sha512-/nes1RGILec3WCBcoMOd0byNTBtnJuPaVz/+ZzqYkLtY7x58VMcBG5kyP6hPyN8cIwjRADE/SR43gwdXuqk/FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "10.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-performance-monitor": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.1.tgz",
+      "integrity": "sha512-9tVcHXwRnbazUv4WSG0h3MqV4+LgmLNgSALAQUflPPW0EMxTf7C4Dmv9cgxJyCEQrdnVKCr58nPPaahhz9LJUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-pipe": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.1.tgz",
+      "integrity": "sha512-HPeXMD9AZ3V/qPkvQaPcak+C7cJ2z7JTHN8smd6J8L2aThLRky2cHc2OyeaHPSHB7WA47b4z2n5u5nawZhv5VQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-resolver": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.1.tgz",
+      "integrity": "sha512-PIzkZHD1fGUQx1XteK2d1iQ0Mzq/maYcoB4jkvAiiR6WqP3MWYNKFdI9z+R5pOq5KgMfW+5Ig1q0oSR6h8irlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-service-bus": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.1.tgz",
+      "integrity": "sha512-y6NcIGP2IdXaBL4PVH8vxsr7K27wzz3Ech87UtUtrDSXAiVEOvXgAIknEOUVp59rTlUE8Rn4IRURC6f/hgMyfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-types": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.1.tgz",
+      "integrity": "sha512-kLgLShnWADDVreKC63pBrWkcvxgZzFIfO34Jhx/SWfuOIA3cD8AXT+HjyuLfoGJ7mUb58hv2kUziKzEy4INb1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/cspell-worker": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.1.tgz",
+      "integrity": "sha512-L2bJerfuYOls2wEknm8FmynLtj/G7O4UqX9I/HznRggEW6i2yZIxagDetpVDNowpyavNHJ3SJtUFiyMiZc16Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cspell-lib": "10.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/dict-ada": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.1.1.tgz",
+      "integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-al": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.1.1.tgz",
+      "integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-aws": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.17.tgz",
+      "integrity": "sha512-ORcblTWcdlGjIbWrgKF+8CNEBQiLVKdUOFoTn0KPNkAYnFcdPP0muT4892h7H4Xafh3j72wqB4/loQ6Nti9E/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-bash": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.2.3.tgz",
+      "integrity": "sha512-ljUZoKHbDqw5Sx0qpL2qTUlmkmr+vhZH/sCNrNaBZKTbdgiswErSnIF1jRbGmEitJNxHRHWsuZyVgnTGfVO1Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-shell": "1.2.0"
+      }
+    },
+    "node_modules/@cspell/dict-companies": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.12.tgz",
+      "integrity": "sha512-mjiz/N3zWOCsz5VfwMUydSl7uW0OU9H2PnbCNc3RV44Vj6Q59CSp6EYGSGZQxrXU1gpsuZUrwr6QCjNjFOOg5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cpp": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-7.0.2.tgz",
+      "integrity": "sha512-dfbeERiVNeqmo/npivdR6rDiBCqZi3QtjH2Z0HFcXwpdj6i97dX1xaKyK2GUsO/p4u1TOv63Dmj5Vm48haDpuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-cryptocurrencies": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-5.0.5.tgz",
+      "integrity": "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-csharp": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.8.tgz",
+      "integrity": "sha512-qmk45pKFHSxckl5mSlbHxmDitSsGMlk/XzFgt7emeTJWLNSTUK//MbYAkBNRtfzB4uD7pAFiKgpKgtJrTMRnrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-css": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.2.tgz",
+      "integrity": "sha512-+ylGoKdwZ2sVOCOnU2Eq5wDZx+RaVX3HoKyNHGGsFvhSw6IidQ6tH/mAPKBDofViHJoWCPNlklE0lTr6MDG3QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dart": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.3.2.tgz",
+      "integrity": "sha512-sUiLW56t9gfZcu8iR/5EUg+KYyRD83Cjl3yjDEA2ApVuJvK1HhX+vn4e4k4YfjpUQMag8XO2AaRhARE09+/rqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-data-science": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.16.tgz",
+      "integrity": "sha512-M72mxv5asuAnORurz4iXRJ+Tw9XBq6eu7D2Ne7biP0Z1RciKGNxXWu9JycA/KlVvK1hAlKj/fANlXhuEWpXKFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-django": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.6.tgz",
+      "integrity": "sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-docker": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.17.tgz",
+      "integrity": "sha512-OcnVTIpHIYYKhztNTyK8ShAnXTfnqs43hVH6p0py0wlcwRIXe5uj4f12n7zPf2CeBI7JAlPjEsV0Rlf4hbz/xQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-dotnet": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.13.tgz",
+      "integrity": "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-elixir": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.8.tgz",
+      "integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en_us": {
+      "version": "4.4.36",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.36.tgz",
+      "integrity": "sha512-2yOhI/+7d1DbfvMljGW4jw8pLqDEsVmnvUXBOCFXtLU2BWgQkrqOJDCNseYjEiEbTp0OtdrWEWWPFSP1TNugQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-en-common-misspellings": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.13.tgz",
+      "integrity": "sha512-00rpydUxKNWY2xxrSx+h46aNWLvbkJdd57SsnEFt24fbs1fROhXZ6XSQu+gQz/zNuiCvFi4Ro3ej9DLbEdWQmQ==",
+      "dev": true,
+      "license": "CC BY-SA 4.0"
+    },
+    "node_modules/@cspell/dict-en-gb-mit": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.25.tgz",
+      "integrity": "sha512-zGODptk24CMrXi49ieG2SUm94CKxEsVF0dYNF+1ZYH0MSsQDZ/PKDlrrbvtBqSupKdPSj0Z9sjOmMNfHHW9ZSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-filetypes": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.18.tgz",
+      "integrity": "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-flutter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.1.1.tgz",
+      "integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fonts": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-4.0.6.tgz",
+      "integrity": "sha512-aR/0csY01dNb0A1tw/UmN9rKgHruUxsYsvXu6YlSBJFu60s26SKr/k1o4LavpHTQ+lznlYMqAvuxGkE4Flliqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fsharp": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.1.1.tgz",
+      "integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-fullstack": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.9.tgz",
+      "integrity": "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-gaming-terms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.2.tgz",
+      "integrity": "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-git": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.1.0.tgz",
+      "integrity": "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-golang": {
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.26.tgz",
+      "integrity": "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-google": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.9.tgz",
+      "integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-haskell": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.6.tgz",
+      "integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
+      "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-html-symbol-entities": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
+      "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-java": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.12.tgz",
+      "integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-julia": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.1.1.tgz",
+      "integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-k8s": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.13.tgz",
+      "integrity": "sha512-ELGkS13k7K/NEfVimBSrxVTfqXvOF/Kvxj4I62YxRm8bvHbfoXgrGaOx28lPiNRz+dmu+yYtvuXbnURKtYbC6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-kotlin": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-kotlin/-/dict-kotlin-1.1.1.tgz",
+      "integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-latex": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-5.1.0.tgz",
+      "integrity": "sha512-qxT4guhysyBt0gzoliXYEBYinkAdEtR2M7goRaUH0a7ltCsoqqAeEV8aXYRIdZGcV77gYSobvu3jJL038tlPAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lorem-ipsum": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-4.0.5.tgz",
+      "integrity": "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-lua": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.8.tgz",
+      "integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-makefile": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.5.tgz",
+      "integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-markdown": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.17.tgz",
+      "integrity": "sha512-H8bAxih6U8NOnSPL7R8My+tqjaB4tmnJTjERuz4zYqmf+cH+5xshX3UVgKlwWFcyjsYfv/zEDuRdMctQv1q6HQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@cspell/dict-css": "^4.1.2",
+        "@cspell/dict-html": "^4.0.15",
+        "@cspell/dict-html-symbol-entities": "^4.0.5",
+        "@cspell/dict-typescript": "^3.2.3"
+      }
+    },
+    "node_modules/@cspell/dict-monkeyc": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.12.tgz",
+      "integrity": "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-node": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.9.tgz",
+      "integrity": "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-npm": {
+      "version": "5.2.43",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.43.tgz",
+      "integrity": "sha512-H2gYwtu59dNO9662Uq0usfuhyNd7lZJE1C61a/UXcpRyWWSrTo2Bz+vwGYp1bXZ1LmjXadqvwJ8ArFlGdiadNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-php": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.1.1.tgz",
+      "integrity": "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-powershell": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.15.tgz",
+      "integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-public-licenses": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.16.tgz",
+      "integrity": "sha512-EQRrPvEOmwhwWezV+W7LjXbIBjiy6y/shrET6Qcpnk3XANTzfvWflf9PnJ5kId/oKWvihFy0za0AV1JHd03pSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-python": {
+      "version": "4.2.29",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.29.tgz",
+      "integrity": "sha512-OnEt1a35iuQzc2Ize1qU/43ZyF10urRKAm+mlTz++vnAgDLBHpKfWakpSK50nyL5/1WvyQ8BaMjb52MBLEpTeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/dict-data-science": "^2.0.16"
+      }
+    },
+    "node_modules/@cspell/dict-r": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.1.1.tgz",
+      "integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-ruby": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.1.tgz",
+      "integrity": "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-rust": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.1.2.tgz",
+      "integrity": "sha512-O1FHrumYcO+HZti3dHfBPUdnDFkI+nbYK3pxYmiM1sr+G0ebOd6qchmswS0Wsc6ZdEVNiPYJY/gZQR6jfW3uOg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-scala": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.9.tgz",
+      "integrity": "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-shell": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-shell/-/dict-shell-1.2.0.tgz",
+      "integrity": "sha512-PVctvT22lJ49niMiakO8xieY7ELCAzjSqhejWR7bAMb5AZ9F4WDEs+XdGMnoVHWeXq7K5rcepLPmEJb+37zzIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-software-terms": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.4.tgz",
+      "integrity": "sha512-z6y/TGH3QNf5wB4pVvN/P3GfFEW/Whf6QAekNsIn06VKl95dnamfpkPWqV8rEtCixQFaKalb5+y9hRQXH3XQ1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-sql": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.2.1.tgz",
+      "integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-svelte": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.7.tgz",
+      "integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-swift": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.6.tgz",
+      "integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-terraform": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.4.tgz",
+      "integrity": "sha512-Ere42ilvMFvQA4GlcN0OKlruMPR6EsvaB+iTHzj2xc+NJGRK64V7yApUcWrOrSgTiM/vhWXPIsK3OMfiAiNdmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-typescript": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
+      "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-vue": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.5.tgz",
+      "integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dict-zig": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-zig/-/dict-zig-1.0.0.tgz",
+      "integrity": "sha512-XibBIxBlVosU06+M6uHWkFeT0/pW5WajDRYdXG2CgHnq85b0TI/Ks0FuBJykmsgi2CAD3Qtx8UHFEtl/DSFnAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspell/dynamic-import": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.1.tgz",
+      "integrity": "sha512-mP1gdq00aIcH8HxNMqnH11X6BKxLcneDtFgl/ecjIKnaGKwi44m8AndP5Kr4ODaYdl8UUw9O3dJh7KaQXnLHZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "10.0.1",
+        "import-meta-resolve": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/filetypes": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.1.tgz",
+      "integrity": "sha512-Z5S35giU5IW49fBBq6BksUbE8PC4IYPfaKuwl5Nl9jkf/OkAKiBmCowKX45NzRUQInwK/GSqqIUifrNeI6LdLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/rpc": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.1.tgz",
+      "integrity": "sha512-axSRKv3zEAmBm66iD/FV/MPmE4/Yf7c3PZiwTW894Yd3iEhtn3KPKeTrqQ2/tDrhB1Z2qTsap/Hue0MK4o5WXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/strong-weak-map": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.1.tgz",
+      "integrity": "sha512-lenN1DVyPi8nJLSMSJJ670ddTjyiruLueuSZO1qLcxBqUhgxDt/mALu9N/1m6WdOVcg6m/5cLiZVg2KOo2UzRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/@cspell/url": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.1.tgz",
+      "integrity": "sha512-abYYgI29wJhWIfWTYrYuzRYDcHQUQ1N5ylnhxYn1NJnIQMqUWGLbDmt12JABtZ+R6h6UNatQrS7rhP86etvJyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1520,6 +2150,26 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1575,6 +2225,59 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
+      "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/comment-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-5.0.0.tgz",
+      "integrity": "sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1595,6 +2298,190 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cspell": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.1.tgz",
+      "integrity": "sha512-Gg6w/flT3fKfl3la62hfTnhtNnDQ+9mU7kUhVqw/axl/Ms4oENw0oJMkWFIoj4f6nL/SDPz7KcPXd2XbkKFNmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-json-reporter": "10.0.1",
+        "@cspell/cspell-performance-monitor": "10.0.1",
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-types": "10.0.1",
+        "@cspell/cspell-worker": "10.0.1",
+        "@cspell/dynamic-import": "10.0.1",
+        "@cspell/url": "10.0.1",
+        "ansi-regex": "^6.2.2",
+        "chalk": "^5.6.2",
+        "chalk-template": "^1.1.2",
+        "commander": "^14.0.3",
+        "cspell-config-lib": "10.0.1",
+        "cspell-dictionary": "10.0.1",
+        "cspell-gitignore": "10.0.1",
+        "cspell-glob": "10.0.1",
+        "cspell-io": "10.0.1",
+        "cspell-lib": "10.0.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "flatted": "^3.4.2",
+        "semver": "^7.8.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "cspell": "bin.mjs",
+        "cspell-esm": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/streetsidesoftware/cspell?sponsor=1"
+      }
+    },
+    "node_modules/cspell-config-lib": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.1.tgz",
+      "integrity": "sha512-hMpo/0j6k7pbiqrLDOLJKD2IGP9XwhjKf2miiM6p84Xeo4nyuFZaxxDCQ68R851HSYFrrdltgpoipMbj1h2Tnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-types": "10.0.1",
+        "comment-json": "^5.0.0",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-dictionary": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.1.tgz",
+      "integrity": "sha512-3cZ659vgsZWkzGQJR/sNqGDVt/OnvTSieLKI76V++4t1bHJfochb9ZrrwsuMsb1VPGiyqClUP1/O6WrefF/FVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-performance-monitor": "10.0.1",
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-types": "10.0.1",
+        "cspell-trie-lib": "10.0.1",
+        "fast-equals": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-gitignore": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.1.tgz",
+      "integrity": "sha512-wN23U61Mx6qPJN3CesOmBU9vnbJ0jQm/ylK0iaVui3CcnO7Zzl5qLu5mPHUzGQGm8yso6qjyxqo16Ho7LpZGOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "10.0.1",
+        "cspell-glob": "10.0.1",
+        "cspell-io": "10.0.1"
+      },
+      "bin": {
+        "cspell-gitignore": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-glob": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.1.tgz",
+      "integrity": "sha512-7bII9J3aSSpZDwhx7w+zfQXbMxHZQ3be0ilUp5bHrsjz6o07v/NqOHMGcwKdPn1sw2dxDz9sv057xE5pqXnSdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/url": "10.0.1",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-grammar": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.1.tgz",
+      "integrity": "sha512-xC9AFYmaI9wsO//a7S5tdDGKGJVD5UEEsTg+Up2fi7lPfXIryisYmV6tePNL1SEg0idYss4ja8LUZ3Mib09BjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-types": "10.0.1"
+      },
+      "bin": {
+        "cspell-grammar": "bin.mjs"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-io": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.1.tgz",
+      "integrity": "sha512-8C2ka07faxflnaqEBO3pektS21XViE/SEHT7F5ZD1ou7FyMR5u3xawTBJSczClfsxLt/WYeztBYrpmGAjmjksw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-service-bus": "10.0.1",
+        "@cspell/url": "10.0.1"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-lib": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.1.tgz",
+      "integrity": "sha512-RpsIPiLzc4/YMW8BMRKpyJ81x439qjYWcqgdKeXnMkbKM88J9PexzutfFf/4v97v96KzfNitEzMpbI0uj8OeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspell/cspell-bundled-dicts": "10.0.1",
+        "@cspell/cspell-performance-monitor": "10.0.1",
+        "@cspell/cspell-pipe": "10.0.1",
+        "@cspell/cspell-resolver": "10.0.1",
+        "@cspell/cspell-types": "10.0.1",
+        "@cspell/dynamic-import": "10.0.1",
+        "@cspell/filetypes": "10.0.1",
+        "@cspell/rpc": "10.0.1",
+        "@cspell/strong-weak-map": "10.0.1",
+        "@cspell/url": "10.0.1",
+        "cspell-config-lib": "10.0.1",
+        "cspell-dictionary": "10.0.1",
+        "cspell-glob": "10.0.1",
+        "cspell-grammar": "10.0.1",
+        "cspell-io": "10.0.1",
+        "cspell-trie-lib": "10.0.1",
+        "env-paths": "^4.0.0",
+        "gensequence": "^8.0.8",
+        "import-fresh": "^4.0.0",
+        "resolve-from": "^5.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-uri": "^3.1.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      }
+    },
+    "node_modules/cspell-trie-lib": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.1.tgz",
+      "integrity": "sha512-BFvhalSkRQFjKrZ//FKK7fRGrZFpifnxB5AwCkzsIsBZqicsfafcQ1xP21qpb0QqyV/IomjNgviG+tRJs+0rMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "peerDependencies": {
+        "@cspell/cspell-types": "10.0.1"
       }
     },
     "node_modules/debug": {
@@ -1630,6 +2517,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-safe-filename": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1803,6 +2706,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -1875,6 +2792,16 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.2.tgz",
+      "integrity": "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -1974,6 +2901,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensequence": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-8.0.8.tgz",
+      "integrity": "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1985,6 +2922,22 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/has-flag": {
@@ -2014,6 +2967,30 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-4.0.0.tgz",
+      "integrity": "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.15"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2022,6 +2999,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/is-extglob": {
@@ -2045,6 +3032,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-safe-filename": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -2697,6 +3697,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
@@ -2772,6 +3782,19 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3103,6 +4126,20 @@
         }
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3144,6 +4181,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -13,18 +13,20 @@
   ],
   "scripts": {
     "format:check": "prettier --check .",
+    "spellcheck": "cspell --no-progress --show-suggestions \"**/*.md\"",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc6 --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "build": "node scripts/build.mjs",
     "package:verify": "node scripts/verify-package.mjs",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run test:coverage && npm run build && npm run package:verify"
+    "verify": "npm run format:check && npm run spellcheck && npm run lint && npm run typecheck && npm test && npm run test:coverage && npm run build && npm run package:verify"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.3",
     "@vitest/coverage-v8": "4.1.10",
+    "cspell": "10.0.1",
     "esbuild": "0.28.1",
     "eslint": "10.8.0",
     "prettier": "3.9.6",

--- a/tests/readme-honesty.test.ts
+++ b/tests/readme-honesty.test.ts
@@ -8,14 +8,19 @@ const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 
 let readme: string;
 let roadmap: string;
-let packageManifest: string;
+let packageManifest: { scripts: Record<string, string> };
 
 beforeAll(async () => {
-  [readme, roadmap, packageManifest] = await Promise.all([
+  const [readmeText, roadmapText, packageText] = await Promise.all([
     readFile(join(repositoryRoot, "README.md"), "utf8"),
     readFile(join(repositoryRoot, "ROADMAP.md"), "utf8"),
     readFile(join(repositoryRoot, "package.json"), "utf8"),
   ]);
+  readme = readmeText;
+  roadmap = roadmapText;
+  packageManifest = JSON.parse(packageText) as {
+    scripts: Record<string, string>;
+  };
 });
 
 describe("README honesty", () => {
@@ -38,19 +43,35 @@ describe("README honesty", () => {
   });
 
   it("shows only executable clean-checkout development commands", () => {
-    const shellBlocks = [...readme.matchAll(/```bash\n([\s\S]*?)```/g)];
-    expect(shellBlocks).toHaveLength(1);
-    expect(shellBlocks[0]?.[1]?.trim().split("\n")).toEqual([
+    const shellBlocks = [
+      ...readme.matchAll(/```(?:bash|sh|console)\n([\s\S]*?)```/g),
+    ];
+    const commands = [
       "npm ci",
       "npm run spellcheck",
       "npm run verify",
       "npm run build",
       "npm run package:verify",
-    ]);
+    ];
+    expect(shellBlocks).toHaveLength(1);
+    expect(shellBlocks[0]?.[1]?.trim().split("\n")).toEqual(commands);
 
-    for (const script of ["spellcheck", "verify", "build", "package:verify"]) {
-      expect(packageManifest).toContain(`"${script}"`);
-    }
+    const documentedNpmCommands = new Set(
+      readme.match(/npm (?:ci|run [a-z:-]+)/g) ?? [],
+    );
+    expect([...documentedNpmCommands].sort()).toEqual([...commands].sort());
+
+    expect(packageManifest.scripts).toMatchObject({
+      spellcheck: 'cspell --no-progress --show-suggestions "**/*.md"',
+      build: "node scripts/build.mjs",
+      "package:verify": "node scripts/verify-package.mjs",
+      verify:
+        "npm run format:check && npm run spellcheck && npm run lint && npm run typecheck && npm test && npm run test:coverage && npm run build && npm run package:verify",
+    });
+    expect(commands.indexOf("npm run build")).toBeLessThan(
+      commands.indexOf("npm run package:verify"),
+    );
+    expect(readme).toContain("it requires the preceding build");
   });
 
   it("preserves the approved state and runtime boundaries", () => {

--- a/tests/readme-honesty.test.ts
+++ b/tests/readme-honesty.test.ts
@@ -1,0 +1,101 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+
+let readme: string;
+let roadmap: string;
+let packageManifest: string;
+
+beforeAll(async () => {
+  [readme, roadmap, packageManifest] = await Promise.all([
+    readFile(join(repositoryRoot, "README.md"), "utf8"),
+    readFile(join(repositoryRoot, "ROADMAP.md"), "utf8"),
+    readFile(join(repositoryRoot, "package.json"), "utf8"),
+  ]);
+});
+
+describe("README honesty", () => {
+  it("shows only real status badges", () => {
+    expect(readme).toContain(
+      "actions/workflows/docs.yml/badge.svg?branch=main",
+    );
+    expect(readme).toContain("actions/workflows/docs.yml");
+    expect(readme).not.toContain("actions/workflows/ci.yml/badge.svg");
+  });
+
+  it("makes current availability impossible to mistake", () => {
+    expect(readme).toContain("There is no supported installation method");
+    expect(readme).toContain("supports only `--help` and `--version`");
+    expect(readme).toContain("not runnable in the current bundle");
+    expect(readme).toContain("not ready for production");
+    expect(readme).not.toMatch(
+      /claude plugin install|codex plugin add|npm install -g/,
+    );
+  });
+
+  it("shows only executable clean-checkout development commands", () => {
+    const shellBlocks = [...readme.matchAll(/```bash\n([\s\S]*?)```/g)];
+    expect(shellBlocks).toHaveLength(1);
+    expect(shellBlocks[0]?.[1]?.trim().split("\n")).toEqual([
+      "npm ci",
+      "npm run spellcheck",
+      "npm run verify",
+      "npm run build",
+      "npm run package:verify",
+    ]);
+
+    for (const script of ["spellcheck", "verify", "build", "package:verify"]) {
+      expect(packageManifest).toContain(`"${script}"`);
+    }
+  });
+
+  it("preserves the approved state and runtime boundaries", () => {
+    expect(readme).toContain("No global Yoda binary");
+    expect(readme).toContain("project-owned `.brain/`");
+    expect(readme).toContain("`.claude/` and `.codex/`");
+    expect(readme).toContain("embedded ESM runtime");
+  });
+
+  it("links every required public path", () => {
+    for (const link of [
+      "[Objective maturity gates](ROADMAP.md)",
+      "[Contribution guide](CONTRIBUTING.md)",
+      "[Security policy](SECURITY.md)",
+      "[MIT License](LICENSE)",
+    ]) {
+      expect(readme).toContain(link);
+    }
+    expect(readme).toContain("## Acknowledgements");
+  });
+});
+
+describe("objective maturity roadmap", () => {
+  it.each(["Experimental", "Preview", "Beta", "Stable"])(
+    "defines the %s stage",
+    (stage) => {
+      expect(roadmap).toContain(`## ${stage}`);
+    },
+  );
+
+  it.each(["Preview", "Beta", "Stable"])("defines promotion to %s", (stage) => {
+    expect(roadmap).toContain(`### Promotion to ${stage}`);
+  });
+
+  it("traces every delivery epic", () => {
+    for (const issue of [1, 8, 15, 24, 34, 40, 48, 57]) {
+      expect(roadmap).toContain(`/issues/${String(issue)}`);
+    }
+  });
+
+  it("requires evidence, regression response, pilots, and oracle parity", () => {
+    expect(roadmap).toContain("No calendar date or feature demo promotes");
+    expect(roadmap).toContain("P0/P1 differential parity");
+    expect(roadmap).toContain("pilot projects");
+    expect(roadmap).toContain("Regression and rollback");
+    expect(roadmap).toContain("Go predecessor retirement");
+  });
+});


### PR DESCRIPTION
Closes #5

## Outcome

Publishes an explicitly Experimental project front page and evidence-based Experimental to Preview to Beta to Stable promotion contract. The README states there is no supported installation, distribution, production runtime, or usable SDD command today.

## Design and compatibility

- preserves the embedded ESM, no-global-binary, and project-owned state architecture
- treats the private Go v3 implementation only as a provenance-controlled behavioral oracle
- presents only the five development commands executed in order
- adds exact CSpell 10.0.1 to deterministic development verification with zero runtime dependencies
- forbids maturity promotion waivers; missing evidence keeps the current stage

No SDD runtime contract or legacy PRD behavior changes in this PR.

## Test-first evidence

The new reader contract first failed because ROADMAP.md did not exist. After implementation and independent review fixes:

- npm ci: pass, 257 packages from lockfile
- npm run verify: pass, 5 files and 30 tests
- coverage: 100 percent configured runtime statements, branches, functions, and lines
- CSpell: 26 Markdown files, zero issues
- markdownlint: 26 Markdown files, zero errors
- Lychee: 78 links, zero errors
- package verification: exact 386-byte runtime/yoda.mjs, help/version only
- git diff --check: pass

Technical and clean-room re-reviews report no Critical, Important, or Minor findings. Full evidence is in docs/roadmap/verification.md.