### PR TITLE
docs: record README roadmap closure

### DIFF
--- a/docs/roadmap/verification.md
+++ b/docs/roadmap/verification.md
@@ -4,7 +4,7 @@
 - Tracking issue: [#5](https://github.com/thiagocorreanet/mestre-yoda/issues/5)
 - Branch: `docs/issue-5-readme-roadmap`
 - Reviewed implementation commit: `d246120`
-- Status: Ready for pull request
+- Status: Complete
 
 ## Command honesty
 
@@ -70,3 +70,10 @@ Minor findings.
 
 No unavailable install or SDD command is presented as executable. Every
 promotion criterion requires current reproducible evidence and cannot be waived.
+
+## Post-merge closure
+
+PR [#74](https://github.com/thiagocorreanet/mestre-yoda/pull/74) merged as
+`d111f4515545d1d50d6497ec92340665a9b23469` and closed issue #5. The real
+Documentation workflow then passed on `main` in
+[run 31142846699](https://github.com/thiagocorreanet/mestre-yoda/actions/runs/31142846699).

--- a/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
+++ b/docs/superpowers/plans/2026-08-06-honest-readme-roadmap.md
@@ -212,7 +212,7 @@ Document branch/commit, test/spell/link counts, real badge URL/status, all
 presented command executions, and both review outcomes. Include a table mapping
 each reader answer to the exact README/ROADMAP evidence.
 
-- [ ] **Step 4: Publish, merge, and close**
+- [x] **Step 4: Publish, merge, and close**
 
 Push `docs/issue-5-readme-roadmap`, open a DCO-signed PR with `Closes #5`, design/
 compatibility impact, failure evidence, and exact results. Wait for the real


### PR DESCRIPTION
Records the already observed post-merge state for issue #5: PR #74 merge commit, automatic issue closure, successful Documentation run on main, and completion of the final implementation-plan checkpoint.

Verification: CSpell 26 files zero issues; markdownlint 26 files zero errors; git diff --check passed.