### PR TITLE
docs: add structured contribution intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a reproducible, non-security defect in public behavior.
+title: "[BUG] "
+labels:
+  - bug
+  - english-only
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use normative English and search for an existing issue first.
+        Do not include vulnerabilities, secrets, customer or personal data, private source, or confidential infrastructure. Report suspected security problems through [private vulnerability reporting](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new).
+  - type: input
+    id: affected-version
+    attributes:
+      label: Affected version or commit
+      description: Provide the exact tag or full commit SHA. State `main` only with its current SHA.
+      placeholder: 0123456789abcdef0123456789abcdef01234567
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include operating system, architecture, Node/npm versions, host, and relevant filesystem or Git details.
+      placeholder: Ubuntu 24.04 x86_64; Node 24.18.0; npm 11.16.0; Codex
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: List the smallest deterministic sequence that reproduces the defect from a known starting state.
+      placeholder: |
+        1. Start from...
+        2. Run...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe the result, state effects, reason/exit code, and evidence that should occur.
+      placeholder: The operation should...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Describe what occurred, including redacted output and state effects.
+      placeholder: The operation instead...
+    validations:
+      required: true
+  - type: textarea
+    id: regression-evidence
+    attributes:
+      label: Regression test or evidence
+      description: Provide a minimal failing test, fixture, command output, or explain precisely how maintainers can capture one.
+      placeholder: npm test -- path/to/focused.test.ts
+    validations:
+      required: true
+  - type: checkboxes
+    id: policy
+    attributes:
+      label: Public-report confirmations
+      description: Every confirmation is required before this public issue is created.
+      options:
+        - label: I searched for an existing issue and this report is focused on one defect.
+          required: true
+        - label: This report is written in normative English.
+          required: true
+        - label: This report contains no suspected vulnerability, exploit detail, secret, private data, or proprietary source.
+          required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,7 +4,6 @@ title: "[BUG] "
 labels:
   - bug
   - english-only
-assignees: []
 body:
   - type: markdown
     attributes:
@@ -74,5 +73,3 @@ body:
           required: true
         - label: This report contains no suspected vulnerability, exploit detail, secret, private data, or proprietary source.
           required: true
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -5,7 +5,6 @@ labels:
   - type:research
   - area:compatibility
   - english-only
-assignees: []
 body:
   - type: markdown
     attributes:
@@ -90,5 +89,3 @@ body:
           required: true
         - label: This report contains no suspected vulnerability, exploit detail, secret, private data, or confidential infrastructure.
           required: true
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -1,0 +1,94 @@
+name: Compatibility regression
+description: Report a measurable Go-v3, contract, fixture, or host parity difference.
+title: "[COMPATIBILITY] "
+labels:
+  - type:research
+  - area:compatibility
+  - english-only
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use normative English and only publish clean-room behavioral observations that you are authorized to disclose.
+        Do not copy private predecessor prose/source or include secrets, customer or personal data, or private data. Report security-sensitive differences through [private vulnerability reporting](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new).
+  - type: input
+    id: oracle
+    attributes:
+      label: Oracle and compared build
+      description: Identify the authorized Go-v3 oracle snapshot and exact TypeScript/host commit or artifact.
+      placeholder: Go oracle inventory ID ... versus commit 012345...
+    validations:
+      required: true
+  - type: dropdown
+    id: provenance
+    attributes:
+      label: Evidence provenance
+      description: Select how the published evidence was produced.
+      multiple: false
+      options:
+        - Original public fixture
+        - Behavioral clean-room observation
+        - Public third-party source with compatible license
+        - Publication-authorized adapted material
+    validations:
+      required: true
+  - type: textarea
+    id: exact-input
+    attributes:
+      label: Exact normalized input and pre-state
+      description: Provide the smallest authorized input, configuration, state identity, and ordering needed for comparison.
+      placeholder: Operation, arguments, state version, artifact hashes...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-result
+    attributes:
+      label: Expected oracle result
+      description: Record observable status, exit/reason codes, output, state effects, and event ordering without private implementation text.
+      placeholder: The frozen oracle returns...
+    validations:
+      required: true
+  - type: textarea
+    id: observed-result
+    attributes:
+      label: Observed rewrite or host result
+      description: Record the corresponding observable result and exact divergence.
+      placeholder: The compared build instead returns...
+    validations:
+      required: true
+  - type: dropdown
+    id: classification
+    attributes:
+      label: Compatibility classification
+      description: Classify impact using the public parity campaign vocabulary.
+      multiple: false
+      options:
+        - P0 - safety, integrity, or authorization
+        - P1 - required workflow or public contract
+        - P2 - important non-blocking behavior
+        - Unclassified - maintainer triage required
+    validations:
+      required: true
+  - type: textarea
+    id: differential-evidence
+    attributes:
+      label: Redacted differential evidence
+      description: Provide a failing fixture/test or exact commands and sanitized output that reproduce both sides.
+      placeholder: Focused differential command and redacted output...
+    validations:
+      required: true
+  - type: checkboxes
+    id: policy
+    attributes:
+      label: Compatibility evidence confirmations
+      description: Every confirmation is required before this public issue is created.
+      options:
+        - label: I am authorized to publish this behavioral evidence and recorded its provenance accurately.
+          required: true
+        - label: This report uses normative English and contains no copied private source or prose.
+          required: true
+        - label: This report contains no suspected vulnerability, exploit detail, secret, private data, or confidential infrastructure.
+          required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a vulnerability privately
+    url: https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new
+    about: Do not disclose vulnerabilities, exploits, or secrets in a public issue.
+  - name: Read the support policy
+    url: https://github.com/thiagocorreanet/mestre-yoda/blob/main/SUPPORT.md
+    about: Choose the correct public or confidential support path before filing.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,60 @@
+name: Documentation report
+description: Correct or improve one public documentation path with acceptance evidence.
+title: "[DOCUMENTATION] "
+labels:
+  - documentation
+  - type:documentation
+  - english-only
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use normative English and search for an existing documentation issue first.
+        Do not include vulnerabilities, secrets, customer or personal data, private source, or confidential infrastructure. Use [private vulnerability reporting](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new) for security-sensitive material.
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the file, heading, page, or workflow whose public text should change.
+      placeholder: README.md#development
+    validations:
+      required: true
+  - type: textarea
+    id: audience-problem
+    attributes:
+      label: Audience and current problem
+      description: Identify the reader and explain what is inaccurate, missing, ambiguous, or inaccessible.
+      placeholder: A first-time contributor may conclude...
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed documentation change
+      description: Describe the smallest accurate correction and any terminology or architecture source it must preserve.
+      placeholder: Update the section to state...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-evidence
+    attributes:
+      label: Acceptance evidence
+      description: List link, spelling, render, example-command, or clean-room reader checks appropriate to this change.
+      placeholder: markdownlint, Lychee, CSpell, and reader outcome...
+    validations:
+      required: true
+  - type: checkboxes
+    id: policy
+    attributes:
+      label: Documentation confirmations
+      description: Every confirmation is required before this public issue is created.
+      options:
+        - label: I checked the architecture and existing documentation terminology.
+          required: true
+        - label: This proposal uses normative English and does not present planned behavior as available.
+          required: true
+        - label: This report contains no secret, private data, proprietary source, or confidential vulnerability detail.
+          required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -5,7 +5,6 @@ labels:
   - documentation
   - type:documentation
   - english-only
-assignees: []
 body:
   - type: markdown
     attributes:
@@ -56,5 +55,3 @@ body:
           required: true
         - label: This report contains no secret, private data, proprietary source, or confidential vulnerability detail.
           required: true
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,7 +5,6 @@ labels:
   - enhancement
   - type:feature
   - english-only
-assignees: []
 body:
   - type: markdown
     attributes:
@@ -67,5 +66,3 @@ body:
           required: true
         - label: This proposal contains no secret, private data, proprietary source, or confidential vulnerability detail.
           required: true
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,71 @@
+name: Feature or design proposal
+description: Propose one reviewable capability with objective acceptance evidence.
+title: "[FEATURE] "
+labels:
+  - enhancement
+  - type:feature
+  - english-only
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use normative English and search the backlog, epics, and roadmap first.
+        Do not include secrets, customer or personal data, private source, or confidential infrastructure. Use [private vulnerability reporting](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new) for suspected security problems.
+        A maintainer assigns the stable work ID during triage; do not invent or reuse one.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and user impact
+      description: Describe the concrete problem, affected user, and why current behavior is insufficient.
+      placeholder: Today, a contributor cannot...
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-outcome
+    attributes:
+      label: Proposed outcome
+      description: Define the smallest observable result without prescribing unnecessary implementation details.
+      placeholder: A successful implementation allows...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-evidence
+    attributes:
+      label: Objective acceptance evidence
+      description: List deterministic tests, fixtures, commands, or review evidence that would prove completion.
+      placeholder: |
+        - A focused contract test proves...
+        - The complete verification suite proves...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives and trade-offs
+      description: Describe credible alternatives, including keeping current behavior, and why this outcome is preferred.
+      placeholder: We considered...
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Contract, state, migration, and security impact
+      description: Cover public schemas/commands, Go compatibility, project state, migration, privacy, security, and rollback. State `None` with rationale where applicable.
+      placeholder: Public contract impact...
+    validations:
+      required: true
+  - type: checkboxes
+    id: policy
+    attributes:
+      label: Proposal confirmations
+      description: Every confirmation is required before this public issue is created.
+      options:
+        - label: I searched the backlog and this proposal has one coherent outcome.
+          required: true
+        - label: This proposal and its durable decision record will use normative English.
+          required: true
+        - label: This proposal contains no secret, private data, proprietary source, or confidential vulnerability detail.
+          required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security-safe.yml
+++ b/.github/ISSUE_TEMPLATE/security-safe.yml
@@ -5,7 +5,6 @@ labels:
   - type:security
   - area:security
   - english-only
-assignees: []
 body:
   - type: markdown
     attributes:
@@ -51,5 +50,3 @@ body:
           required: true
         - label: This request is written in normative English.
           required: true
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/security-safe.yml
+++ b/.github/ISSUE_TEMPLATE/security-safe.yml
@@ -1,0 +1,55 @@
+name: Public security hardening request
+description: Propose public hardening or security documentation with no vulnerability details.
+title: "[SECURITY-SAFE] "
+labels:
+  - type:security
+  - area:security
+  - english-only
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is a public security hardening form, not a vulnerability disclosure form.
+        Do not report a vulnerability, exploit, exposed secret, customer or personal data, private data, or confidential source here. Use [private vulnerability reporting](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new) whenever security-sensitive detail may exist.
+        Use normative English and include only information that is safe to publish immediately.
+  - type: textarea
+    id: safe-scope
+    attributes:
+      label: Public and non-sensitive scope
+      description: Describe the general hardening, threat-model, policy, or documentation gap without revealing a weakness or reproduction path.
+      placeholder: The public security documentation should define...
+    validations:
+      required: true
+  - type: textarea
+    id: desired-hardening
+    attributes:
+      label: Desired hardening outcome
+      description: State the safe, observable outcome and boundaries without exploit details.
+      placeholder: Maintainers and contributors should be able to verify...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-evidence
+    attributes:
+      label: Safe acceptance evidence
+      description: List public tests, review checks, policy assertions, or documentation evidence that would prove the outcome.
+      placeholder: A contract test proves that public configuration...
+    validations:
+      required: true
+  - type: checkboxes
+    id: public-safety
+    attributes:
+      label: Mandatory public-safety attestations
+      description: If any statement is false or uncertain, stop and use private vulnerability reporting instead.
+      options:
+        - label: This request contains no suspected vulnerability, weakness reproduction, exploit, or affected-user detail.
+          required: true
+        - label: This request contains no secret, credential, token, customer or personal data, private data, or confidential infrastructure.
+          required: true
+        - label: This request contains no private or proprietary source/prose and is safe for immediate public disclosure.
+          required: true
+        - label: This request is written in normative English.
+          required: true
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,70 @@
+# Pull request
+
+## Linked issue and work ID
+
+Closes #ISSUE_NUMBER
+
+Work ID: `<STREAM-NN>`
+
+## Outcome and design
+
+Describe the observable outcome, selected design, alternatives considered, and
+the explicit out-of-scope boundary. Link the approved design/ADR when required.
+
+## Compatibility and public contracts
+
+Describe effects on Go-v3 parity, PRD/spec behavior, commands, schemas, reason/
+exit codes, fixtures, host contracts, documentation, and other public behavior.
+Use `None` only with a concrete rationale.
+
+## State, migration, security, and rollback
+
+Describe project-state, event, filesystem, Git, concurrency, migration,
+privacy/security, supply-chain, and rollback impact. Identify new trust
+boundaries, permissions, secrets, or data handling. Use `None` with rationale
+where a dimension does not apply.
+
+## Deterministic test evidence
+
+List exact focused and complete commands with current results, including test
+counts, coverage/gate results, platforms, and artifact identity where relevant.
+
+```text
+command
+observed result
+```
+
+## Prompt and model evaluations
+
+List prompt/model evaluations only where deterministic tests cannot answer the
+question, including model/host identity, sample size, rubric, and observed
+limitations. Write `Not applicable` when none are required. A probabilistic
+prompt or model evaluation is not a substitute for deterministic tests.
+
+## Failure evidence
+
+Show the initial failing test or contract check and explain why it failed before
+the implementation. For a bug, include the minimal reproduction and regression
+test. Do not include secrets, private data, or confidential vulnerability detail.
+
+## Provenance
+
+- Sources used (including whether each is public/private and its owner/license):
+- Contribution method (`original`, `behavioral clean-room`, `adapted`, or `verbatim`):
+- Publication authority and required notices for adapted/verbatim material:
+- Confirmation that no secret, credential, customer/personal data, private
+  infrastructure, or confidential business information is included:
+
+## Checklist
+
+- [ ] The PR contains one coherent outcome and no unrelated opportunistic refactor.
+- [ ] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
+- [ ] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
+- [ ] Deterministic tests are separate from any prompt/model evaluations.
+- [ ] Focused tests and the complete required verification suite pass.
+- [ ] Failure evidence from the test-first cycle is included.
+- [ ] Documentation and migration/recovery guidance are updated where required.
+- [ ] All repository text and durable discussion use normative English.
+- [ ] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
+- [ ] Legacy/third-party provenance and publication authority are reviewable.
+- [ ] No unresolved placeholder, secret, private data, or confidential detail remains.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ in English.
    and applicable [ADRs](docs/adr/README.md). Structural decisions require an
    ADR or approved design; they cannot live only in a commit message.
 
+The [contribution workflow and work taxonomy](docs/contributing/workflow.md)
+defines Issue Forms, label meanings, milestone ownership, stable work IDs, and
+the proposed branch/release flow.
+
 ## Development workflow
 
 Use Node.js `24.18.0` and npm `11.16.0` exactly. The complete environment and

--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ commands proves the repository foundation, not SDD product readiness.
 
 Mestre Yoda is being developed in the open, and thoughtful contributions are welcome.
 
-Start with the [Contribution guide](CONTRIBUTING.md), then use the
+Start with the [Contribution guide](CONTRIBUTING.md) and
+[work taxonomy](docs/contributing/workflow.md), then use the
 [Code of Conduct](CODE_OF_CONDUCT.md), [Governance](GOVERNANCE.md), and
 [Support policy](SUPPORT.md) for their respective paths.
 

--- a/docs/contributing/verification.md
+++ b/docs/contributing/verification.md
@@ -1,0 +1,108 @@
+# Contribution Intake Verification
+
+- Verification date: 2026-08-06 (America/Sao_Paulo)
+- Tracking issue: [#6](https://github.com/thiagocorreanet/mestre-yoda/issues/6)
+- Branch: `docs/issue-6-contribution-templates`
+- Reviewed implementation commit: `b9c5876`
+- Status: Implementation ready; platform discovery and issue closure pending
+
+## Test-first evidence
+
+`tests/github-contribution-contract.test.ts` was introduced before any template.
+Its first run had 11 failures: `.github/ISSUE_TEMPLATE`, the pull-request
+template, and the workflow guide did not exist. The YAML dependency-isolation
+assertion was the only passing test. After implementation, all 12 focused tests
+pass.
+
+The contract checks the exact chooser/form inventory, supported form shape,
+unique IDs, required evidence, existing default labels, private vulnerability
+routing, PR evidence sections, taxonomy, work IDs, milestones, proposed branch
+flow, and dependency isolation. It also creates five filled Markdown drafts in
+an OS temporary directory, verifies every required field is discoverable, and
+removes the complete draft tree in `finally`.
+
+## Pinned schema validation
+
+`npm run templates:validate` retrieves the SchemaStore GitHub Issue Forms schema
+from immutable commit `4b00bca7dc9307b9dd34ca13d8c87329d66ad4ce` and rejects it unless its SHA-256
+is `c2722dbf00334ce4fdeffa960b8c9047caf4f1cbb8f3809663f4d604b1d3ae76`.
+Ajv 8.20.0 validated all five parsed forms against the complete snapshot:
+
+```text
+valid: bug.yml
+valid: compatibility.yml
+valid: documentation.yml
+valid: feature.yml
+valid: security-safe.yml
+forms: 5
+```
+
+The complete schema detected and prevented two errors that the initial policy
+subset did not: empty assignee arrays and unsupported checkbox-level validation
+objects. Required checkbox options now carry their own GitHub-supported
+`required: true` flags.
+
+## Form and evidence inventory
+
+| Form | Default labels | Required evidence boundary |
+| --- | --- | --- |
+| Bug | `bug`, `english-only` | version, environment, reproduction, expected/actual behavior, regression evidence |
+| Compatibility | `type:research`, `area:compatibility`, `english-only` | oracle/provenance, exact input, two results, class, differential evidence |
+| Documentation | `documentation`, `type:documentation`, `english-only` | location, audience problem, proposed change, acceptance evidence |
+| Feature | `enhancement`, `type:feature`, `english-only` | problem, outcome, acceptance evidence, alternatives, architecture/risk impact |
+| Security-safe | `type:security`, `area:security`, `english-only` | public scope, hardening, safe evidence, no-vulnerability/no-secret attestations |
+
+Blank issues are disabled. The first chooser contact link and the opening text
+of every form route suspected vulnerabilities to GitHub private vulnerability
+reporting. The security-safe form cannot be submitted until the reporter attests
+that it contains no suspected vulnerability, exploit, secret, customer/private
+data, confidential infrastructure, or proprietary source.
+
+## Local verification
+
+Using Node.js `v24.18.0` and npm `11.16.0`:
+
+| Check | Result |
+| --- | --- |
+| `npm ci` | Pass; 261 locked development packages installed |
+| `npm ls ajv yaml --depth=0` | Ajv 8.20.0 and YAML 2.9.0 exactly |
+| Focused contract | Pass; 1 file and 12 tests |
+| `npm run verify` | Pass; 6 files and 42 tests |
+| Coverage | 100% configured runtime statements, branches, functions, and lines |
+| `npm run templates:validate` | Five forms valid against pinned schema/hash |
+| Form/template CSpell | 8 files, zero issues |
+| Markdown CSpell | 30 files, zero issues |
+| markdownlint | 31 files, zero errors |
+| Lychee | 117 links checked, 66 unique, zero errors |
+| Package verification | Exact 386-byte ESM; unchanged help/version and SHA-256 |
+| `git diff --check` | Pass |
+
+The root still has zero production dependencies. Ajv/YAML are development-only;
+the package verifier reports the same sole `runtime/yoda.mjs` artifact and
+`24293983cba88bb6e96ba4586bb5492b5e84bd18a8d5f0b7b536e8ad8d2108ee` hash.
+No runtime, state, migration, host, PRD, or spec behavior changed.
+
+## Independent review
+
+The first independent review found that a hand-written schema subset could not
+prove GitHub fidelity and that the original publication order closed #6 before
+platform discovery. The complete pinned-schema validator was added, and the
+implementation PR will not contain a closing keyword. A follow-up can close #6
+only after GitHub discovers and renders every form on `main`.
+
+Re-review found one contradictory sentence describing the offline `verify`
+chain; the guide now separates it from the online pinned-schema command. Final
+review reported no Critical, Important, or Minor findings.
+
+## Pending platform gate
+
+After the implementation merge, evidence must still prove:
+
+- GitHub's issue-template API discovers exactly five forms;
+- the community profile recognizes issue and pull-request templates;
+- each direct `issues/new?template=<filename>` URL renders the expected title and
+  required fields;
+- the implementation PR and `main` Documentation workflow are green.
+
+Issue #6 must remain open until those observations are recorded and merged in a
+follow-up PR carrying `Closes #6`.

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -1,0 +1,175 @@
+# Contribution Workflow and Work Taxonomy
+
+This guide defines how Mestre Yoda classifies, plans, and integrates public
+work. It complements [CONTRIBUTING.md](../../CONTRIBUTING.md); the contribution,
+security, conduct, governance, provenance, DCO, and English rules there remain
+normative.
+
+## Intake workflow
+
+Search the backlog before opening an issue. Select the form whose evidence
+matches the work:
+
+- **Bug report:** reproducible non-security behavior with expected/actual output
+  and regression evidence.
+- **Feature or design proposal:** one user problem, objective outcome, acceptance
+  evidence, alternatives, and architecture/risk impact.
+- **Compatibility regression:** authorized clean-room oracle comparison with
+  exact inputs and redacted differential evidence.
+- **Public security hardening:** only information safe for immediate disclosure;
+  never vulnerabilities, exploits, exposed secrets, or sensitive details.
+- **Documentation report:** one reader/location problem and the checks that will
+  prove the correction.
+
+Blank public issues are disabled. Suspected vulnerabilities and exposed secrets
+use [private vulnerability reporting](https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new),
+not an Issue Form. General routing follows [SUPPORT.md](../../SUPPORT.md).
+
+Maintainers triage duplicates, scope, dependencies, work ID, labels, milestone,
+priority, and readiness. A form submission does not itself approve a public
+contract, assign a maintainer, or authorize implementation.
+
+## Label taxonomy
+
+Use labels as independent dimensions:
+
+- exactly one `type:*` label identifies the primary work product when a
+  namespaced type applies;
+- one or more `area:*` labels identify architecture boundaries materially
+  affected by the work;
+- exactly one `priority:p0` through `priority:p3` communicates delivery order;
+- `status:blocked` means a named dependency or external condition prevents work;
+- GitHub intake aliases (`bug`, `enhancement`, `documentation`, `question`) aid
+  discovery and may coexist with namespaced labels;
+- community labels (`good first issue`, `help wanted`) describe contribution
+  suitability, not priority, ownership, or approval;
+- lifecycle outcomes (`duplicate`, `invalid`, `wontfix`) require a public triage
+  explanation before closure;
+- `english-only` records the normative public-language contract;
+- `future` is reserved for work beyond the first public beta.
+
+### Type labels
+
+| Label | Meaning |
+| --- | --- |
+| `type:ci` | Continuous integration and automation |
+| `type:documentation` | Documentation work |
+| `type:epic` | Coordinated body of work and exit criteria |
+| `type:feature` | New product capability |
+| `type:maintenance` | Repository and maintenance work |
+| `type:research` | Discovery or compatibility research |
+| `type:security` | Security hardening or validation |
+| `type:testing` | Test infrastructure or quality assurance |
+
+### Area labels
+
+| Label | Meaning |
+| --- | --- |
+| `area:adapters` | Claude Code and Codex integrations |
+| `area:community` | Open-source governance and contribution |
+| `area:compatibility` | Legacy parity and compatibility contracts |
+| `area:foundation` | Repository and architecture foundation |
+| `area:migration` | Legacy migration, upgrade, and recovery |
+| `area:observability` | Events, evidence, explanation, and dashboards |
+| `area:quality` | Testing and quality engineering |
+| `area:release` | Packaging, releases, and distribution |
+| `area:runtime` | Deterministic TypeScript runtime |
+| `area:security` | Security-sensitive architecture and hardening |
+| `area:state` | State model, schemas, and persistence |
+| `area:workflow` | SDD workflow and gates |
+
+### Priority and status labels
+
+| Label | Meaning |
+| --- | --- |
+| `priority:p0` | Required before all other work |
+| `priority:p1` | Required for the first public beta |
+| `priority:p2` | Important after the beta foundation |
+| `priority:p3` | Future or optional capability |
+| `status:blocked` | Cannot start until named dependencies are complete |
+
+The remaining GitHub intake/community labels are `bug`, `documentation`,
+`duplicate`, `enhancement`, `english-only`, `future`, `good first issue`,
+`help wanted`, `invalid`, `question`, and `wontfix`. Maintainers preserve the
+descriptions and colors configured in GitHub; a taxonomy change requires a
+focused issue/PR so repository documentation and platform state stay aligned.
+
+## Milestones
+
+Milestones are evidence campaigns, not calendar promises. The public sequence is:
+
+| Milestone | Evidence boundary |
+| --- | --- |
+| Foundation | Repository, architecture, governance, and CI foundation |
+| Compatibility Contract | Frozen Go baseline and measurable TypeScript parity |
+| Deterministic Runtime | Core runtime, state, filesystem, and Git services |
+| SDD Workflow Parity | Objective-to-done workflow and deterministic gates |
+| Host Integrations | Claude Code and Codex adapters without a global binary |
+| Migration and Observability | Safe migration, replay, repair, and evidence |
+| Quality Campaign | Layered tests, platforms, security, and compatibility |
+| Public Beta | Documentation, distribution, release, and pilot readiness |
+| Post-1.0 Ideas | Advanced adaptive and collaborative capabilities |
+
+A non-epic issue belongs to at most one milestone: the campaign whose exit
+criteria it advances. An epic uses that same milestone to coordinate its child
+issues. A bug belongs to the milestone that owns its fix, not automatically to
+the release where it was observed. Moving work between milestones requires a
+public triage rationale; due dates do not replace objective exit evidence.
+
+## Stable work IDs
+
+Accepted backlog items use `[STREAM-NN]` at the beginning of the title. `NN` is
+the next unused positive two-digit sequence within its stream:
+
+| Stream | Scope |
+| --- | --- |
+| `FND` | Foundation |
+| `CMP` | Compatibility Contract |
+| `RUN` | Deterministic Runtime |
+| `SDD` | SDD Workflow Parity |
+| `ADP` | Host Integrations |
+| `MIG` | Migration |
+| `OBS` | Observability |
+| `QAL` | Quality Campaign |
+| `BET` | Public Beta |
+| `FUT` | Post-1.0 Ideas |
+
+Coordinating epics use `[EPIC]`. Maintainers allocate IDs during triage after
+checking the complete open and closed backlog. Contributors should not guess an
+ID in a new form.
+
+Once assigned, a work ID is immutable and never reused, even when an issue is
+closed, moved, superseded, or cancelled. GitHub issue numbers remain the
+canonical URL and relationship key; work IDs provide stable human references
+across roadmap exports, migrations, and repository history.
+
+## Branch and release flow
+
+The proposed flow is not active until [issue #60](https://github.com/thiagocorreanet/mestre-yoda/issues/60)
+creates/configures the branches and protections:
+
+```text
+feature/*, fix/*, docs/*, refactor/* -> developer -> approved release PR -> main
+```
+
+Short-lived contribution branches use
+`<type>/<issue-number>-<short-name>`, contain one coherent issue outcome, and
+will target `developer`. Approved release pull requests will move reviewed
+integration commits from `developer` to protected `main`.
+
+Until issue #60 activates that model, contributors must use the base branch
+named by the current repository instructions and GitHub pull-request interface.
+Documentation of the target flow does not create a `developer` branch, change
+the default branch, activate protection, or imply that unavailable checks run.
+
+## Pull requests
+
+Use the repository pull-request template. A reviewable PR closes one issue,
+names its stable work ID, explains design and compatibility impact, and separates
+deterministic tests from prompt/model evaluations. It includes RED evidence,
+exact current commands/results, provenance, DCO, migration/security/rollback
+impact, and normative-English confirmation.
+
+Probabilistic model evaluation is supplementary and is never accepted as a
+substitute for deterministic runtime, state, compatibility, migration, package,
+or security tests. All available required checks must pass before merge.

--- a/docs/development/toolchain.md
+++ b/docs/development/toolchain.md
@@ -58,11 +58,13 @@ scripts/             deterministic build and package verification
 
 All npm packages are private ESM workspaces. The root has no production
 dependencies. Its exactly pinned development dependencies are compilers,
-linters, formatters, the CSpell documentation checker, test/coverage tools, type
-declarations, and the bundler.
+linters, formatters, the CSpell documentation checker, the YAML configuration
+parser, test/coverage tools, type declarations, and the bundler.
 Only the exactly pinned esbuild installer is allowed to run a dependency
 lifecycle script. npm treats uncovered scripts as installation errors and
 explicitly denies the optional fsevents script recorded for macOS compatibility.
+YAML `2.9.0` is used only by repository contract tests for GitHub configuration;
+it is absent from the embedded runtime bundle.
 
 ## Runtime artifact
 

--- a/docs/development/toolchain.md
+++ b/docs/development/toolchain.md
@@ -32,13 +32,19 @@ clean and CI installations. Changing a dependency requires Node `24.18.0`, npm
 | --- | --- |
 | `npm run format:check` | Check supported source and configuration formatting |
 | `npm run spellcheck` | Check tracked English Markdown with the project dictionary |
+| `npm run templates:validate` | Validate Issue Forms against a pinned SchemaStore snapshot of GitHub's documented schema |
 | `npm run lint` | Run typed ESLint with zero warnings |
 | `npm run typecheck` | Run strict TypeScript 6 compatibility checking without emit |
 | `npm test` | Run unit and clean-room bundle tests once |
 | `npm run test:coverage` | Enforce 100% coverage on the initial CLI decision surface |
 | `npm run build` | Rebuild the standalone runtime artifact |
 | `npm run package:verify` | Inspect and execute the staged artifact outside the checkout |
-| `npm run verify` | Run every validation above in dependency order |
+| `npm run verify` | Run the complete offline validation chain in dependency order |
+
+Run `npm run templates:validate` separately when Issue Forms or their validation
+contract changes. It requires network access only to retrieve the immutable,
+hash-verified schema snapshot; `npm run verify` remains reproducible offline
+after `npm ci`.
 
 Issue [#7](https://github.com/thiagocorreanet/mestre-yoda/issues/7) will add the
 Node pull-request workflow. It must call these commands and must not introduce
@@ -58,13 +64,17 @@ scripts/             deterministic build and package verification
 
 All npm packages are private ESM workspaces. The root has no production
 dependencies. Its exactly pinned development dependencies are compilers,
-linters, formatters, the CSpell documentation checker, the YAML configuration
-parser, test/coverage tools, type declarations, and the bundler.
+linters, formatters, the CSpell documentation checker, the Ajv JSON Schema and
+YAML configuration parsers, test/coverage tools, type declarations, and the
+bundler.
 Only the exactly pinned esbuild installer is allowed to run a dependency
 lifecycle script. npm treats uncovered scripts as installation errors and
 explicitly denies the optional fsevents script recorded for macOS compatibility.
 YAML `2.9.0` is used only by repository contract tests for GitHub configuration;
 it is absent from the embedded runtime bundle.
+Ajv `8.20.0` validates Issue Forms against a content-hash-verified schema
+snapshot. That explicit online evidence command is separate from the offline
+`verify` chain; both validation dependencies remain absent from the runtime.
 
 ## Runtime artifact
 

--- a/docs/superpowers/plans/2026-08-06-contribution-intake.md
+++ b/docs/superpowers/plans/2026-08-06-contribution-intake.md
@@ -1,0 +1,243 @@
+# Contribution Intake Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every public issue and pull request arrive with typed context, safe routing, deterministic evidence, and a stable work-taxonomy reference.
+
+**Architecture:** GitHub-native Issue Forms and one PR template remain static repository artifacts. A Vitest contract parses every YAML form, enforces the supported schema subset and repository policy, and renders temporary local drafts; a contributor guide owns labels, milestones, IDs, and the proposed branch flow.
+
+**Tech Stack:** GitHub Issue Forms YAML, Markdown, TypeScript, Vitest 4.1.10, YAML 2.9.0, GitHub community profile/template APIs.
+
+## Global constraints
+
+- Keep every public artifact and test in normative English.
+- Do not expose a public vulnerability intake path or collect sensitive details.
+- Do not claim `developer` or branch protection exists before issue #60.
+- Preserve the private Go predecessor only as a behavioral oracle; do not copy private prose.
+- Keep YAML development-only and retain zero production dependencies.
+- Do not alter runtime, state, migration, host, or PRD/spec behavior.
+- Sign every commit under DCO 1.1.
+
+---
+
+### Task 1: Add deterministic YAML parsing
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `docs/development/toolchain.md`
+- Modify: `docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md`
+
+**Interfaces:**
+
+- Consumes: exact npm lockfile and Issue Form YAML.
+- Produces: one development-only YAML parser available to Vitest.
+
+- [ ] **Step 1: Pin YAML exactly**
+
+Add `"yaml": "2.9.0"` to root `devDependencies`. Do not add a production
+dependency or a new public script.
+
+- [ ] **Step 2: Regenerate and verify the lockfile**
+
+Using exact Node/npm:
+
+```bash
+npm install --package-lock-only
+npm ci
+npm ls yaml --depth=0
+```
+
+Expected: YAML resolves exactly to `2.9.0`; strict lifecycle policy still passes.
+
+- [ ] **Step 3: Update the toolchain contract**
+
+List YAML 2.9.0 as the development-only configuration parser and state that it
+does not enter the embedded runtime bundle.
+
+### Task 2: Define the failing GitHub contribution contract
+
+**Files:**
+
+- Create: `tests/github-contribution-contract.test.ts`
+
+**Interfaces:**
+
+- Consumes: `.github/ISSUE_TEMPLATE/*.yml`, PR template, workflow guide, package manifest.
+- Produces: schema, policy, discovery, and local draft assertions.
+
+- [ ] **Step 1: Write schema-subset helpers**
+
+Parse YAML with `parseDocument`, reject parser warnings/errors, require object
+roots, and validate exactly the GitHub-supported form keys and body element
+types. Validate unique kebab-case IDs, required attributes, option shapes,
+existing labels, and form-level names/descriptions/titles.
+
+- [ ] **Step 2: Write intake-policy tests**
+
+Assert exact form inventory plus `config.yml`; blank issues disabled; the first
+contact link is private vulnerability reporting. Assert each form contains its
+designated reproduction/acceptance IDs and safe required checkboxes. Assert the
+security-safe form cannot be mistaken for confidential reporting.
+
+- [ ] **Step 3: Write PR/workflow contract tests**
+
+Assert PR headings for issue/work ID, design, compatibility, state/migration/
+security, deterministic tests, model evaluations, failure evidence, provenance,
+DCO, English, and focused scope. Assert workflow guide contains the complete
+label taxonomy, nine milestones, ten work-ID streams, immutability/no reuse, and
+the proposed `developer` to `main` boundary owned by issue #60.
+
+- [ ] **Step 4: Write local draft rendering test**
+
+For each form, render a filled Markdown draft into an OS temporary directory,
+assert every required non-Markdown field has a visible heading/value, then remove
+the tree in `finally`. No GitHub issue or notification is created.
+
+- [ ] **Step 5: Confirm RED**
+
+Run: `npm test -- tests/github-contribution-contract.test.ts`
+
+Expected: FAIL because `.github/ISSUE_TEMPLATE` and the PR/workflow templates do
+not exist.
+
+### Task 3: Implement the five Issue Forms
+
+**Files:**
+
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+- Create: `.github/ISSUE_TEMPLATE/bug.yml`
+- Create: `.github/ISSUE_TEMPLATE/feature.yml`
+- Create: `.github/ISSUE_TEMPLATE/compatibility.yml`
+- Create: `.github/ISSUE_TEMPLATE/security-safe.yml`
+- Create: `.github/ISSUE_TEMPLATE/documentation.yml`
+
+**Interfaces:**
+
+- Consumes: GitHub Issue Form schema and approved governance/security policy.
+- Produces: exactly five discoverable public forms and two non-issue contact links.
+
+- [ ] **Step 1: Configure the chooser**
+
+Set `blank_issues_enabled: false`. Put private vulnerability reporting first and
+the repository support policy second.
+
+- [ ] **Step 2: Implement bug and compatibility forms**
+
+Bug requires affected version/commit, environment, minimal reproduction,
+expected/actual behavior, regression test/evidence, and policy confirmations.
+Compatibility additionally requires oracle/provenance boundary, exact input,
+expected/observed result, severity class, and redacted differential evidence.
+
+- [ ] **Step 3: Implement feature and documentation forms**
+
+Feature requires problem, outcome, alternatives, objective acceptance evidence,
+and contract/state/migration/security impact. Documentation requires location,
+audience problem, proposed change, acceptance evidence, and safety confirmation.
+
+- [ ] **Step 4: Implement the security-safe form**
+
+Use a public-hardening title and prominent private-report URL. Require safe scope,
+desired hardening, acceptance evidence, and attestations that no suspected
+vulnerability, exploit, secret, customer/private data, or confidential source is
+present.
+
+### Task 4: Implement pull-request and taxonomy documentation
+
+**Files:**
+
+- Create: `.github/pull_request_template.md`
+- Create: `docs/contributing/workflow.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `README.md`
+
+**Interfaces:**
+
+- Consumes: contribution/governance policy and current GitHub labels/milestones.
+- Produces: one review contract and one authoritative taxonomy/branch guide.
+
+- [ ] **Step 1: Write the PR template**
+
+Add all design-required sections and separate deterministic tests from prompt/
+model evaluations. Include closing reference, stable work ID, compatibility,
+risk, migration, security, rollback, failure evidence, provenance, DCO, English,
+documentation, and focused-scope confirmations.
+
+- [ ] **Step 2: Document labels and milestones**
+
+Inventory every current namespaced and GitHub intake/community label with usage
+rules. Document the nine public milestones as evidence campaigns without date
+promises and one-milestone ownership.
+
+- [ ] **Step 3: Document stable IDs and proposed branches**
+
+Specify `[STREAM-NN]`, all ten streams, immutable/no-reuse allocation, and
+`[EPIC]`. Document short-lived branch names, proposed integration into
+`developer`, approved release PRs into `main`, and issue #60 ownership. State the
+current repository/PR instructions control until activation.
+
+- [ ] **Step 4: Link the workflow entrypoint**
+
+Add the guide to CONTRIBUTING and the README contribution path without expanding
+the installation or product-readiness claims.
+
+- [ ] **Step 5: Confirm GREEN and commit**
+
+```bash
+npm test -- tests/github-contribution-contract.test.ts
+npm run spellcheck
+npm run typecheck
+npm run lint
+git add .github package.json package-lock.json tests docs CONTRIBUTING.md README.md
+git commit -s -m "docs: add structured contribution intake"
+```
+
+Expected: all contract tests and focused static checks pass.
+
+### Task 5: Verify, review, publish, and prove GitHub discovery
+
+**Files:**
+
+- Create: `docs/contributing/verification.md`
+- Modify: `docs/superpowers/plans/2026-08-06-contribution-intake.md`
+
+**Interfaces:**
+
+- Consumes: final templates, checks, independent review, GitHub APIs.
+- Produces: reproducible local and platform discovery evidence and issue closure.
+
+- [ ] **Step 1: Run complete local verification**
+
+```bash
+npm run verify
+npx --yes markdownlint-cli2@0.20.0 "README.md" "*.md" "docs/**/*.md"
+lychee --config .lychee.toml './**/*.md'
+git diff --check
+```
+
+Expected: full suite, spelling, Markdown, links, package, and whitespace pass.
+
+- [ ] **Step 2: Request independent review**
+
+Review issue/design/plan acceptance, YAML schema fidelity, security routing,
+command truth, label/milestone/ID rules, and proposed-vs-active branch wording.
+Resolve every finding and rerun affected plus complete checks.
+
+- [ ] **Step 3: Record pre-merge evidence**
+
+Record exact versions, test/file/link counts, local temporary draft inventory,
+form labels/required fields, review outcome, DCO trailers, and no production
+dependency/runtime-bundle change.
+
+- [ ] **Step 4: Publish, merge, and close**
+
+Push `docs/issue-6-contribution-templates`, open a signed PR with `Closes #6`,
+wait for all available checks, merge, confirm issue #6 closed, and synchronize
+`main`.
+
+- [ ] **Step 5: Prove platform discovery post-merge**
+
+Use GitHub's issue-template and community-profile APIs to verify exactly five
+forms plus recognized issue/PR template paths on `main`. Record the merged commit
+and green workflow, publish the evidence follow-up, then begin issue #7.

--- a/docs/superpowers/plans/2026-08-06-contribution-intake.md
+++ b/docs/superpowers/plans/2026-08-06-contribution-intake.md
@@ -4,9 +4,9 @@
 
 **Goal:** Make every public issue and pull request arrive with typed context, safe routing, deterministic evidence, and a stable work-taxonomy reference.
 
-**Architecture:** GitHub-native Issue Forms and one PR template remain static repository artifacts. A Vitest contract parses every YAML form, enforces the supported schema subset and repository policy, and renders temporary local drafts; a contributor guide owns labels, milestones, IDs, and the proposed branch flow.
+**Architecture:** GitHub-native Issue Forms and one PR template remain static repository artifacts. A Vitest policy contract parses every YAML form and renders temporary local drafts; a separate validator checks all forms against a content-hash-verified schema snapshot. A contributor guide owns labels, milestones, IDs, and the proposed branch flow.
 
-**Tech Stack:** GitHub Issue Forms YAML, Markdown, TypeScript, Vitest 4.1.10, YAML 2.9.0, GitHub community profile/template APIs.
+**Tech Stack:** GitHub Issue Forms YAML, Markdown, TypeScript, Vitest 4.1.10, YAML 2.9.0, Ajv 8.20.0, pinned SchemaStore snapshot, GitHub community profile/template APIs.
 
 ## Global constraints
 
@@ -14,13 +14,13 @@
 - Do not expose a public vulnerability intake path or collect sensitive details.
 - Do not claim `developer` or branch protection exists before issue #60.
 - Preserve the private Go predecessor only as a behavioral oracle; do not copy private prose.
-- Keep YAML development-only and retain zero production dependencies.
+- Keep Ajv/YAML development-only and retain zero production dependencies.
 - Do not alter runtime, state, migration, host, or PRD/spec behavior.
 - Sign every commit under DCO 1.1.
 
 ---
 
-### Task 1: Add deterministic YAML parsing
+### Task 1: Add deterministic schema and YAML parsing
 
 **Files:**
 
@@ -32,12 +32,12 @@
 **Interfaces:**
 
 - Consumes: exact npm lockfile and Issue Form YAML.
-- Produces: one development-only YAML parser available to Vitest.
+- Produces: development-only schema/YAML validation without runtime impact.
 
-- [x] **Step 1: Pin YAML exactly**
+- [x] **Step 1: Pin Ajv and YAML exactly**
 
-Add `"yaml": "2.9.0"` to root `devDependencies`. Do not add a production
-dependency or a new public script.
+Add `"ajv": "8.20.0"` and `"yaml": "2.9.0"` to root `devDependencies`. Do
+not add a production dependency.
 
 - [x] **Step 2: Regenerate and verify the lockfile**
 
@@ -46,15 +46,16 @@ Using exact Node/npm:
 ```bash
 npm install --package-lock-only
 npm ci
-npm ls yaml --depth=0
+npm ls ajv yaml --depth=0
 ```
 
-Expected: YAML resolves exactly to `2.9.0`; strict lifecycle policy still passes.
+Expected: Ajv/YAML resolve exactly to `8.20.0`/`2.9.0`; strict lifecycle policy
+still passes.
 
 - [x] **Step 3: Update the toolchain contract**
 
-List YAML 2.9.0 as the development-only configuration parser and state that it
-does not enter the embedded runtime bundle.
+List Ajv/YAML as development-only configuration validators and state that they
+do not enter the embedded runtime bundle.
 
 ### Task 2: Define the failing GitHub contribution contract
 
@@ -195,7 +196,7 @@ git commit -s -m "docs: add structured contribution intake"
 
 Expected: all contract tests and focused static checks pass.
 
-### Task 5: Verify, review, publish, and prove GitHub discovery
+### Task 5: Verify, review, publish, and prove GitHub discovery before closure
 
 **Files:**
 
@@ -211,12 +212,14 @@ Expected: all contract tests and focused static checks pass.
 
 ```bash
 npm run verify
+npm run templates:validate
 npx --yes markdownlint-cli2@0.20.0 "README.md" "*.md" "docs/**/*.md"
 lychee --config .lychee.toml './**/*.md'
 git diff --check
 ```
 
-Expected: full suite, spelling, Markdown, links, package, and whitespace pass.
+Expected: full suite, hash-verified pinned Issue Forms schema, spelling,
+Markdown, links, package, and whitespace pass.
 
 - [ ] **Step 2: Request independent review**
 
@@ -230,14 +233,16 @@ Record exact versions, test/file/link counts, local temporary draft inventory,
 form labels/required fields, review outcome, DCO trailers, and no production
 dependency/runtime-bundle change.
 
-- [ ] **Step 4: Publish, merge, and close**
+- [ ] **Step 4: Publish implementation without closing the issue**
 
-Push `docs/issue-6-contribution-templates`, open a signed PR with `Closes #6`,
-wait for all available checks, merge, confirm issue #6 closed, and synchronize
-`main`.
+Push `docs/issue-6-contribution-templates`, open a signed PR that references but
+does not close #6, wait for all available checks, merge, confirm issue #6 remains
+open, and synchronize `main`.
 
-- [ ] **Step 5: Prove platform discovery post-merge**
+- [ ] **Step 5: Prove platform discovery, record evidence, and close**
 
 Use GitHub's issue-template and community-profile APIs to verify exactly five
-forms plus recognized issue/PR template paths on `main`. Record the merged commit
-and green workflow, publish the evidence follow-up, then begin issue #7.
+forms plus recognized issue/PR template paths on `main`. Open every direct form
+URL and verify its rendered title/required fields. Record the merged commit and
+green workflow, publish an evidence follow-up with `Closes #6`, merge it, confirm
+issue #6 closed, then begin issue #7.

--- a/docs/superpowers/plans/2026-08-06-contribution-intake.md
+++ b/docs/superpowers/plans/2026-08-06-contribution-intake.md
@@ -208,26 +208,26 @@ Expected: all contract tests and focused static checks pass.
 - Consumes: final templates, checks, independent review, GitHub APIs.
 - Produces: reproducible local and platform discovery evidence and issue closure.
 
-- [ ] **Step 1: Run complete local verification**
+- [x] **Step 1: Run complete local verification**
 
 ```bash
 npm run verify
 npm run templates:validate
 npx --yes markdownlint-cli2@0.20.0 "README.md" "*.md" "docs/**/*.md"
-lychee --config .lychee.toml './**/*.md'
+lychee --config .lychee.toml README.md ROADMAP.md CONTRIBUTING.md CODE_OF_CONDUCT.md GOVERNANCE.md SECURITY.md SUPPORT.md .github/pull_request_template.md docs
 git diff --check
 ```
 
 Expected: full suite, hash-verified pinned Issue Forms schema, spelling,
 Markdown, links, package, and whitespace pass.
 
-- [ ] **Step 2: Request independent review**
+- [x] **Step 2: Request independent review**
 
 Review issue/design/plan acceptance, YAML schema fidelity, security routing,
 command truth, label/milestone/ID rules, and proposed-vs-active branch wording.
 Resolve every finding and rerun affected plus complete checks.
 
-- [ ] **Step 3: Record pre-merge evidence**
+- [x] **Step 3: Record pre-merge evidence**
 
 Record exact versions, test/file/link counts, local temporary draft inventory,
 form labels/required fields, review outcome, DCO trailers, and no production

--- a/docs/superpowers/plans/2026-08-06-contribution-intake.md
+++ b/docs/superpowers/plans/2026-08-06-contribution-intake.md
@@ -34,12 +34,12 @@
 - Consumes: exact npm lockfile and Issue Form YAML.
 - Produces: one development-only YAML parser available to Vitest.
 
-- [ ] **Step 1: Pin YAML exactly**
+- [x] **Step 1: Pin YAML exactly**
 
 Add `"yaml": "2.9.0"` to root `devDependencies`. Do not add a production
 dependency or a new public script.
 
-- [ ] **Step 2: Regenerate and verify the lockfile**
+- [x] **Step 2: Regenerate and verify the lockfile**
 
 Using exact Node/npm:
 
@@ -51,7 +51,7 @@ npm ls yaml --depth=0
 
 Expected: YAML resolves exactly to `2.9.0`; strict lifecycle policy still passes.
 
-- [ ] **Step 3: Update the toolchain contract**
+- [x] **Step 3: Update the toolchain contract**
 
 List YAML 2.9.0 as the development-only configuration parser and state that it
 does not enter the embedded runtime bundle.
@@ -67,21 +67,21 @@ does not enter the embedded runtime bundle.
 - Consumes: `.github/ISSUE_TEMPLATE/*.yml`, PR template, workflow guide, package manifest.
 - Produces: schema, policy, discovery, and local draft assertions.
 
-- [ ] **Step 1: Write schema-subset helpers**
+- [x] **Step 1: Write schema-subset helpers**
 
 Parse YAML with `parseDocument`, reject parser warnings/errors, require object
 roots, and validate exactly the GitHub-supported form keys and body element
 types. Validate unique kebab-case IDs, required attributes, option shapes,
 existing labels, and form-level names/descriptions/titles.
 
-- [ ] **Step 2: Write intake-policy tests**
+- [x] **Step 2: Write intake-policy tests**
 
 Assert exact form inventory plus `config.yml`; blank issues disabled; the first
 contact link is private vulnerability reporting. Assert each form contains its
 designated reproduction/acceptance IDs and safe required checkboxes. Assert the
 security-safe form cannot be mistaken for confidential reporting.
 
-- [ ] **Step 3: Write PR/workflow contract tests**
+- [x] **Step 3: Write PR/workflow contract tests**
 
 Assert PR headings for issue/work ID, design, compatibility, state/migration/
 security, deterministic tests, model evaluations, failure evidence, provenance,
@@ -89,13 +89,13 @@ DCO, English, and focused scope. Assert workflow guide contains the complete
 label taxonomy, nine milestones, ten work-ID streams, immutability/no reuse, and
 the proposed `developer` to `main` boundary owned by issue #60.
 
-- [ ] **Step 4: Write local draft rendering test**
+- [x] **Step 4: Write local draft rendering test**
 
 For each form, render a filled Markdown draft into an OS temporary directory,
 assert every required non-Markdown field has a visible heading/value, then remove
 the tree in `finally`. No GitHub issue or notification is created.
 
-- [ ] **Step 5: Confirm RED**
+- [x] **Step 5: Confirm RED**
 
 Run: `npm test -- tests/github-contribution-contract.test.ts`
 
@@ -118,25 +118,25 @@ not exist.
 - Consumes: GitHub Issue Form schema and approved governance/security policy.
 - Produces: exactly five discoverable public forms and two non-issue contact links.
 
-- [ ] **Step 1: Configure the chooser**
+- [x] **Step 1: Configure the chooser**
 
 Set `blank_issues_enabled: false`. Put private vulnerability reporting first and
 the repository support policy second.
 
-- [ ] **Step 2: Implement bug and compatibility forms**
+- [x] **Step 2: Implement bug and compatibility forms**
 
 Bug requires affected version/commit, environment, minimal reproduction,
 expected/actual behavior, regression test/evidence, and policy confirmations.
 Compatibility additionally requires oracle/provenance boundary, exact input,
 expected/observed result, severity class, and redacted differential evidence.
 
-- [ ] **Step 3: Implement feature and documentation forms**
+- [x] **Step 3: Implement feature and documentation forms**
 
 Feature requires problem, outcome, alternatives, objective acceptance evidence,
 and contract/state/migration/security impact. Documentation requires location,
 audience problem, proposed change, acceptance evidence, and safety confirmation.
 
-- [ ] **Step 4: Implement the security-safe form**
+- [x] **Step 4: Implement the security-safe form**
 
 Use a public-hardening title and prominent private-report URL. Require safe scope,
 desired hardening, acceptance evidence, and attestations that no suspected
@@ -157,32 +157,32 @@ present.
 - Consumes: contribution/governance policy and current GitHub labels/milestones.
 - Produces: one review contract and one authoritative taxonomy/branch guide.
 
-- [ ] **Step 1: Write the PR template**
+- [x] **Step 1: Write the PR template**
 
 Add all design-required sections and separate deterministic tests from prompt/
 model evaluations. Include closing reference, stable work ID, compatibility,
 risk, migration, security, rollback, failure evidence, provenance, DCO, English,
 documentation, and focused-scope confirmations.
 
-- [ ] **Step 2: Document labels and milestones**
+- [x] **Step 2: Document labels and milestones**
 
 Inventory every current namespaced and GitHub intake/community label with usage
 rules. Document the nine public milestones as evidence campaigns without date
 promises and one-milestone ownership.
 
-- [ ] **Step 3: Document stable IDs and proposed branches**
+- [x] **Step 3: Document stable IDs and proposed branches**
 
 Specify `[STREAM-NN]`, all ten streams, immutable/no-reuse allocation, and
 `[EPIC]`. Document short-lived branch names, proposed integration into
 `developer`, approved release PRs into `main`, and issue #60 ownership. State the
 current repository/PR instructions control until activation.
 
-- [ ] **Step 4: Link the workflow entrypoint**
+- [x] **Step 4: Link the workflow entrypoint**
 
 Add the guide to CONTRIBUTING and the README contribution path without expanding
 the installation or product-readiness claims.
 
-- [ ] **Step 5: Confirm GREEN and commit**
+- [x] **Step 5: Confirm GREEN and commit**
 
 ```bash
 npm test -- tests/github-contribution-contract.test.ts

--- a/docs/superpowers/specs/2026-08-06-contribution-intake-design.md
+++ b/docs/superpowers/specs/2026-08-06-contribution-intake-design.md
@@ -131,13 +131,19 @@ label the flow proposed rather than pretending protection already exists.
 
 ## 7. Deterministic validation and discoverability
 
-The repository pins `yaml@2.9.0` as a development-only parser and keeps zero
-production dependencies. `tests/github-contribution-contract.test.ts` starts
-red while the templates are absent, then validates:
+The repository pins Ajv `8.20.0` and YAML `2.9.0` as development-only validators
+and keeps zero production dependencies. `npm run templates:validate` downloads
+the GitHub Issue Forms schema from the immutable SchemaStore commit
+`4b00bca7dc9307b9dd34ca13d8c87329d66ad4ce`, rejects any content whose SHA-256
+is not `c2722dbf00334ce4fdeffa960b8c9047caf4f1cbb8f3809663f4d604b1d3ae76`,
+and validates all five forms against that complete snapshot.
+
+`tests/github-contribution-contract.test.ts` starts red while the templates are
+absent, then validates repository-specific policy:
 
 - the exact chooser/form inventory and parseable YAML object shape;
-- GitHub-supported top-level and body element keys, types, unique IDs, required
-  attributes, valid option shapes, and existing default labels;
+- parseable YAML, supported keys/types, unique IDs, required attributes, valid
+  option shapes, and existing default labels;
 - form-specific reproduction or acceptance evidence;
 - private vulnerability routing and public safety attestations;
 - the PR template's required risk, evidence, provenance, DCO, and English
@@ -150,9 +156,12 @@ system temporary directory, verifies that all required fields are discoverable,
 and deletes the draft tree. This proves local draft creation without opening a
 real issue or notifying maintainers.
 
-After merge, GitHub's issue-template API must discover exactly the five forms,
-and the community profile must recognize both issue and pull-request templates.
-That post-merge evidence is the platform-level GitHub schema/discovery gate.
+The implementation PR references #6 without a closing keyword. After merge,
+GitHub's issue-template API must discover exactly the five forms, every direct
+form URL must render its title and required fields, and the community profile
+must recognize issue and pull-request templates. Only an evidence follow-up may
+use `Closes #6`. This keeps the issue open until the platform-level discovery and
+rendering gate has actually passed.
 
 ## 8. Compatibility, security, and provenance
 

--- a/docs/superpowers/specs/2026-08-06-contribution-intake-design.md
+++ b/docs/superpowers/specs/2026-08-06-contribution-intake-design.md
@@ -1,0 +1,169 @@
+# Contribution Intake and Work Taxonomy Design
+
+- Status: Approved
+- Decision date: 2026-08-06
+- Tracking issue: [#6](https://github.com/thiagocorreanet/mestre-yoda/issues/6)
+- Depends on: [#4](https://github.com/thiagocorreanet/mestre-yoda/issues/4)
+- Approval basis: Maintainer-authorized autonomous recommendation
+
+## 1. Outcome
+
+Every new public issue enters through a GitHub-native form that requests the
+acceptance or reproduction evidence appropriate to its work type. Every pull
+request carries one linked issue, explicit compatibility and risk analysis,
+separate deterministic-test and model-evaluation evidence, provenance, DCO, and
+English confirmations. Contributors can determine the meaning of every label,
+milestone, work ID, and branch without relying on oral convention.
+
+Confidential vulnerability details never enter a public form. GitHub's private
+vulnerability-reporting URL is the primary security contact and remains visible
+from both the issue chooser and the security-safe public form.
+
+## 2. Approaches considered
+
+| Approach | Advantages | Costs | Decision |
+| --- | --- | --- | --- |
+| Free-form Markdown templates | Small and familiar | Weak required-field semantics, ambiguous intake, easy to omit evidence | Rejected |
+| GitHub Issue Forms plus repository contract tests | Native discovery and validation, typed required fields, reviewable YAML, no bot permissions | YAML schema and local draft rendering must be maintained | Selected |
+| Custom intake bot or external form | Arbitrary validation and routing | New credentials, privacy boundary, availability dependency, and maintenance surface | Rejected |
+
+## 3. Issue chooser and forms
+
+`.github/ISSUE_TEMPLATE/config.yml` disables blank public issues. Its first
+contact link routes suspected vulnerabilities and exposed secrets directly to
+GitHub private vulnerability reporting. A second link routes support questions
+to `SUPPORT.md`; neither link creates an issue.
+
+The chooser exposes exactly five public forms:
+
+| File | Purpose | Default labels | Required evidence |
+| --- | --- | --- | --- |
+| `bug.yml` | Reproducible non-security defect | `bug`, `english-only` | affected commit/version, environment, minimal reproduction, expected/actual behavior, regression evidence |
+| `feature.yml` | New behavior or design proposal | `enhancement`, `type:feature`, `english-only` | problem, proposed outcome, acceptance evidence, alternatives, contract/state/security impact |
+| `compatibility.yml` | Go-v3 or host parity regression | `type:research`, `area:compatibility`, `english-only` | oracle/provenance boundary, exact input, expected/observed output, classification, redacted differential evidence |
+| `security-safe.yml` | Public hardening/documentation request with no sensitive details | `type:security`, `area:security`, `english-only` | safe scope, desired hardening, acceptance evidence, mandatory no-vulnerability/no-secret attestations |
+| `documentation.yml` | Public documentation correction | `documentation`, `type:documentation`, `english-only` | location, audience problem, proposed change, acceptance evidence |
+
+All forms begin with a Markdown warning to use normative English, search for a
+duplicate, and exclude secrets, customer data, and private source. All use
+stable kebab-case field IDs, unique within their form. Required checkboxes make
+the public-safety and contribution-policy boundaries explicit.
+
+The security-safe form is intentionally not a vulnerability form. Its title,
+description, opening warning, and required attestations all redirect suspected
+vulnerabilities, secrets, and exploit details to the private advisory URL. It is
+appropriate only for public security hardening, threat-model, or documentation
+work whose full content is safe to disclose.
+
+## 4. Pull-request contract
+
+`.github/pull_request_template.md` is one structured review contract. It asks
+for:
+
+- a closing issue reference and stable work ID;
+- outcome, design choice, alternatives, and scope boundary;
+- public-contract and Go-v3 compatibility impact;
+- state, migration, security, privacy, and rollback impact;
+- a dedicated deterministic-test section with exact commands/results and RED
+  evidence;
+- a separate prompt/model-evaluation section that permits `Not applicable` but
+  never treats probabilistic evaluation as a substitute for deterministic tests;
+- legacy and third-party provenance classification and publication authority;
+- an English-only, DCO, focused-change, documentation, and no-placeholder
+  checklist.
+
+The template does not claim that future CI or branch protection exists. It asks
+contributors to report the evidence available for their change and leaves
+automated enforcement to issue #7.
+
+## 5. Labels, milestones, and stable work IDs
+
+The contributor workflow documents the existing GitHub taxonomy rather than
+silently creating a competing set:
+
+- one `type:*` label describes the work product;
+- one or more `area:*` labels describe affected architecture boundaries;
+- one `priority:p0` through `priority:p3` communicates ordering;
+- `status:blocked` records an unmet dependency;
+- GitHub intake labels such as `bug`, `enhancement`, and `documentation` remain
+  discoverability aliases and may coexist with the namespaced labels;
+- community-routing labels such as `good first issue` and `help wanted` do not
+  change priority or ownership.
+
+Milestones represent delivery campaigns, not due-date promises. Each non-epic
+work item belongs to at most one milestone matching the epic whose exit criteria
+it advances. A bug is assigned to the milestone that owns its fix, not merely
+the version where it was observed. Moving a work item requires a public triage
+rationale.
+
+Backlog work IDs use `[STREAM-NN]` at the start of the title. The maintained
+streams are `FND`, `CMP`, `RUN`, `SDD`, `ADP`, `MIG`, `OBS`, `QAL`, `BET`, and
+`FUT`; coordinating epics use `[EPIC]`. Maintainers allocate the next unused
+positive two-digit sequence within a stream. An assigned ID is immutable and
+never reused, even after closure, transfer, or cancellation. Contributors may
+leave the proposed ID field blank; triage assigns it before work is accepted.
+GitHub issue numbers remain canonical links, while work IDs remain stable human
+references across exports and migrations.
+
+## 6. Branch flow
+
+The target contribution flow is:
+
+```text
+feature/*, fix/*, docs/*, refactor/*
+                    |
+                    v
+               developer
+                    |
+        approved release pull request
+                    |
+                    v
+                  main
+```
+
+Short-lived branches contain one issue and use
+`<type>/<issue-number>-<short-name>`. `developer` is the future integration
+branch; `main` is the protected release line. Issue #60 owns creating that
+branch, changing repository defaults, enabling protection, and publishing the
+release cadence. Until #60 is implemented, contributors follow the base branch
+named by the active repository instructions and PR UI. The template and guide
+label the flow proposed rather than pretending protection already exists.
+
+## 7. Deterministic validation and discoverability
+
+The repository pins `yaml@2.9.0` as a development-only parser and keeps zero
+production dependencies. `tests/github-contribution-contract.test.ts` starts
+red while the templates are absent, then validates:
+
+- the exact chooser/form inventory and parseable YAML object shape;
+- GitHub-supported top-level and body element keys, types, unique IDs, required
+  attributes, valid option shapes, and existing default labels;
+- form-specific reproduction or acceptance evidence;
+- private vulnerability routing and public safety attestations;
+- the PR template's required risk, evidence, provenance, DCO, and English
+  sections;
+- the documented label namespaces, milestones, work-ID streams, immutability,
+  and proposed branch boundary.
+
+The test renders one filled Markdown draft for every form into an operating-
+system temporary directory, verifies that all required fields are discoverable,
+and deletes the draft tree. This proves local draft creation without opening a
+real issue or notifying maintainers.
+
+After merge, GitHub's issue-template API must discover exactly the five forms,
+and the community profile must recognize both issue and pull-request templates.
+That post-merge evidence is the platform-level GitHub schema/discovery gate.
+
+## 8. Compatibility, security, and provenance
+
+This change affects contribution intake only. It does not alter runtime, state,
+schema, migration, SDD, host, or legacy PRD/spec behavior. The private Go
+repository was checked only for repository-template precedent and contains no
+Issue Forms or pull-request template to copy. All public form prose and tests are
+original clean-room work grounded in public GitHub behavior and this repository's
+approved governance rules.
+
+No form accepts credentials, customer/personal data, proprietary source, or
+uncoordinated vulnerability details. The template reinforces that model/prompt
+evaluation is supplementary evidence and cannot weaken deterministic runtime or
+compatibility gates.

--- a/docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md
+++ b/docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md
@@ -157,11 +157,15 @@ an exactly pinned root `devDependency`:
 - `vitest@4.1.10`;
 - `@vitest/coverage-v8@4.1.10`;
 - `cspell@10.0.1`;
+- `yaml@2.9.0`;
 - `esbuild@0.28.1`.
 
 Version ranges are not permitted in manifests. The lockfile is the complete
 transitive resolution. Automated dependency updates must change one logical
 tool family at a time and run the entire verification suite.
+
+YAML is development-only and parses repository configuration in contract tests;
+it cannot enter the embedded runtime artifact.
 
 npm's strict lifecycle-script allowlist permits only the exactly pinned
 `esbuild@0.28.1` installer, which selects its locked native binary. The optional

--- a/docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md
+++ b/docs/superpowers/specs/2026-08-06-typescript-toolchain-design.md
@@ -157,6 +157,7 @@ an exactly pinned root `devDependency`:
 - `vitest@4.1.10`;
 - `@vitest/coverage-v8@4.1.10`;
 - `cspell@10.0.1`;
+- `ajv@8.20.0`;
 - `yaml@2.9.0`;
 - `esbuild@0.28.1`.
 
@@ -164,8 +165,8 @@ Version ranges are not permitted in manifests. The lockfile is the complete
 transitive resolution. Automated dependency updates must change one logical
 tool family at a time and run the entire verification suite.
 
-YAML is development-only and parses repository configuration in contract tests;
-it cannot enter the embedded runtime artifact.
+Ajv and YAML are development-only and validate repository configuration against
+reviewed schemas; they cannot enter the embedded runtime artifact.
 
 npm's strict lifecycle-script allowlist permits only the exactly pinned
 `esbuild@0.28.1` installer, which selects its locked native binary. The optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@eslint/js": "10.0.1",
         "@types/node": "24.13.3",
         "@vitest/coverage-v8": "4.1.10",
+        "ajv": "8.20.0",
         "cspell": "10.0.1",
         "esbuild": "0.28.1",
         "eslint": "10.8.0",
@@ -2135,16 +2136,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2689,6 +2690,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -2817,6 +2842,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3109,9 +3151,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -3696,6 +3738,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "prettier": "3.9.6",
         "typescript": "npm:@typescript/typescript6@6.0.2",
         "typescript-eslint": "8.66.0",
-        "vitest": "4.1.10"
+        "vitest": "4.1.10",
+        "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=24.18.0 <25",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "format:check": "prettier --check .",
     "spellcheck": "cspell --no-progress --show-suggestions \"**/*.md\"",
+    "templates:validate": "node scripts/validate-github-templates.mjs",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc6 --noEmit",
     "test": "vitest run",
@@ -26,6 +27,7 @@
     "@eslint/js": "10.0.1",
     "@types/node": "24.13.3",
     "@vitest/coverage-v8": "4.1.10",
+    "ajv": "8.20.0",
     "cspell": "10.0.1",
     "esbuild": "0.28.1",
     "eslint": "10.8.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "prettier": "3.9.6",
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "typescript-eslint": "8.66.0",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "yaml": "2.9.0"
   },
   "allowScripts": {
     "esbuild@0.28.1": true,

--- a/scripts/validate-github-templates.mjs
+++ b/scripts/validate-github-templates.mjs
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { TextDecoder } from "node:util";
+import { fileURLToPath } from "node:url";
+
+import Ajv from "ajv";
+import { parseDocument } from "yaml";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const templateRoot = join(repositoryRoot, ".github", "ISSUE_TEMPLATE");
+const schemaCommit = "4b00bca7dc9307b9dd34ca13d8c87329d66ad4ce";
+const schemaSha256 =
+  "c2722dbf00334ce4fdeffa960b8c9047caf4f1cbb8f3809663f4d604b1d3ae76";
+const schemaUrl = `https://raw.githubusercontent.com/SchemaStore/schemastore/${schemaCommit}/src/schemas/json/github-issue-forms.json`;
+
+const response = await globalThis.fetch(schemaUrl, {
+  headers: { "user-agent": "mestre-yoda-template-validator" },
+});
+if (!response.ok) {
+  throw new Error(
+    `Unable to fetch pinned GitHub Issue Forms schema: HTTP ${String(response.status)}`,
+  );
+}
+
+const schemaBytes = new Uint8Array(await response.arrayBuffer());
+const observedSha256 = createHash("sha256").update(schemaBytes).digest("hex");
+if (observedSha256 !== schemaSha256) {
+  throw new Error(
+    `Pinned schema hash mismatch: expected ${schemaSha256}, observed ${observedSha256}`,
+  );
+}
+
+const schema = JSON.parse(new TextDecoder().decode(schemaBytes));
+const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
+const filenames = (await readdir(templateRoot))
+  .filter((filename) => filename.endsWith(".yml") && filename !== "config.yml")
+  .sort();
+
+for (const filename of filenames) {
+  const path = join(templateRoot, filename);
+  const source = await readFile(path, "utf8");
+  const document = parseDocument(source, {
+    prettyErrors: true,
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0 || document.warnings.length > 0) {
+    throw new Error(
+      `${filename}: YAML parse findings: ${JSON.stringify([
+        ...document.errors,
+        ...document.warnings,
+      ])}`,
+    );
+  }
+  const value = document.toJS();
+  if (!validate(value)) {
+    throw new Error(
+      `${filename}: GitHub Issue Forms schema findings: ${JSON.stringify(validate.errors)}`,
+    );
+  }
+  process.stdout.write(`valid: ${filename}\n`);
+}
+
+process.stdout.write(`schema-commit: ${schemaCommit}\n`);
+process.stdout.write(`schema-sha256: ${schemaSha256}\n`);
+process.stdout.write(`forms: ${String(filenames.length)}\n`);

--- a/tests/github-contribution-contract.test.ts
+++ b/tests/github-contribution-contract.test.ts
@@ -141,6 +141,7 @@ function validateBodyElement(
     );
   }
   if (type === "checkboxes") {
+    expect(element.validations, context).toBeUndefined();
     expect(Array.isArray(attributes.options), context).toBe(true);
     for (const [index, optionValue] of (
       attributes.options as unknown[]
@@ -153,6 +154,7 @@ function validateBodyElement(
       expect(option.label, context).toEqual(expect.any(String));
       expect(option.required, context).toBe(true);
     }
+    return element;
   }
 
   const validations = object(element.validations, `${context}.validations`);
@@ -204,7 +206,6 @@ describe("GitHub Issue Form schema contract", () => {
       expect(form.name, filename).toEqual(expect.any(String));
       expect(form.description, filename).toEqual(expect.any(String));
       expect(form.title, filename).toMatch(/^\[[A-Z-]+\] /);
-      expect(form.assignees, filename).toEqual([]);
       expect(form.labels, filename).toEqual(
         expect.arrayContaining(["english-only"]),
       );
@@ -328,9 +329,14 @@ describe("pull request and contribution workflow contract", () => {
     ) as {
       dependencies?: Record<string, string>;
       devDependencies: Record<string, string>;
+      scripts: Record<string, string>;
     };
     expect(packageManifest.dependencies).toBeUndefined();
+    expect(packageManifest.devDependencies.ajv).toBe("8.20.0");
     expect(packageManifest.devDependencies.yaml).toBe("2.9.0");
+    expect(packageManifest.scripts["templates:validate"]).toBe(
+      "node scripts/validate-github-templates.mjs",
+    );
   });
 });
 

--- a/tests/github-contribution-contract.test.ts
+++ b/tests/github-contribution-contract.test.ts
@@ -1,0 +1,371 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const templateRoot = join(repositoryRoot, ".github", "ISSUE_TEMPLATE");
+
+const formFiles = [
+  "bug.yml",
+  "compatibility.yml",
+  "documentation.yml",
+  "feature.yml",
+  "security-safe.yml",
+] as const;
+
+const requiredFields: Record<(typeof formFiles)[number], readonly string[]> = {
+  "bug.yml": [
+    "affected-version",
+    "environment",
+    "reproduction",
+    "expected",
+    "actual",
+    "regression-evidence",
+    "policy",
+  ],
+  "compatibility.yml": [
+    "oracle",
+    "provenance",
+    "exact-input",
+    "expected-result",
+    "observed-result",
+    "classification",
+    "differential-evidence",
+    "policy",
+  ],
+  "documentation.yml": [
+    "location",
+    "audience-problem",
+    "proposed-change",
+    "acceptance-evidence",
+    "policy",
+  ],
+  "feature.yml": [
+    "problem",
+    "proposed-outcome",
+    "acceptance-evidence",
+    "alternatives",
+    "impact",
+    "policy",
+  ],
+  "security-safe.yml": [
+    "safe-scope",
+    "desired-hardening",
+    "acceptance-evidence",
+    "public-safety",
+  ],
+};
+
+const existingLabels = new Set([
+  "area:compatibility",
+  "area:security",
+  "bug",
+  "documentation",
+  "english-only",
+  "enhancement",
+  "type:documentation",
+  "type:feature",
+  "type:research",
+  "type:security",
+]);
+
+type JsonObject = Record<string, unknown>;
+
+function object(value: unknown, context: string): JsonObject {
+  expect(value, context).not.toBeNull();
+  expect(Array.isArray(value), context).toBe(false);
+  expect(typeof value, context).toBe("object");
+  return value as JsonObject;
+}
+
+function onlyKeys(
+  value: JsonObject,
+  allowed: readonly string[],
+  context: string,
+): void {
+  expect(
+    Object.keys(value).filter((key) => !allowed.includes(key)),
+    context,
+  ).toEqual([]);
+}
+
+async function readYaml(path: string): Promise<JsonObject> {
+  const source = await readFile(path, "utf8");
+  const document = parseDocument(source, {
+    prettyErrors: true,
+    uniqueKeys: true,
+  });
+  expect(document.errors, path).toEqual([]);
+  expect(document.warnings, path).toEqual([]);
+  return object(document.toJS(), path);
+}
+
+function validateBodyElement(
+  elementValue: unknown,
+  context: string,
+): JsonObject {
+  const element = object(elementValue, context);
+  const type = element.type;
+  expect(["markdown", "input", "textarea", "dropdown", "checkboxes"]).toContain(
+    type,
+  );
+
+  if (type === "markdown") {
+    onlyKeys(element, ["type", "attributes"], context);
+    const attributes = object(element.attributes, `${context}.attributes`);
+    expect(Object.keys(attributes), `${context}.attributes`).toEqual(["value"]);
+    expect(attributes.value, context).toEqual(expect.any(String));
+    return element;
+  }
+
+  onlyKeys(element, ["type", "id", "attributes", "validations"], context);
+  expect(element.id, context).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+  const attributes = object(element.attributes, `${context}.attributes`);
+  expect(attributes.label, context).toEqual(expect.any(String));
+
+  const allowedAttributeKeys: Record<string, readonly string[]> = {
+    input: ["label", "description", "placeholder", "value"],
+    textarea: ["label", "description", "placeholder", "value", "render"],
+    dropdown: ["label", "description", "multiple", "options"],
+    checkboxes: ["label", "description", "options"],
+  };
+  onlyKeys(attributes, allowedAttributeKeys[String(type)] ?? [], context);
+
+  if (type === "dropdown") {
+    expect(attributes.options, context).toEqual(
+      expect.arrayContaining([expect.any(String)]),
+    );
+  }
+  if (type === "checkboxes") {
+    expect(Array.isArray(attributes.options), context).toBe(true);
+    for (const [index, optionValue] of (
+      attributes.options as unknown[]
+    ).entries()) {
+      const option = object(
+        optionValue,
+        `${context}.options[${String(index)}]`,
+      );
+      onlyKeys(option, ["label", "required"], context);
+      expect(option.label, context).toEqual(expect.any(String));
+      expect(option.required, context).toBe(true);
+    }
+  }
+
+  const validations = object(element.validations, `${context}.validations`);
+  expect(validations).toEqual({ required: true });
+  return element;
+}
+
+async function readForm(
+  filename: (typeof formFiles)[number],
+): Promise<JsonObject> {
+  return readYaml(join(templateRoot, filename));
+}
+
+describe("GitHub Issue Form schema contract", () => {
+  it("exposes exactly five forms and one chooser configuration", async () => {
+    expect((await readdir(templateRoot)).sort()).toEqual(
+      [...formFiles, "config.yml"].sort(),
+    );
+  });
+
+  it("disables blank issues and routes confidential reports privately first", async () => {
+    const config = await readYaml(join(templateRoot, "config.yml"));
+    onlyKeys(config, ["blank_issues_enabled", "contact_links"], "config.yml");
+    expect(config.blank_issues_enabled).toBe(false);
+    expect(Array.isArray(config.contact_links)).toBe(true);
+    const contactLinks = config.contact_links as unknown[];
+    expect(contactLinks).toHaveLength(2);
+    const security = object(contactLinks[0], "config.yml.contact_links[0]");
+    const support = object(contactLinks[1], "config.yml.contact_links[1]");
+    expect(security.name).toMatch(/vulnerability/i);
+    expect(security.url).toBe(
+      "https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new",
+    );
+    expect(support.name).toMatch(/support/i);
+    expect(support.url).toBe(
+      "https://github.com/thiagocorreanet/mestre-yoda/blob/main/SUPPORT.md",
+    );
+  });
+
+  it.each(formFiles)(
+    "validates GitHub schema and policy for %s",
+    async (filename) => {
+      const form = await readForm(filename);
+      onlyKeys(
+        form,
+        ["name", "description", "title", "labels", "assignees", "body"],
+        filename,
+      );
+      expect(form.name, filename).toEqual(expect.any(String));
+      expect(form.description, filename).toEqual(expect.any(String));
+      expect(form.title, filename).toMatch(/^\[[A-Z-]+\] /);
+      expect(form.assignees, filename).toEqual([]);
+      expect(form.labels, filename).toEqual(
+        expect.arrayContaining(["english-only"]),
+      );
+      for (const label of form.labels as string[]) {
+        expect(
+          existingLabels.has(label),
+          `${filename}: unknown label ${label}`,
+        ).toBe(true);
+      }
+
+      expect(Array.isArray(form.body), filename).toBe(true);
+      const elements = (form.body as unknown[]).map((element, index) =>
+        validateBodyElement(element, `${filename}.body[${String(index)}]`),
+      );
+      const ids = elements.flatMap((element) =>
+        typeof element.id === "string" ? [element.id] : [],
+      );
+      expect(new Set(ids).size, `${filename}: duplicate IDs`).toBe(ids.length);
+      expect(ids, filename).toEqual(
+        expect.arrayContaining([...requiredFields[filename]]),
+      );
+
+      const markdown = elements
+        .filter((element) => element.type === "markdown")
+        .map((element) => object(element.attributes, filename).value)
+        .join("\n");
+      expect(markdown).toMatch(/English/i);
+      expect(markdown).toMatch(/secret|private data/i);
+    },
+  );
+
+  it("makes the public security-safe form impossible to mistake for disclosure", async () => {
+    const form = await readForm("security-safe.yml");
+    const source = JSON.stringify(form);
+    expect(source).toMatch(/public security hardening/i);
+    expect(source).toContain(
+      "https://github.com/thiagocorreanet/mestre-yoda/security/advisories/new",
+    );
+    expect(source).toMatch(/do not.*vulnerabilit/i);
+    expect(source).toMatch(/no suspected vulnerability/i);
+    expect(source).toMatch(/no secret/i);
+  });
+});
+
+describe("pull request and contribution workflow contract", () => {
+  it("separates deterministic evidence from model evaluations", async () => {
+    const template = await readFile(
+      join(repositoryRoot, ".github", "pull_request_template.md"),
+      "utf8",
+    );
+    for (const heading of [
+      "## Linked issue and work ID",
+      "## Outcome and design",
+      "## Compatibility and public contracts",
+      "## State, migration, security, and rollback",
+      "## Deterministic test evidence",
+      "## Prompt and model evaluations",
+      "## Failure evidence",
+      "## Provenance",
+      "## Checklist",
+    ]) {
+      expect(template).toContain(heading);
+    }
+    expect(template).toContain("Closes #ISSUE_NUMBER");
+    expect(template).toMatch(/not a substitute for deterministic tests/i);
+    expect(template).toMatch(/Signed-off-by|DCO/);
+    expect(template).toMatch(/normative English/i);
+  });
+
+  it("documents labels, milestones, stable IDs, and proposed branches", async () => {
+    const workflow = await readFile(
+      join(repositoryRoot, "docs", "contributing", "workflow.md"),
+      "utf8",
+    );
+    for (const namespace of [
+      "type:*",
+      "area:*",
+      "priority:p0",
+      "status:blocked",
+    ]) {
+      expect(workflow).toContain(`\`${namespace}\``);
+    }
+    for (const milestone of [
+      "Foundation",
+      "Compatibility Contract",
+      "Deterministic Runtime",
+      "SDD Workflow Parity",
+      "Host Integrations",
+      "Migration and Observability",
+      "Quality Campaign",
+      "Public Beta",
+      "Post-1.0 Ideas",
+    ]) {
+      expect(workflow).toContain(milestone);
+    }
+    for (const stream of [
+      "FND",
+      "CMP",
+      "RUN",
+      "SDD",
+      "ADP",
+      "MIG",
+      "OBS",
+      "QAL",
+      "BET",
+      "FUT",
+    ]) {
+      expect(workflow).toMatch(new RegExp(`\\b${stream}\\b`));
+    }
+    expect(workflow).toContain("[STREAM-NN]");
+    expect(workflow).toMatch(/immutable/i);
+    expect(workflow).toMatch(/never reused/i);
+    expect(workflow).toMatch(/`developer`.*`main`/s);
+    expect(workflow).toContain("issue #60");
+    expect(workflow).toMatch(/proposed.*not active/is);
+  });
+
+  it("keeps YAML development-only", async () => {
+    const packageManifest = JSON.parse(
+      await readFile(join(repositoryRoot, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(packageManifest.dependencies).toBeUndefined();
+    expect(packageManifest.devDependencies.yaml).toBe("2.9.0");
+  });
+});
+
+describe("local draft discovery", () => {
+  it("renders and removes one complete temporary draft per form", async () => {
+    const draftRoot = await mkdtemp(
+      join(tmpdir(), "mestre-yoda-issue-drafts-"),
+    );
+    try {
+      for (const filename of formFiles) {
+        const form = await readForm(filename);
+        const sections = (form.body as unknown[])
+          .map((value, index) =>
+            validateBodyElement(value, `${filename}.body[${String(index)}]`),
+          )
+          .filter((element) => element.type !== "markdown")
+          .map((element) => {
+            const attributes = object(element.attributes, filename);
+            return `## ${String(attributes.label)}\n\nLocal draft value for ${String(element.id)}.`;
+          });
+        const draft = `# ${String(form.name)}\n\n${sections.join("\n\n")}\n`;
+        const draftPath = join(draftRoot, filename.replace(/\.yml$/, ".md"));
+        await writeFile(draftPath, draft, "utf8");
+        const rendered = await readFile(draftPath, "utf8");
+        for (const id of requiredFields[filename]) {
+          expect(rendered, `${filename}: missing ${id}`).toContain(
+            `Local draft value for ${id}.`,
+          );
+        }
+      }
+      expect((await readdir(draftRoot)).sort()).toEqual(
+        formFiles.map((filename) => filename.replace(/\.yml$/, ".md")).sort(),
+      );
+    } finally {
+      await rm(draftRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
References #6. This implementation PR intentionally does not close the issue; platform discovery and rendering must pass on main first.

## Outcome and design

Adds five GitHub Issue Forms, private security routing, one PR review contract, and versioned label/milestone/work-ID/branch-flow guidance. The developer integration flow remains explicitly proposed and owned by #60.

## Compatibility and risk

No runtime, state, migration, host, PRD, or spec behavior changes. Ajv 8.20.0 and YAML 2.9.0 are development-only; the embedded bundle remains unchanged. Public security intake rejects vulnerability, exploit, secret, private-data, and proprietary-source details.

## Test-first and verification evidence

The contract initially failed 11 tests because all intake artifacts were absent. Current results:

- npm run verify: 6 files, 42 tests, pass
- coverage: 100 percent configured runtime surface
- npm run templates:validate: five forms valid against immutable schema commit and SHA-256
- focused contract: 12 tests, pass; five temporary local drafts created/verified/removed
- CSpell: 30 Markdown files and 8 form/template files, zero issues
- markdownlint: 31 files, zero errors
- Lychee: 117 links, zero errors
- package verifier: unchanged sole 386-byte ESM artifact and hash
- independent final review: no Critical, Important, or Minor findings

Full evidence: docs/contributing/verification.md. After this merge, a separate evidence PR will record GitHub API/UI discovery and close #6.