### PR TITLE
docs: record GitHub contribution template discovery

### DIFF
--- a/docs/contributing/verification.md
+++ b/docs/contributing/verification.md
@@ -1,10 +1,11 @@
 # Contribution Intake Verification
 
-- Verification date: 2026-08-06 (America/Sao_Paulo)
+- Local verification date: 2026-08-06 (America/Sao_Paulo)
+- Platform verification date: 2026-08-07 (America/Sao_Paulo)
 - Tracking issue: [#6](https://github.com/thiagocorreanet/mestre-yoda/issues/6)
 - Branch: `docs/issue-6-contribution-templates`
 - Reviewed implementation commit: `b9c5876`
-- Status: Implementation ready; platform discovery and issue closure pending
+- Status: Complete through the platform gate; this evidence follow-up closes #6
 
 ## Test-first evidence
 
@@ -87,22 +88,48 @@ No runtime, state, migration, host, PRD, or spec behavior changed.
 The first independent review found that a hand-written schema subset could not
 prove GitHub fidelity and that the original publication order closed #6 before
 platform discovery. The complete pinned-schema validator was added, and the
-implementation PR will not contain a closing keyword. A follow-up can close #6
-only after GitHub discovers and renders every form on `main`.
+publication flow was split so a follow-up can close #6 only after GitHub renders
+every form on `main`.
 
 Re-review found one contradictory sentence describing the offline `verify`
 chain; the guide now separates it from the online pinned-schema command. Final
 review reported no Critical, Important, or Minor findings.
 
-## Pending platform gate
+## GitHub platform discovery and rendering
 
-After the implementation merge, evidence must still prove:
+Implementation PR [#76](https://github.com/thiagocorreanet/mestre-yoda/pull/76)
+merged as `7210222db48edb98309807aea0f6dde223bde63c`. Its Documentation check passed,
+and the merge commit passed again on `main` in
+[run 31144110180](https://github.com/thiagocorreanet/mestre-yoda/actions/runs/31144110180).
 
-- GitHub's issue-template API discovers exactly five forms;
-- the community profile recognizes issue and pull-request templates;
-- each direct `issues/new?template=<filename>` URL renders the expected title and
-  required fields;
-- the implementation PR and `main` Documentation workflow are green.
+The PR body avoided `Closes #6`, but the explanatory phrase `close #6` was also
+recognized by GitHub as a closing keyword. Issue #6 was immediately reopened
+before platform testing and remained open throughout the gate.
 
-Issue #6 must remain open until those observations are recorded and merged in a
-follow-up PR carrying `Closes #6`.
+An authenticated clean chooser inspection at
+[`issues/new/choose`](https://github.com/thiagocorreanet/mestre-yoda/issues/new/choose)
+rendered exactly these five forms in source order, both configured contact links,
+GitHub's native private vulnerability entry, and `Blank issue — Maintainers only`:
+
+| Direct form | Rendered title | Visible first required evidence | Labels rendered |
+| --- | --- | --- | --- |
+| [`bug.yml`](https://github.com/thiagocorreanet/mestre-yoda/issues/new?template=bug.yml) | `[BUG]` | Affected version or commit | `bug`, `english-only` |
+| [`compatibility.yml`](https://github.com/thiagocorreanet/mestre-yoda/issues/new?template=compatibility.yml) | `[COMPATIBILITY]` | Oracle and compared build | `area:compatibility`, `english-only`, `type:research` |
+| [`documentation.yml`](https://github.com/thiagocorreanet/mestre-yoda/issues/new?template=documentation.yml) | `[DOCUMENTATION]` | Documentation location | `documentation`, `english-only`, `type:documentation` |
+| [`feature.yml`](https://github.com/thiagocorreanet/mestre-yoda/issues/new?template=feature.yml) | `[FEATURE]` | Problem and user impact | `english-only`, `enhancement`, `type:feature` |
+| [`security-safe.yml`](https://github.com/thiagocorreanet/mestre-yoda/issues/new?template=security-safe.yml) | `[SECURITY-SAFE]` | Public and non-sensitive scope | `area:security`, `english-only`, `type:security` |
+
+Every direct URL rendered a GitHub Issue Form with required-field asterisks and
+the expected descriptions/placeholders. No issue was submitted and no
+notification was created.
+
+GitHub's GraphQL `pullRequestTemplates` field returned the complete repository
+PR template, and the community profile recognized it at the canonical path with
+100% health. In the same observation, GraphQL `issueTemplates` was empty and the
+community profile's legacy `issue_template` field was null even though the Issue
+Forms visibly rendered. Those legacy/template metadata fields are therefore not
+used as Issue Forms discovery evidence; the authenticated chooser and five
+direct rendered forms are the platform gate.
+
+All required platform observations now exist. This evidence follow-up carries
+`Closes #6`, so closure occurs only when the verified record merges.

--- a/docs/superpowers/plans/2026-08-06-contribution-intake.md
+++ b/docs/superpowers/plans/2026-08-06-contribution-intake.md
@@ -233,16 +233,19 @@ Record exact versions, test/file/link counts, local temporary draft inventory,
 form labels/required fields, review outcome, DCO trailers, and no production
 dependency/runtime-bundle change.
 
-- [ ] **Step 4: Publish implementation without closing the issue**
+- [x] **Step 4: Publish implementation and preserve the platform gate**
 
-Push `docs/issue-6-contribution-templates`, open a signed PR that references but
-does not close #6, wait for all available checks, merge, confirm issue #6 remains
-open, and synchronize `main`.
+Push `docs/issue-6-contribution-templates`, open a signed PR intended to reference
+without closing #6, wait for all available checks, merge, and synchronize `main`.
+If explanatory wording is interpreted as a closing keyword, reopen #6 immediately
+and confirm it remains open throughout platform verification. PR #76 triggered
+that recovery path and #6 was reopened before the gate began.
 
-- [ ] **Step 5: Prove platform discovery, record evidence, and close**
+- [x] **Step 5: Prove platform discovery, record evidence, and close**
 
-Use GitHub's issue-template and community-profile APIs to verify exactly five
-forms plus recognized issue/PR template paths on `main`. Open every direct form
-URL and verify its rendered title/required fields. Record the merged commit and
-green workflow, publish an evidence follow-up with `Closes #6`, merge it, confirm
-issue #6 closed, then begin issue #7.
+Use GitHub's authenticated chooser and direct form URLs to verify exactly five
+rendered forms, titles, labels, and required fields on `main`. Use platform
+metadata for the PR template and record any Issue Forms metadata limitation
+honestly. Record the merged commit and green workflow, publish an evidence
+follow-up with `Closes #6`, merge it, confirm issue #6 closed, then begin issue
+number 7.

--- a/docs/superpowers/specs/2026-08-06-contribution-intake-design.md
+++ b/docs/superpowers/specs/2026-08-06-contribution-intake-design.md
@@ -156,12 +156,18 @@ system temporary directory, verifies that all required fields are discoverable,
 and deletes the draft tree. This proves local draft creation without opening a
 real issue or notifying maintainers.
 
-The implementation PR references #6 without a closing keyword. After merge,
-GitHub's issue-template API must discover exactly the five forms, every direct
-form URL must render its title and required fields, and the community profile
-must recognize issue and pull-request templates. Only an evidence follow-up may
-use `Closes #6`. This keeps the issue open until the platform-level discovery and
-rendering gate has actually passed.
+The implementation PR is intended to reference #6 without automatic closure.
+Any accidental closing-keyword match must be recovered by immediately reopening
+issue #6 before platform verification. After merge, the authenticated GitHub chooser
+must show exactly five forms, and every direct form URL must render its title,
+labels, and required fields. Platform metadata must also recognize the
+pull-request template; Issue Forms are proven through their native chooser/
+rendering surface when legacy template metadata does not enumerate them. Only
+an evidence follow-up intentionally closes #6 after this platform gate passes.
+
+PR #76 demonstrated the recovery rule: explanatory text containing `close #6`
+was interpreted as a closing keyword, so maintainers reopened #6 immediately
+before beginning platform verification.
 
 ## 8. Compatibility, security, and provenance
 


### PR DESCRIPTION
Closes #6

## Platform evidence

PR #76 merged the validated intake artifacts as commit 7210222db48edb98309807aea0f6dde223bde63c. Documentation passed on the PR and main.

Authenticated GitHub inspection then proved:

- chooser renders exactly bug, compatibility, documentation, feature, and security-safe forms
- chooser renders both configured contact links and GitHub private vulnerability reporting
- blank issue is restricted to maintainers
- every direct form URL renders its expected title, labels, required-field asterisks, descriptions, and placeholders
- GraphQL and community profile recognize the complete PR template; health is 100 percent
- no issue was submitted and no notification was created

The record also documents that legacy issueTemplates/community metadata does not enumerate the visibly rendered Issue Forms, and accurately records #6 immediate reopening after PR #76 explanatory wording triggered an unintended closing match. Issue #6 remained open during the platform gate.

Verification: CSpell 30 files zero issues; markdownlint 31 files zero errors; 9 evidence links zero failures; git diff --check pass; independent final review zero findings.