### PR TITLE
ci: add pull-request quality foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -43,66 +43,68 @@ jobs:
 
       - name: Verify exact toolchain
         run: |
-          set -o pipefail
+          set -euo pipefail
           {
-            node --version
-            npm --version
-            test "$(node --version)" = "v24.18.0"
-            test "$(npm --version)" = "11.16.0"
+            node_version="$(node --version)"
+            npm_version="$(npm --version)"
+            printf '%s\n' "$node_version"
+            printf '%s\n' "$npm_version"
+            test "$node_version" = "v24.18.0"
+            test "$npm_version" = "11.16.0"
           } 2>&1 | tee .ci-diagnostics/toolchain.log
 
       - name: Install locked dependencies
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm ci 2>&1 | tee .ci-diagnostics/install.log
 
       - name: Check formatting
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run format:check 2>&1 | tee .ci-diagnostics/format.log
 
       - name: Check spelling
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run spellcheck 2>&1 | tee .ci-diagnostics/spelling.log
 
       - name: Lint
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run lint 2>&1 | tee .ci-diagnostics/lint.log
 
       - name: Type-check
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run typecheck 2>&1 | tee .ci-diagnostics/type-check.log
 
       - name: Run unit tests
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm test 2>&1 | tee .ci-diagnostics/unit-tests.log
 
       - name: Run coverage tests
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run test:coverage 2>&1 | tee .ci-diagnostics/coverage.log
 
       - name: Validate GitHub template schemas
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run templates:validate 2>&1 | tee .ci-diagnostics/templates.log
 
       - name: Build bundle
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run build 2>&1 | tee .ci-diagnostics/build.log
 
       - name: Verify package contents
         run: |
-          set -o pipefail
+          set -euo pipefail
           npm run package:verify 2>&1 | tee .ci-diagnostics/package.log
 
       - name: Upload failure diagnostics
-        if: ${{ failure() }}
+        if: ${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-failure-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - developer
+      - main
+  push:
+    branches:
+      - developer
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  quality:
+    name: Node quality and package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CI: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up exact Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          check-latest: false
+          package-manager-cache: false
+
+      - name: Prepare diagnostics
+        run: mkdir -p .ci-diagnostics
+
+      - name: Verify exact toolchain
+        run: |
+          set -o pipefail
+          {
+            node --version
+            npm --version
+            test "$(node --version)" = "v24.18.0"
+            test "$(npm --version)" = "11.16.0"
+          } 2>&1 | tee .ci-diagnostics/toolchain.log
+
+      - name: Install locked dependencies
+        run: |
+          set -o pipefail
+          npm ci 2>&1 | tee .ci-diagnostics/install.log
+
+      - name: Check formatting
+        run: |
+          set -o pipefail
+          npm run format:check 2>&1 | tee .ci-diagnostics/format.log
+
+      - name: Check spelling
+        run: |
+          set -o pipefail
+          npm run spellcheck 2>&1 | tee .ci-diagnostics/spelling.log
+
+      - name: Lint
+        run: |
+          set -o pipefail
+          npm run lint 2>&1 | tee .ci-diagnostics/lint.log
+
+      - name: Type-check
+        run: |
+          set -o pipefail
+          npm run typecheck 2>&1 | tee .ci-diagnostics/type-check.log
+
+      - name: Run unit tests
+        run: |
+          set -o pipefail
+          npm test 2>&1 | tee .ci-diagnostics/unit-tests.log
+
+      - name: Run coverage tests
+        run: |
+          set -o pipefail
+          npm run test:coverage 2>&1 | tee .ci-diagnostics/coverage.log
+
+      - name: Validate GitHub template schemas
+        run: |
+          set -o pipefail
+          npm run templates:validate 2>&1 | tee .ci-diagnostics/templates.log
+
+      - name: Build bundle
+        run: |
+          set -o pipefail
+          npm run build 2>&1 | tee .ci-diagnostics/build.log
+
+      - name: Verify package contents
+        run: |
+          set -o pipefail
+          npm run package:verify 2>&1 | tee .ci-diagnostics/package.log
+
+      - name: Upload failure diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .ci-diagnostics/
+            coverage/
+            dist/
+          if-no-files-found: ignore
+          retention-days: 3
+          compression-level: 6
+          include-hidden-files: true

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 **The model will propose. The runtime will decide. The event log will prove.**
 
 [![Project Status: Experimental](https://img.shields.io/badge/status-experimental-orange.svg)](#project-status)
+[![CI](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/ci.yml)
 [![Documentation](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml/badge.svg?branch=main)](https://github.com/thiagocorreanet/mestre-yoda/actions/workflows/docs.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Language: English](https://img.shields.io/badge/project_language-English-1f6feb.svg)](#contributing)

--- a/docs/development/toolchain.md
+++ b/docs/development/toolchain.md
@@ -56,10 +56,12 @@ distinct online step between coverage and build; CI does not hide additional
 validation behavior from local contributors.
 
 Checks run sequentially after one locked installation, so the first invalid
-stage names the blocking concern directly. A failed run uploads the completed
-step logs plus any existing coverage and build output as a diagnostic artifact
-for three days. The artifact intentionally excludes npm user logs, environment
-dumps, and secrets.
+stage names the blocking concern directly. A failed trusted-branch or
+same-repository pull-request run uploads the completed step logs plus any
+existing coverage and build output as a diagnostic artifact for three days.
+Fork pull requests keep their step logs in Actions but cannot upload artifacts,
+which prevents untrusted code from substituting paths. Artifacts intentionally
+exclude npm user logs, environment dumps, and secrets.
 
 The workflow uses the `pull_request` event, read-only repository permissions,
 no secret references, no persisted checkout credentials, and standard

--- a/docs/development/toolchain.md
+++ b/docs/development/toolchain.md
@@ -46,9 +46,26 @@ contract changes. It requires network access only to retrieve the immutable,
 hash-verified schema snapshot; `npm run verify` remains reproducible offline
 after `npm ci`.
 
-Issue [#7](https://github.com/thiagocorreanet/mestre-yoda/issues/7) will add the
-Node pull-request workflow. It must call these commands and must not introduce
-CI-only validation behavior.
+## Pull-request CI
+
+The [CI workflow](../../.github/workflows/ci.yml) runs on pull requests and
+pushes targeting `developer` or `main`. It selects the exact Node version from
+`.nvmrc`, verifies both Node and npm, installs with `npm ci`, and executes the
+same repository commands documented above. Template schema validation remains a
+distinct online step between coverage and build; CI does not hide additional
+validation behavior from local contributors.
+
+Checks run sequentially after one locked installation, so the first invalid
+stage names the blocking concern directly. A failed run uploads the completed
+step logs plus any existing coverage and build output as a diagnostic artifact
+for three days. The artifact intentionally excludes npm user logs, environment
+dumps, and secrets.
+
+The workflow uses the `pull_request` event, read-only repository permissions,
+no secret references, no persisted checkout credentials, and standard
+GitHub-hosted runners. Superseded pull-request commits are cancelled; branch
+pushes are allowed to finish. Those controls make contribution checks safe for
+untrusted fork code without granting it repository write authority.
 
 ## Workspace ownership
 

--- a/docs/superpowers/plans/2026-08-07-pull-request-ci.md
+++ b/docs/superpowers/plans/2026-08-07-pull-request-ci.md
@@ -13,7 +13,7 @@
 - Trigger only on pull requests and pushes targeting `developer` or `main`, plus manual dispatch.
 - Use `pull_request`, never `pull_request_target`; reference no secrets and grant only `contents: read`.
 - Pin every third-party action to an immutable full commit SHA with a release comment.
-- Cancel superseded pull-request runs but never cancel branch pushes.
+- Cancel superseded pull-request runs but give every branch push a unique concurrency group so pending pushes are also preserved.
 - Run on `ubuntu-latest`, cap the job at 15 minutes, and retain failure diagnostics for three days.
 - Install with `npm ci` and verify the exact Node.js and npm versions before quality checks.
 - Keep issue #7 open until GitHub-hosted success and deliberate-failure evidence exists.
@@ -31,15 +31,16 @@
 - Consumes: `.github/workflows/ci.yml`, `package.json`, and the approved CI design.
 - Produces: deterministic assertions for triggers, permissions, concurrency, runner, timeouts, pinned actions, command order, diagnostics, and fork-safe exclusions.
 
-- [ ] **Step 1: Write the workflow contract test**
+- [x] **Step 1: Write the workflow contract test**
 
 Parse the workflow with the pinned `yaml` package. Assert exact protected branches,
-read-only permissions, pull-request-only cancellation, one `ubuntu-latest` job,
+read-only permissions without job overrides, pull-request-only cancellation,
+unique branch-push groups, no ignored failures, one `ubuntu-latest` job,
 the 15-minute timeout, exact action SHAs and inputs, expected command order,
 failure-only artifact policy, and the absence of secrets, elevated permissions,
 publishing, deployment, or `pull_request_target` behavior.
 
-- [ ] **Step 2: Confirm RED**
+- [x] **Step 2: Confirm RED**
 
 Run:
 
@@ -49,7 +50,7 @@ npm test -- tests/ci-workflow-contract.test.ts
 
 Expected: FAIL because `.github/workflows/ci.yml` does not exist.
 
-- [ ] **Step 3: Commit the failing contract**
+- [x] **Step 3: Commit the failing contract**
 
 ```bash
 git add tests/ci-workflow-contract.test.ts
@@ -68,13 +69,13 @@ git commit -s -m "test: specify pull-request CI contract"
 - Consumes: `.nvmrc`, `package-lock.json`, root npm scripts, and the immutable action SHAs in the design.
 - Produces: the `CI / Node quality and package` required-check candidate and three-day failure diagnostics.
 
-- [ ] **Step 1: Add triggers, permissions, concurrency, and the bounded job**
+- [x] **Step 1: Add triggers, permissions, concurrency, and the bounded job**
 
 Configure `pull_request`, `push`, and `workflow_dispatch`; grant only
 `contents: read`; cancel superseded pull-request runs; define one
 `ubuntu-latest` job with `timeout-minutes: 15` and `CI: "true"`.
 
-- [ ] **Step 2: Add the pinned setup and validation pipeline**
+- [x] **Step 2: Add the pinned setup and validation pipeline**
 
 Pin checkout, setup-node, and upload-artifact to their approved full SHAs.
 Disable persisted Git credentials and package-manager caching. Verify the exact
@@ -83,13 +84,14 @@ type-checking, unit tests, coverage, template schema validation, build, and
 package verification in that order. Pipe each command through `tee` with shell
 pipeline failure propagation into `.ci-diagnostics`.
 
-- [ ] **Step 3: Add failure-only diagnostics**
+- [x] **Step 3: Add failure-only diagnostics**
 
-Upload only fixed repository paths on failure, ignore absent optional paths,
-include hidden diagnostic files, and retain the artifact for exactly three days.
-Do not upload npm user logs or environment dumps.
+Upload only fixed repository paths for failures from trusted repository refs,
+ignore absent optional paths, include hidden diagnostic files, and retain the
+artifact for exactly three days. Do not upload artifacts for fork pull requests,
+npm user logs, or environment dumps.
 
-- [ ] **Step 4: Confirm GREEN and validate Actions syntax**
+- [x] **Step 4: Confirm GREEN and validate Actions syntax**
 
 Run:
 
@@ -100,7 +102,7 @@ go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.y
 
 Expected: contract tests pass and actionlint emits no diagnostics.
 
-- [ ] **Step 5: Commit the workflow**
+- [x] **Step 5: Commit the workflow**
 
 ```bash
 git add .github/workflows/ci.yml tests/ci-workflow-contract.test.ts
@@ -119,18 +121,18 @@ git commit -s -m "ci: add pull-request quality foundation"
 - Consumes: the implemented workflow and its exact local command sequence.
 - Produces: an honest CI badge and documentation for local reproduction and diagnostics.
 
-- [ ] **Step 1: Add the real CI status badge**
+- [x] **Step 1: Add the real CI status badge**
 
 Link the README badge to `.github/workflows/ci.yml` on `main`; do not add
 coverage or release badges without published services.
 
-- [ ] **Step 2: Document local parity and diagnostic behavior**
+- [x] **Step 2: Document local parity and diagnostic behavior**
 
 Explain the exact pinned runtime, `npm ci`, `npm run verify`, the separate
 template-schema command, sequential failure behavior, and the three-day
 failure artifact without promising a required branch-protection rule.
 
-- [ ] **Step 3: Run focused documentation checks and commit**
+- [x] **Step 3: Run focused documentation checks and commit**
 
 ```bash
 npm run format:check
@@ -151,7 +153,7 @@ git commit -s -m "docs: explain pull-request CI checks"
 - Consumes: Tasks 1–3.
 - Produces: a reviewed implementation pull request merged into `main`, while issue #7 remains open for platform evidence.
 
-- [ ] **Step 1: Run the clean local quality suite**
+- [x] **Step 1: Run the clean local quality suite**
 
 ```bash
 npm ci

--- a/docs/superpowers/plans/2026-08-07-pull-request-ci.md
+++ b/docs/superpowers/plans/2026-08-07-pull-request-ci.md
@@ -163,7 +163,7 @@ go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.y
 git diff --check
 ```
 
-- [ ] **Step 2: Obtain an independent code review**
+- [x] **Step 2: Obtain an independent code review**
 
 Resolve every technically valid finding and rerun affected checks.
 

--- a/docs/superpowers/plans/2026-08-07-pull-request-ci.md
+++ b/docs/superpowers/plans/2026-08-07-pull-request-ci.md
@@ -1,0 +1,228 @@
+# Pull-request CI Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Protect pull requests to `developer` and `main` with a least-privilege, deterministic CI workflow that reports useful short-lived diagnostics and demonstrably blocks invalid lint, types, tests, and package contents.
+
+**Architecture:** One sequential GitHub-hosted job installs the pinned npm lockfile once and runs every existing repository quality command in dependency order. A Vitest contract test treats the workflow as configuration code, while a disposable pull request proves the four required failure paths and the final green path on GitHub.
+
+**Tech Stack:** GitHub Actions, Node.js 24.18.0, npm 11.16.0, YAML 2.9.0, Vitest 4.1.10, actionlint 1.7.12.
+
+## Global Constraints
+
+- Trigger only on pull requests and pushes targeting `developer` or `main`, plus manual dispatch.
+- Use `pull_request`, never `pull_request_target`; reference no secrets and grant only `contents: read`.
+- Pin every third-party action to an immutable full commit SHA with a release comment.
+- Cancel superseded pull-request runs but never cancel branch pushes.
+- Run on `ubuntu-latest`, cap the job at 15 minutes, and retain failure diagnostics for three days.
+- Install with `npm ci` and verify the exact Node.js and npm versions before quality checks.
+- Keep issue #7 open until GitHub-hosted success and deliberate-failure evidence exists.
+
+---
+
+### Task 1: Specify the workflow as an executable contract
+
+**Files:**
+
+- Create: `tests/ci-workflow-contract.test.ts`
+
+**Interfaces:**
+
+- Consumes: `.github/workflows/ci.yml`, `package.json`, and the approved CI design.
+- Produces: deterministic assertions for triggers, permissions, concurrency, runner, timeouts, pinned actions, command order, diagnostics, and fork-safe exclusions.
+
+- [ ] **Step 1: Write the workflow contract test**
+
+Parse the workflow with the pinned `yaml` package. Assert exact protected branches,
+read-only permissions, pull-request-only cancellation, one `ubuntu-latest` job,
+the 15-minute timeout, exact action SHAs and inputs, expected command order,
+failure-only artifact policy, and the absence of secrets, elevated permissions,
+publishing, deployment, or `pull_request_target` behavior.
+
+- [ ] **Step 2: Confirm RED**
+
+Run:
+
+```bash
+npm test -- tests/ci-workflow-contract.test.ts
+```
+
+Expected: FAIL because `.github/workflows/ci.yml` does not exist.
+
+- [ ] **Step 3: Commit the failing contract**
+
+```bash
+git add tests/ci-workflow-contract.test.ts
+git commit -s -m "test: specify pull-request CI contract"
+```
+
+### Task 2: Implement the least-privilege CI workflow
+
+**Files:**
+
+- Create: `.github/workflows/ci.yml`
+- Modify: `tests/ci-workflow-contract.test.ts` only if the executable contract exposes a design ambiguity.
+
+**Interfaces:**
+
+- Consumes: `.nvmrc`, `package-lock.json`, root npm scripts, and the immutable action SHAs in the design.
+- Produces: the `CI / Node quality and package` required-check candidate and three-day failure diagnostics.
+
+- [ ] **Step 1: Add triggers, permissions, concurrency, and the bounded job**
+
+Configure `pull_request`, `push`, and `workflow_dispatch`; grant only
+`contents: read`; cancel superseded pull-request runs; define one
+`ubuntu-latest` job with `timeout-minutes: 15` and `CI: "true"`.
+
+- [ ] **Step 2: Add the pinned setup and validation pipeline**
+
+Pin checkout, setup-node, and upload-artifact to their approved full SHAs.
+Disable persisted Git credentials and package-manager caching. Verify the exact
+Node/npm versions, install with `npm ci`, then run formatting, spelling, lint,
+type-checking, unit tests, coverage, template schema validation, build, and
+package verification in that order. Pipe each command through `tee` with shell
+pipeline failure propagation into `.ci-diagnostics`.
+
+- [ ] **Step 3: Add failure-only diagnostics**
+
+Upload only fixed repository paths on failure, ignore absent optional paths,
+include hidden diagnostic files, and retain the artifact for exactly three days.
+Do not upload npm user logs or environment dumps.
+
+- [ ] **Step 4: Confirm GREEN and validate Actions syntax**
+
+Run:
+
+```bash
+npm test -- tests/ci-workflow-contract.test.ts
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml
+```
+
+Expected: contract tests pass and actionlint emits no diagnostics.
+
+- [ ] **Step 5: Commit the workflow**
+
+```bash
+git add .github/workflows/ci.yml tests/ci-workflow-contract.test.ts
+git commit -s -m "ci: add pull-request quality foundation"
+```
+
+### Task 3: Publish contributor-facing CI guidance
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/development/toolchain.md`
+
+**Interfaces:**
+
+- Consumes: the implemented workflow and its exact local command sequence.
+- Produces: an honest CI badge and documentation for local reproduction and diagnostics.
+
+- [ ] **Step 1: Add the real CI status badge**
+
+Link the README badge to `.github/workflows/ci.yml` on `main`; do not add
+coverage or release badges without published services.
+
+- [ ] **Step 2: Document local parity and diagnostic behavior**
+
+Explain the exact pinned runtime, `npm ci`, `npm run verify`, the separate
+template-schema command, sequential failure behavior, and the three-day
+failure artifact without promising a required branch-protection rule.
+
+- [ ] **Step 3: Run focused documentation checks and commit**
+
+```bash
+npm run format:check
+npm run spellcheck
+git diff --check
+git add README.md docs/development/toolchain.md
+git commit -s -m "docs: explain pull-request CI checks"
+```
+
+### Task 4: Verify and merge the implementation without closing the issue
+
+**Files:**
+
+- Verify: all changed files and generated package output.
+
+**Interfaces:**
+
+- Consumes: Tasks 1–3.
+- Produces: a reviewed implementation pull request merged into `main`, while issue #7 remains open for platform evidence.
+
+- [ ] **Step 1: Run the clean local quality suite**
+
+```bash
+npm ci
+npm run templates:validate
+npm run verify
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml
+git diff --check
+```
+
+- [ ] **Step 2: Obtain an independent code review**
+
+Resolve every technically valid finding and rerun affected checks.
+
+- [ ] **Step 3: Push and open the implementation pull request**
+
+Describe the implementation and local evidence. Refer to issue #7 without an
+automatic closure keyword because the deliberate failure campaign is pending.
+
+- [ ] **Step 4: Confirm the GitHub-hosted green run and merge**
+
+Inspect each step and the exact event/permission context before merging the pull
+request. Sync local `main` after merge.
+
+### Task 5: Prove blocking failures and close with platform evidence
+
+**Files:**
+
+- Temporarily modify on a disposable branch: one TypeScript source, one test, and `scripts/build.mjs`.
+- Create: `docs/verification/issue-7-ci-evidence.md`
+
+**Interfaces:**
+
+- Consumes: the merged CI workflow.
+- Produces: GitHub run URLs for lint, type-check, test, package-content failure, and clean success; static fork-safety evidence; closure of issue #7.
+
+- [ ] **Step 1: Open a disposable pull request from a test branch**
+
+Start from current `main`. Never merge this pull request.
+
+- [ ] **Step 2: Exercise the lint failure**
+
+Commit a deliberately lint-invalid TypeScript probe, push, and record that the
+Lint step blocks the job while the failure artifact is available.
+
+- [ ] **Step 3: Exercise the type failure**
+
+Replace the probe with lint-valid but type-invalid TypeScript, push, and record
+that Type-check blocks the job.
+
+- [ ] **Step 4: Exercise the unit-test failure**
+
+Replace the probe with a deliberately failing Vitest assertion, push, and record
+that Unit tests blocks the job.
+
+- [ ] **Step 5: Exercise the package-content failure**
+
+Alter the disposable build to stage an unexpected file, push, and record that
+Verify package blocks the job.
+
+- [ ] **Step 6: Restore a clean tree and prove success**
+
+Remove every probe, push a final signed commit, and record a fully green run.
+Close the disposable pull request without merging and delete its branch.
+
+- [ ] **Step 7: Record fork-safety and platform evidence**
+
+Document the use of `pull_request`, read-only permissions, no secret references,
+no persisted credentials, standard hosted runner, and the relevant GitHub event
+contract. Include the implementation and test pull requests plus all run URLs.
+
+- [ ] **Step 8: Merge the evidence pull request and close issue #7**
+
+Use an automatic closure keyword only in this final evidence pull request.
+Confirm the issue is closed after merge and then inspect the next sequential issue.

--- a/docs/superpowers/specs/2026-08-07-pull-request-ci-design.md
+++ b/docs/superpowers/specs/2026-08-07-pull-request-ci-design.md
@@ -1,0 +1,181 @@
+# Pull-Request CI Foundation Design
+
+- Status: Approved
+- Decision date: 2026-08-07
+- Tracking issue: [#7](https://github.com/thiagocorreanet/mestre-yoda/issues/7)
+- Depends on: [#3](https://github.com/thiagocorreanet/mestre-yoda/issues/3)
+- Approval basis: Maintainer-authorized autonomous recommendation
+
+## 1. Outcome
+
+Every pull request targeting `developer` or `main` receives one fast,
+reproducible, least-privilege Node validation job on a standard public GitHub-
+hosted runner. Each required gate has a named step and preserves its own failure
+log. A superseded pull-request run is cancelled, while protected branch runs are
+never cancelled by this workflow.
+
+The workflow is safe for fork-originated code: it uses `pull_request`, never
+`pull_request_target`; declares only `contents: read`; persists no checkout
+credentials; references no repository/environment secret; and performs no
+write, publish, deploy, cache-save, comment, or approval operation.
+
+## 2. Approaches considered
+
+| Approach | Advantages | Costs | Decision |
+| --- | --- | --- | --- |
+| One job invoking only `npm run verify` | Minimal YAML and one local/CI entrypoint | Hides the failing gate in one step, omits online template schema validation, weak failure artifacts | Rejected |
+| One sequential job with named gates | One install, fast feedback, exact failure step/log, low public compute, mirrors scripts | Later gates do not run after an early failure | Selected |
+| Parallel job per gate | Maximum gate parallelism and isolation | Repeats checkout/install many times, consumes more public compute, uploads fragmented diagnostics | Rejected for foundation |
+
+Issue #55 may later split platform, nightly, compatibility, security, and release
+campaigns when their implementation exists. This issue establishes only the
+fast pull-request foundation.
+
+## 3. Trigger and concurrency contract
+
+`.github/workflows/ci.yml` runs on:
+
+- `pull_request` targeting `developer` or `main`;
+- `push` to `developer` or `main` for protected-line confirmation;
+- `workflow_dispatch` for safe manual re-execution.
+
+It does not use `pull_request_target`, `workflow_run`, privileged reusable
+workflows, tag/release triggers, schedules, or paths filters. Every source or
+configuration change must receive the same foundation checks.
+
+Concurrency groups by workflow plus pull-request number or Git ref. Only
+`pull_request` runs set `cancel-in-progress: true`; branch pushes are preserved
+as durable integration/release evidence. This carries forward the useful
+superseded-PR lesson from the private predecessor without copying its Go,
+self-hosted runner, private distribution, or prose implementation.
+
+## 4. Runner, permissions, and action supply chain
+
+The job uses `ubuntu-latest`, the standard GitHub-hosted runner appropriate to a
+public repository, and an explicit 15-minute timeout. Workflow permissions are:
+
+```yaml
+permissions:
+  contents: read
+```
+
+No job or step expands permission. Repository default workflow permissions are
+already read-only and cannot approve pull requests; the explicit workflow block
+makes that boundary reviewable even if repository defaults later change.
+
+Every third-party Action is pinned to a full immutable commit SHA with its
+reviewed release in a comment:
+
+| Action | Release | Commit |
+| --- | --- | --- |
+| `actions/checkout` | `v7.0.1` | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
+| `actions/setup-node` | `v7.0.0` | `820762786026740c76f36085b0efc47a31fe5020` |
+| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
+
+Checkout sets `persist-credentials: false`. Setup Node reads exact `24.18.0`
+from `.nvmrc`, disables latest-version lookup and automatic package-manager
+caching, and does not write a dependency cache. The environment step asserts
+Node `v24.18.0` and npm `11.16.0` before install. The exact npm version comes
+from the exact Node distribution and fails closed if the upstream bundle ever
+changes unexpectedly.
+
+## 5. Named validation gates
+
+After checkout/setup, the job creates `.ci-diagnostics/` and executes these
+steps in order:
+
+1. exact toolchain assertion;
+2. `npm ci` under strict lifecycle-script policy;
+3. `npm run format:check`;
+4. `npm run spellcheck`;
+5. `npm run lint`;
+6. `npm run typecheck`;
+7. `npm test`;
+8. `npm run test:coverage`;
+9. `npm run templates:validate`;
+10. `npm run build`;
+11. `npm run package:verify`.
+
+Each command runs under Bash pipe-failure semantics and tees combined output to
+a fixed diagnostic file. A failing command therefore fails its named step; the
+log capture cannot turn a failure into success. The template schema step remains
+the one explicit online validation because it retrieves a commit- and SHA-256-
+pinned schema; all other repository gates are offline after install.
+
+This order distinguishes unit tests, schema checks, final bundle build, bundle
+smoke behavior, and exact package contents. It does not replace deterministic
+tests with prompt/model evaluations and does not introduce CI-only product
+behavior.
+
+## 6. Failure diagnostics
+
+One final `if: failure()` step uploads only:
+
+- `.ci-diagnostics/` named command logs;
+- `coverage/` when the coverage gate ran;
+- `dist/` when build/package validation ran.
+
+The artifact name uses only run ID/attempt, hidden-file inclusion is limited to
+the explicitly named diagnostics directory, missing paths are ignored, and
+retention is 3 days. No npm cache/debug tree, repository secret, token,
+credential, environment dump, home directory, or arbitrary workspace archive is
+uploaded. Successful runs upload no artifact.
+
+## 7. Fork safety
+
+GitHub's documented `pull_request` model supplies fork workflows a read-only
+token and withholds repository secrets unless maintainers explicitly configure
+otherwise. This workflow further removes every secret reference and write use.
+Fork code can read the already-public checkout, execute public tests, and upload
+failure logs from that public code; it cannot mutate repository content,
+approve/comment on a PR, publish a package, deploy, or read a repository secret.
+
+The security boundary is protected by a repository contract test that rejects:
+
+- `pull_request_target` or any secret expression;
+- permissions other than `contents: read`;
+- self-hosted or non-`ubuntu-latest` runners;
+- mutable/non-SHA action references;
+- persisted checkout credentials, package-manager cache, write/publish steps,
+  or unbounded artifact retention.
+
+## 8. Validation campaign and closure order
+
+`tests/ci-workflow-contract.test.ts` is written first and fails while `ci.yml`
+is absent. It parses the workflow, validates exact triggers/concurrency,
+permissions, runner/timeout, action pins, named command order, pipe-safe logging,
+failure-only artifact policy, and fork-safety exclusions. Actionlint 1.7.12 then
+validates GitHub expression and workflow syntax.
+
+The implementation PR references #7 without any automatic-closing phrase and
+merges only after the real CI job is green. Issue #7 remains open. A separate,
+unmerged test PR then exercises four actual failure modes against the workflow:
+
+| Probe | Expected blocking step |
+| --- | --- |
+| ESLint-invalid TypeScript | Lint |
+| Lint-valid but type-invalid TypeScript assignment | Type-check |
+| Intentionally false Vitest assertion | Unit tests |
+| Extra staged package file | Verify package |
+
+Each probe is a signed commit/push; the run conclusion and named failed step are
+recorded before the next probe. A final clean probe returns the same PR to green.
+The test PR is closed without merge and its branch is deleted. No intentional
+failure enters `main`.
+
+Only after the success run, all four blocking runs, failure-artifact retention,
+fork-safety inspection, and the final clean run are recorded may an evidence
+follow-up intentionally close #7.
+
+## 9. Compatibility and provenance
+
+This workflow changes repository validation only. It does not alter runtime,
+state, migration, host, public schema, PRD, or spec behavior. It consumes the
+already approved toolchain/package contracts and will expose violations without
+redefining them.
+
+The private Go CI was consulted only for observable lessons about PR-only
+concurrency cancellation and explicit timeouts. Its self-hosted runners, Go/
+Python checks, private coverage policy, comments, and implementation are not
+copied. The new workflow/design/test prose is original clean-room work based on
+the public TypeScript repository and public GitHub Actions contracts.

--- a/docs/superpowers/specs/2026-08-07-pull-request-ci-design.md
+++ b/docs/superpowers/specs/2026-08-07-pull-request-ci-design.md
@@ -43,9 +43,10 @@ It does not use `pull_request_target`, `workflow_run`, privileged reusable
 workflows, tag/release triggers, schedules, or paths filters. Every source or
 configuration change must receive the same foundation checks.
 
-Concurrency groups by workflow plus pull-request number or Git ref. Only
-`pull_request` runs set `cancel-in-progress: true`; branch pushes are preserved
-as durable integration/release evidence. This carries forward the useful
+Concurrency groups pull requests by workflow plus pull-request number and gives
+every non-PR run its unique run ID. Only `pull_request` runs set
+`cancel-in-progress: true`; branch pushes are preserved as durable
+integration/release evidence, including pending pushes. This carries forward the useful
 superseded-PR lesson from the private predecessor without copying its Go,
 self-hosted runner, private distribution, or prose implementation.
 
@@ -96,9 +97,11 @@ steps in order:
 10. `npm run build`;
 11. `npm run package:verify`.
 
-Each command runs under Bash pipe-failure semantics and tees combined output to
-a fixed diagnostic file. A failing command therefore fails its named step; the
-log capture cannot turn a failure into success. The template schema step remains
+Each command runs under Bash fail-fast, unset-variable, and pipe-failure
+semantics and tees combined output to a fixed diagnostic file. Toolchain values
+are captured once and each assertion fails immediately. A failing command
+therefore fails its named step; the log capture cannot turn a failure into
+success. The template schema step remains
 the one explicit online validation because it retrieves a commit- and SHA-256-
 pinned schema; all other repository gates are offline after install.
 
@@ -109,7 +112,8 @@ behavior.
 
 ## 6. Failure diagnostics
 
-One final `if: failure()` step uploads only:
+One final failure step uploads only for pushes, manual runs, and same-repository
+pull requests:
 
 - `.ci-diagnostics/` named command logs;
 - `coverage/` when the coverage gate ran;
@@ -119,21 +123,24 @@ The artifact name uses only run ID/attempt, hidden-file inclusion is limited to
 the explicitly named diagnostics directory, missing paths are ignored, and
 retention is 3 days. No npm cache/debug tree, repository secret, token,
 credential, environment dump, home directory, or arbitrary workspace archive is
-uploaded. Successful runs upload no artifact.
+uploaded. Successful runs and fork pull requests upload no artifact. Fork runs
+retain the same named step logs in the GitHub Actions interface without allowing
+untrusted code to substitute symlinks in artifact paths.
 
 ## 7. Fork safety
 
 GitHub's documented `pull_request` model supplies fork workflows a read-only
 token and withholds repository secrets unless maintainers explicitly configure
 otherwise. This workflow further removes every secret reference and write use.
-Fork code can read the already-public checkout, execute public tests, and upload
-failure logs from that public code; it cannot mutate repository content,
+Fork code can read the already-public checkout, execute public tests, and read
+its run logs; it cannot upload artifacts, mutate repository content,
 approve/comment on a PR, publish a package, deploy, or read a repository secret.
 
 The security boundary is protected by a repository contract test that rejects:
 
 - `pull_request_target` or any secret expression;
-- permissions other than `contents: read`;
+- workflow permissions other than `contents: read`, any job-level permission
+  override, or any `continue-on-error` override;
 - self-hosted or non-`ubuntu-latest` runners;
 - mutable/non-SHA action references;
 - persisted checkout credentials, package-manager cache, write/publish steps,

--- a/tests/ci-workflow-contract.test.ts
+++ b/tests/ci-workflow-contract.test.ts
@@ -1,0 +1,161 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const workflowPath = join(repositoryRoot, ".github/workflows/ci.yml");
+
+type JsonObject = Record<string, unknown>;
+
+let rawWorkflow: string;
+let workflow: JsonObject;
+
+function object(value: unknown, context: string): JsonObject {
+  expect(value, context).not.toBeNull();
+  expect(Array.isArray(value), context).toBe(false);
+  expect(typeof value, context).toBe("object");
+  return value as JsonObject;
+}
+
+beforeAll(async () => {
+  rawWorkflow = await readFile(workflowPath, "utf8");
+  const document = parseDocument(rawWorkflow, {
+    prettyErrors: true,
+    uniqueKeys: true,
+  });
+  expect(document.errors).toEqual([]);
+  expect(document.warnings).toEqual([]);
+  workflow = object(document.toJS(), "workflow");
+});
+
+describe("pull-request CI workflow", () => {
+  it("targets the two protected integration branches", () => {
+    const triggers = object(workflow.on, "on");
+
+    expect(Object.keys(triggers).sort()).toEqual([
+      "pull_request",
+      "push",
+      "workflow_dispatch",
+    ]);
+    expect(object(triggers.pull_request, "pull_request").branches).toEqual([
+      "developer",
+      "main",
+    ]);
+    expect(object(triggers.push, "push").branches).toEqual([
+      "developer",
+      "main",
+    ]);
+    expect(triggers.workflow_dispatch).toBeNull();
+    expect(rawWorkflow).not.toContain("pull_request_target");
+  });
+
+  it("uses read-only, fork-safe authority", () => {
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(rawWorkflow).not.toMatch(/\bsecrets\s*[.[]/u);
+    expect(rawWorkflow).not.toMatch(
+      /\b(?:deploy|publish|pull-requests:\s*write|issues:\s*write)\b/iu,
+    );
+
+    const concurrency = object(workflow.concurrency, "concurrency");
+    expect(concurrency.group).toBe(
+      "ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+    );
+    expect(concurrency["cancel-in-progress"]).toBe(
+      "${{ github.event_name == 'pull_request' }}",
+    );
+  });
+
+  it("pins a single bounded GitHub-hosted quality job", () => {
+    const jobs = object(workflow.jobs, "jobs");
+    expect(Object.keys(jobs)).toEqual(["quality"]);
+
+    const quality = object(jobs.quality, "quality");
+    expect(quality.name).toBe("Node quality and package");
+    expect(quality["runs-on"]).toBe("ubuntu-latest");
+    expect(quality["timeout-minutes"]).toBe(15);
+    expect(quality.env).toEqual({ CI: "true" });
+
+    const steps = quality.steps as JsonObject[];
+    expect(steps.map((step) => step.name)).toEqual([
+      "Checkout",
+      "Set up exact Node.js",
+      "Prepare diagnostics",
+      "Verify exact toolchain",
+      "Install locked dependencies",
+      "Check formatting",
+      "Check spelling",
+      "Lint",
+      "Type-check",
+      "Run unit tests",
+      "Run coverage tests",
+      "Validate GitHub template schemas",
+      "Build bundle",
+      "Verify package contents",
+      "Upload failure diagnostics",
+    ]);
+
+    expect(steps.filter((step) => step.uses).map((step) => step.uses)).toEqual([
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    ]);
+    expect(object(steps[0]?.with, "checkout.with")).toEqual({
+      "persist-credentials": false,
+    });
+    expect(object(steps[1]?.with, "setup-node.with")).toEqual({
+      "check-latest": false,
+      "node-version-file": ".nvmrc",
+      "package-manager-cache": false,
+    });
+  });
+
+  it("runs the complete command graph with durable step logs", () => {
+    const jobs = object(workflow.jobs, "jobs");
+    const quality = object(jobs.quality, "quality");
+    const steps = quality.steps as JsonObject[];
+    const commandSteps = steps.slice(3, 14);
+    const expectedCommands = [
+      "node --version",
+      "npm ci",
+      "npm run format:check",
+      "npm run spellcheck",
+      "npm run lint",
+      "npm run typecheck",
+      "npm test",
+      "npm run test:coverage",
+      "npm run templates:validate",
+      "npm run build",
+      "npm run package:verify",
+    ];
+
+    for (const [index, step] of commandSteps.entries()) {
+      const command = String(step.run);
+      expect(command, String(step.name)).toContain("set -o pipefail");
+      expect(command, String(step.name)).toContain(expectedCommands[index]);
+      expect(command, String(step.name)).toMatch(
+        /2>&1\s*\|\s*tee \.ci-diagnostics\/[a-z-]+\.log/u,
+      );
+    }
+  });
+
+  it("uploads only short-lived diagnostics after failure", () => {
+    const jobs = object(workflow.jobs, "jobs");
+    const quality = object(jobs.quality, "quality");
+    const steps = quality.steps as JsonObject[];
+    const upload = steps.at(-1);
+    expect(upload?.if).toBe("${{ failure() }}");
+
+    expect(object(upload?.with, "upload.with")).toEqual({
+      "compression-level": 6,
+      "if-no-files-found": "ignore",
+      "include-hidden-files": true,
+      name: "ci-failure-${{ github.run_id }}-${{ github.run_attempt }}",
+      path: ".ci-diagnostics/\ncoverage/\ndist/\n",
+      "retention-days": 3,
+    });
+    expect(rawWorkflow).not.toMatch(/\.npm|npm-debug|environment/iu);
+  });
+});

--- a/tests/ci-workflow-contract.test.ts
+++ b/tests/ci-workflow-contract.test.ts
@@ -54,14 +54,14 @@ describe("pull-request CI workflow", () => {
 
   it("uses read-only, fork-safe authority", () => {
     expect(workflow.permissions).toEqual({ contents: "read" });
-    expect(rawWorkflow).not.toMatch(/\bsecrets\s*[.[]/u);
+    expect(rawWorkflow).not.toMatch(/\bsecrets\b/iu);
     expect(rawWorkflow).not.toMatch(
       /\b(?:deploy|publish|pull-requests:\s*write|issues:\s*write)\b/iu,
     );
 
     const concurrency = object(workflow.concurrency, "concurrency");
     expect(concurrency.group).toBe(
-      "ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+      "ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}",
     );
     expect(concurrency["cancel-in-progress"]).toBe(
       "${{ github.event_name == 'pull_request' }}",
@@ -77,8 +77,13 @@ describe("pull-request CI workflow", () => {
     expect(quality["runs-on"]).toBe("ubuntu-latest");
     expect(quality["timeout-minutes"]).toBe(15);
     expect(quality.env).toEqual({ CI: "true" });
+    expect(quality.permissions).toBeUndefined();
+    expect(quality["continue-on-error"]).toBeUndefined();
 
     const steps = quality.steps as JsonObject[];
+    expect(steps.every((step) => step["continue-on-error"] === undefined)).toBe(
+      true,
+    );
     expect(steps.map((step) => step.name)).toEqual([
       "Checkout",
       "Set up exact Node.js",
@@ -133,12 +138,16 @@ describe("pull-request CI workflow", () => {
 
     for (const [index, step] of commandSteps.entries()) {
       const command = String(step.run);
-      expect(command, String(step.name)).toContain("set -o pipefail");
+      expect(command, String(step.name)).toContain("set -euo pipefail");
       expect(command, String(step.name)).toContain(expectedCommands[index]);
       expect(command, String(step.name)).toMatch(
         /2>&1\s*\|\s*tee \.ci-diagnostics\/[a-z-]+\.log/u,
       );
     }
+
+    const toolchain = String(commandSteps[0]?.run);
+    expect(toolchain).toContain('test "$node_version" = "v24.18.0"');
+    expect(toolchain).toContain('test "$npm_version" = "11.16.0"');
   });
 
   it("uploads only short-lived diagnostics after failure", () => {
@@ -146,7 +155,9 @@ describe("pull-request CI workflow", () => {
     const quality = object(jobs.quality, "quality");
     const steps = quality.steps as JsonObject[];
     const upload = steps.at(-1);
-    expect(upload?.if).toBe("${{ failure() }}");
+    expect(upload?.if).toBe(
+      "${{ failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}",
+    );
 
     expect(object(upload?.with, "upload.with")).toEqual({
       "compression-level": 6,

--- a/tests/readme-honesty.test.ts
+++ b/tests/readme-honesty.test.ts
@@ -29,7 +29,8 @@ describe("README honesty", () => {
       "actions/workflows/docs.yml/badge.svg?branch=main",
     );
     expect(readme).toContain("actions/workflows/docs.yml");
-    expect(readme).not.toContain("actions/workflows/ci.yml/badge.svg");
+    expect(readme).toContain("actions/workflows/ci.yml/badge.svg?branch=main");
+    expect(readme).toContain("actions/workflows/ci.yml");
   });
 
   it("makes current availability impossible to mistake", () => {


### PR DESCRIPTION
## Summary

- add a least-privilege CI workflow for pull requests and protected-line pushes
- pin Actions, the Node/npm toolchain, timeouts, concurrency, and short-lived diagnostics
- enforce fork-safe permissions and disable artifact upload for fork-originated code
- specify workflow behavior with executable contract tests and contributor documentation

## Issue

Implements the workflow foundation for #7. The issue remains open until the deliberate failure campaign and final platform evidence are merged.

## Verification

- npm ci
- npm run templates:validate
- npm run verify
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml
- git diff --check

Local result: 47 tests passed, 100% coverage on the measured runtime surface, five Issue Forms validated against the pinned schema, package verification passed, and actionlint reported no diagnostics.

## Security and compatibility

The workflow uses pull_request, contents read, no secret context, no persisted checkout credentials, standard hosted runners, and immutable Action SHAs. Fork pull requests can run checks and read step logs but cannot upload artifacts. No runtime or SDD public contract changes.