### PR TITLE
test: build the golden-fixture and Go-vs-TypeScript differential harness

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -21,6 +21,7 @@
     "CSpell",
     "divergente",
     "ENOENT",
+    "EPIPE",
     "esbuild",
     "ESM",
     "evented",

--- a/.cspell.json
+++ b/.cspell.json
@@ -34,6 +34,8 @@
     "Mestre",
     "mktemp",
     "MWTC",
+    "NOSYSTEM",
+    "objectname",
     "oneline",
     "particionamento",
     "previewable",
@@ -48,6 +50,7 @@
     "uninspectable",
     "Vitest",
     "worktree",
+    "worktrees",
     "worklist",
     "Yoda"
   ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
           set -euo pipefail
           npm run templates:validate 2>&1 | tee .ci-diagnostics/templates.log
 
+      - name: Run differential self-tests
+        run: |
+          set -euo pipefail
+          npm run differential:check 2>&1 | tee .ci-diagnostics/differential.log
+
       - name: Build bundle
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository is intentionally public from the beginning so that its architect
 | Go-to-TypeScript parity inventory | [Complete; parity evidence at 0.00%](docs/compatibility/parity-inventory.md) |
 | Universal result contract | [Version 1 published and verified](docs/compatibility/result-contract.md) |
 | Plugin, state, and host contracts | [Version 1 schemas and compatibility checks available](docs/compatibility/contract-versioning.md) |
+| Go-to-TypeScript differential harness | [Public self-test available; live bootstrap differences measured](docs/compatibility/differential-harness.md) |
 | TypeScript deterministic runtime | [Foundation available](docs/development/toolchain.md) |
 | Claude Code integration | Planned |
 | OpenAI Codex integration | Planned |
@@ -312,6 +313,7 @@ Run this block in order from a clean checkout using Node.js `24.18.0` and npm
 npm ci
 npm run spellcheck
 npm run verify
+npm run differential:check
 npm run build
 npm run package:verify
 ```

--- a/compatibility/fixtures/differential/v1/corpus.json
+++ b/compatibility/fixtures/differential/v1/corpus.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "oracleId": "go-v3-v0.6.5",
+  "entries": [
+    { "class": "self-test", "path": "scenarios/self-test-equality.json" },
+    { "class": "live", "path": "scenarios/live-version.json" },
+    { "class": "live", "path": "scenarios/live-help.json" },
+    {
+      "class": "planned",
+      "id": "prd-sufficient-context",
+      "parityContractIds": [
+        "PRD-RESEARCHER",
+        "PRD-OUTPUT-SCHEMA",
+        "PRD-TEMPLATE"
+      ],
+      "requirements": [
+        "Complete sufficient context produces a completed structured result and one WHAT/WHY PRD artifact."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-insufficient-context",
+      "parityContractIds": [
+        "PRD-RESEARCHER",
+        "PRD-OUTPUT-SCHEMA",
+        "PRD-TEMPLATE"
+      ],
+      "requirements": [
+        "Insufficient context produces needs_input with blocking questions and no PRD artifact."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-blocking-and-deferred-questions",
+      "parityContractIds": ["PRD-RESEARCHER", "PRD-OUTPUT-SCHEMA"],
+      "requirements": [
+        "Blocking questions prevent publication while deferred open questions remain explicit without inventing answers."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-five-whys-applied",
+      "parityContractIds": ["PRD-PROBLEM-DISCOVERY", "PRD-TEMPLATE"],
+      "requirements": [
+        "5 Whys is applied adaptively when causal discovery is useful and its conclusion remains WHAT/WHY context."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-five-whys-skipped",
+      "parityContractIds": ["PRD-PROBLEM-DISCOVERY", "PRD-TEMPLATE"],
+      "requirements": [
+        "5 Whys is skipped when it adds no value without fabricating a causal chain."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-probable-root-cause",
+      "parityContractIds": ["PRD-PROBLEM-DISCOVERY", "PRD-TEMPLATE"],
+      "requirements": [
+        "A probable root cause is labeled with appropriate uncertainty and retained in the generated PRD."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-five-w-two-h-applied",
+      "parityContractIds": ["PRD-PROBLEM-DISCOVERY", "PRD-TEMPLATE"],
+      "requirements": [
+        "5W2H is applied adaptively when it clarifies problem context without adding implementation architecture."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-five-w-two-h-skipped",
+      "parityContractIds": ["PRD-PROBLEM-DISCOVERY", "PRD-TEMPLATE"],
+      "requirements": [
+        "5W2H is skipped when existing context is already sufficient and no empty ceremony is emitted."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-invalid-structured-output",
+      "parityContractIds": ["PRD-RESEARCHER", "PRD-OUTPUT-SCHEMA"],
+      "requirements": [
+        "Invalid structured researcher output fails closed and creates no authoritative PRD artifact."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-lineage-drift",
+      "parityContractIds": [
+        "PRD-RESEARCHER",
+        "PRD-OUTPUT-SCHEMA",
+        "PRD-TEMPLATE"
+      ],
+      "requirements": [
+        "Changed source lineage invalidates stale derived approval and requires a traceable revision."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-spec-revision",
+      "parityContractIds": ["PRD-OUTPUT-SCHEMA", "PRD-TEMPLATE"],
+      "requirements": [
+        "A PRD revision preserves lineage, explicit open questions, and the WHAT/WHY boundary."
+      ]
+    },
+    {
+      "class": "planned",
+      "id": "prd-content-bound-approval",
+      "parityContractIds": [
+        "PRD-RESEARCHER",
+        "PRD-OUTPUT-SCHEMA",
+        "PRD-TEMPLATE"
+      ],
+      "requirements": [
+        "Approval binds to exact reviewed PRD content and does not authorize a later changed artifact."
+      ]
+    }
+  ]
+}

--- a/compatibility/fixtures/differential/v1/corpus.json
+++ b/compatibility/fixtures/differential/v1/corpus.json
@@ -3,6 +3,10 @@
   "oracleId": "go-v3-v0.6.5",
   "entries": [
     { "class": "self-test", "path": "scenarios/self-test-equality.json" },
+    {
+      "class": "self-test",
+      "path": "scenarios/self-test-normalized-state.json"
+    },
     { "class": "live", "path": "scenarios/live-version.json" },
     { "class": "live", "path": "scenarios/live-help.json" },
     {

--- a/compatibility/fixtures/differential/v1/scenarios/live-help.json
+++ b/compatibility/fixtures/differential/v1/scenarios/live-help.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "id": "live-help",
+  "parityContractIds": ["CLI-ALIAS-HELP", "CLI-HELP"],
+  "workspace": { "entries": [] },
+  "invocation": {
+    "args": ["--help"],
+    "stdin": "",
+    "environment": {},
+    "timeoutMs": 5000,
+    "maxStdoutBytes": 1048576,
+    "maxStderrBytes": 1048576
+  },
+  "capture": { "structured": [], "git": false },
+  "normalization": [],
+  "disclosure": {
+    "stdout": "digest",
+    "stderr": "digest",
+    "artifacts": "digest"
+  },
+  "expected": {
+    "process": {
+      "outcome": "exit",
+      "exitCode": 0,
+      "signal": null,
+      "stdout": {
+        "bytes": 1058,
+        "sha256": "8fe918223dc75b5fc644f2769fa38456077c1b0467e5bc2394597a77431414b6"
+      },
+      "stderr": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "filesystem": { "before": [], "after": [], "mutations": [] },
+    "structured": [],
+    "git": null
+  }
+}

--- a/compatibility/fixtures/differential/v1/scenarios/live-version.json
+++ b/compatibility/fixtures/differential/v1/scenarios/live-version.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "id": "live-version",
+  "parityContractIds": ["CLI-ALIAS-VERSION", "CLI-VERSION"],
+  "workspace": { "entries": [] },
+  "invocation": {
+    "args": ["--version"],
+    "stdin": "",
+    "environment": {},
+    "timeoutMs": 5000,
+    "maxStdoutBytes": 1048576,
+    "maxStderrBytes": 1048576
+  },
+  "capture": { "structured": [], "git": false },
+  "normalization": [],
+  "disclosure": {
+    "stdout": "digest",
+    "stderr": "digest",
+    "artifacts": "digest"
+  },
+  "expected": {
+    "process": {
+      "outcome": "exit",
+      "exitCode": 0,
+      "signal": null,
+      "stdout": {
+        "bytes": 6,
+        "sha256": "34bf52562bae401de106933a7565c9d3a5c8dc83c04b0b29492dd3f6f3983b7a"
+      },
+      "stderr": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "filesystem": { "before": [], "after": [], "mutations": [] },
+    "structured": [],
+    "git": null
+  }
+}

--- a/compatibility/fixtures/differential/v1/scenarios/self-test-equality.json
+++ b/compatibility/fixtures/differential/v1/scenarios/self-test-equality.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "id": "self-test-equality",
+  "parityContractIds": ["CLI-VERSION"],
+  "workspace": {
+    "entries": [
+      {
+        "type": "file",
+        "path": "driver.mjs",
+        "content": "process.stdout.write(\"equal\\n\");\n",
+        "executable": false
+      }
+    ]
+  },
+  "invocation": {
+    "args": ["driver.mjs"],
+    "stdin": "",
+    "environment": {},
+    "timeoutMs": 2000,
+    "maxStdoutBytes": 1048576,
+    "maxStderrBytes": 1048576
+  },
+  "capture": { "structured": [], "git": false },
+  "normalization": [],
+  "disclosure": {
+    "stdout": "digest",
+    "stderr": "digest",
+    "artifacts": "digest"
+  },
+  "expected": {
+    "process": {
+      "outcome": "exit",
+      "exitCode": 0,
+      "signal": null,
+      "stdout": {
+        "bytes": 6,
+        "sha256": "1907d592edca123512edf021ad7230b31ee3b68b2e38b78b07acd5e85256a3d6"
+      },
+      "stderr": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "filesystem": {
+      "before": [
+        {
+          "path": "driver.mjs",
+          "type": "file",
+          "mode": "file",
+          "size": 33,
+          "sha256": "c4c1aff27d475fa1d8f8b0cecd9c2eac767ddd4efa8469e602df0acd13a09460"
+        }
+      ],
+      "after": [
+        {
+          "path": "driver.mjs",
+          "type": "file",
+          "mode": "file",
+          "size": 33,
+          "sha256": "c4c1aff27d475fa1d8f8b0cecd9c2eac767ddd4efa8469e602df0acd13a09460"
+        }
+      ],
+      "mutations": []
+    },
+    "structured": [],
+    "git": null
+  }
+}

--- a/compatibility/fixtures/differential/v1/scenarios/self-test-normalized-state.json
+++ b/compatibility/fixtures/differential/v1/scenarios/self-test-normalized-state.json
@@ -1,0 +1,141 @@
+{
+  "schemaVersion": 1,
+  "id": "self-test-normalized-state",
+  "parityContractIds": ["CLI-VERSION"],
+  "workspace": {
+    "entries": [
+      {
+        "type": "file",
+        "path": "driver.mjs",
+        "content": "import { mkdir, writeFile } from \"node:fs/promises\";\n\nawait mkdir(\".brain\", { recursive: true });\nawait writeFile(\n  \".brain/state.json\",\n  `${JSON.stringify({\n    generatedAt: \"2026-08-07T00:00:00.000Z\",\n    entries: [{ id: \"b\" }, { id: \"a\" }],\n    revision: 1,\n  })}\\n`,\n  \"utf8\",\n);\nprocess.stdout.write(\"state written\\r\\n\");\n",
+        "executable": false
+      }
+    ]
+  },
+  "invocation": {
+    "args": ["driver.mjs"],
+    "stdin": "",
+    "environment": {},
+    "timeoutMs": 2000,
+    "maxStdoutBytes": 1048576,
+    "maxStderrBytes": 1048576
+  },
+  "capture": {
+    "structured": [
+      {
+        "id": "state",
+        "path": ".brain/state.json"
+      },
+      {
+        "id": "result",
+        "path": "result.json"
+      }
+    ],
+    "git": false
+  },
+  "normalization": [
+    {
+      "operation": "line_endings",
+      "pointer": "/process/stdout/content"
+    },
+    {
+      "operation": "replace_json_value",
+      "pointer": "/structured/0/value/generatedAt",
+      "token": "<TIMESTAMP>"
+    },
+    {
+      "operation": "sort_json_array",
+      "pointer": "/structured/0/value/entries",
+      "identityKey": "id"
+    }
+  ],
+  "disclosure": {
+    "stdout": "content",
+    "stderr": "digest",
+    "artifacts": "content"
+  },
+  "expected": {
+    "process": {
+      "outcome": "exit",
+      "exitCode": 0,
+      "signal": null,
+      "stdout": {
+        "bytes": 14,
+        "sha256": "b025c45f10a6a71e4b59cf5e89bc260539ddd2036e69d0a6acfec94c286b5430",
+        "content": "state written\n"
+      },
+      "stderr": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "filesystem": {
+      "before": [
+        {
+          "path": "driver.mjs",
+          "type": "file",
+          "mode": "file",
+          "size": 329,
+          "sha256": "166cbfec137aebfb953b358e6757af6c451989ebfcfc96cf0635687e220fc4cf"
+        }
+      ],
+      "after": [
+        {
+          "path": ".brain",
+          "type": "directory",
+          "mode": "directory",
+          "size": 0
+        },
+        {
+          "path": ".brain/state.json",
+          "type": "file",
+          "mode": "file",
+          "size": 90,
+          "sha256": "57f1976e6669ebab33e7bda300c6007fb4859380a6f91dedd4daf72644b1d3f5"
+        },
+        {
+          "path": "driver.mjs",
+          "type": "file",
+          "mode": "file",
+          "size": 329,
+          "sha256": "166cbfec137aebfb953b358e6757af6c451989ebfcfc96cf0635687e220fc4cf"
+        }
+      ],
+      "mutations": [
+        {
+          "path": ".brain",
+          "kind": "added"
+        },
+        {
+          "path": ".brain/state.json",
+          "kind": "added"
+        }
+      ]
+    },
+    "structured": [
+      {
+        "id": "state",
+        "path": ".brain/state.json",
+        "state": "valid",
+        "value": {
+          "entries": [
+            {
+              "id": "a"
+            },
+            {
+              "id": "b"
+            }
+          ],
+          "generatedAt": "<TIMESTAMP>",
+          "revision": 1
+        }
+      },
+      {
+        "id": "result",
+        "path": "result.json",
+        "state": "absent"
+      }
+    ],
+    "git": null
+  }
+}

--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -110,12 +110,13 @@ migration must keep its inner payload byte-preserving; a current envelope may
 identify the payload but may not rewrite its fields or meaning. Its frozen
 schema digest is recorded only as compatibility metadata.
 
-PRD behavior remains `migration-only` until issue #13 proves differential
-parity for sufficient and insufficient context, blocking questions, 5 Whys,
-5W2H, root cause, validated problem, solution hypothesis, success metric,
-risks, deferred questions, invalid structured output, lineage revision, and
-content-bound approval. No current manifest entry claims PRD parity before that
-evidence exists.
+PRD behavior remains `migration-only`. The issue #13 differential harness now
+tracks 12 planned PRD requirements for sufficient and insufficient context,
+`needs_input`, blocking/deferred questions, 5 Whys, 5W2H, probable root cause,
+invalid structured output, lineage drift, revision, and content-bound approval.
+They deliberately contain no invented golden output and grant no parity. No
+current manifest entry claims PRD parity before executable unit, differential,
+integration, and E2E evidence exists.
 
 ## Evolution rules
 

--- a/docs/compatibility/differential-harness.md
+++ b/docs/compatibility/differential-harness.md
@@ -1,0 +1,139 @@
+# Go-to-TypeScript Differential Harness
+
+## Current result
+
+The differential harness executes one validated scenario in two independent
+workspaces, captures process/filesystem/structured/Git observations, applies
+only declared normalization, and reports stable field-level mismatches. It does
+not modify the source checkout.
+
+Public CI runs an original synthetic equality scenario:
+
+```bash
+npm run differential:check
+```
+
+The corpus contains one executable public self-test, two authorized live
+bootstrap scenarios, and 12 planned PRD requirements. The public self-test
+proves the harness; it is not Go parity evidence and does not change the current
+`0 / 400 (0.00%)` parity result.
+
+## Authorized live comparison
+
+An authorized maintainer can compare the installed frozen Linux oracle with the
+fresh TypeScript bundle:
+
+```text
+npm run build
+node scripts/run-differential.mjs \
+  --class live \
+  --oracle <verified-go-v3-v0.6.5-binary> \
+  --candidate dist/plugin/runtime/yoda.mjs
+```
+
+The runner verifies the oracle SHA-256 against the issue #9 baseline before it
+loads or materializes a scenario. It never searches home directories or
+downloads a binary.
+
+The initial authorized run has a known mismatch while the TypeScript bundle
+remains a bootstrap runtime:
+
+| Scenario | Contracts | Result |
+| --- | --- | --- |
+| `live-version` | `CLI-ALIAS-VERSION`, `CLI-VERSION` | stdout byte count and digest differ |
+| `live-help` | `CLI-ALIAS-HELP`, `CLI-HELP` | stdout byte count and digest differ |
+
+The verified Go outputs retain their published issue #9 byte counts and
+digests. No private help text is printed or checked in. Live comparison returns
+nonzero until both sides satisfy the same golden observation.
+
+## Exit contract
+
+- Exit `0`: every selected executable scenario matches its golden observation
+  on both sides.
+- Exit `1`: at least one field differs; output contains scenario IDs, parity
+  contract IDs, mismatch kinds, and JSON Pointers.
+- Exit `2`: usage, corpus/schema, runner provenance, unsafe path, or internal
+  harness validation failed.
+
+JSON is the default deterministic renderer. `--format human` prints one concise
+line per scenario and mismatch pointer. Normal comparison failures use stdout;
+usage and harness failures use stderr. Normal output contains no stack trace,
+caller path, secret, or undisclosed stream content.
+
+## Isolation and capture
+
+Each side receives a separately materialized copy of the same fixture below an
+external temporary root. The project, HOME, TMPDIR, and Git configuration are
+isolated. Executables are spawned directly with a literal argument vector and
+`shell: false`; arbitrary environment variables, `NODE_OPTIONS`, credentials,
+and proxy configuration are not inherited.
+
+Wall time and stdout/stderr bytes are bounded. Timeout or output overflow first
+terminates the process group and then escalates to a forced kill. Capture still
+runs after a nonzero exit, signal, timeout, crash, or partial mutation. Both
+temporary roots are removed in `finally`, and cleanup failure is a harness
+failure.
+
+The canonical observation includes:
+
+- process outcome, exit/signal, and stream byte/digest summaries;
+- sorted before/after filesystem manifests and added/modified/deleted paths;
+- selected canonical JSON state/result/event values;
+- optional Git HEAD, refs, status, staged diff, and unstaged diff summaries.
+
+Filesystem traversal uses `lstat` and never follows captured symlinks. Selected
+JSON must remain a regular file whose resolved path is below the workspace.
+Special files, unsafe links, malformed JSON, over-limit manifests, and
+case-fold-colliding fixture paths fail explicitly.
+
+## Normalization and disclosure
+
+Normalization is scenario-owned and applied in declared order. The only
+operations are selected CRLF-to-LF conversion, workspace-token replacement,
+explicit JSON value tokens, keyed array sorting, and justified removal of one
+field. Wildcards and regular-expression rewriting are unavailable.
+
+Normalization cannot target process outcome/exit, result status/reason,
+filesystem mutations/unexpected files, or Git effects. Reports default to
+digest-only stream and artifact summaries. A digest field may show its digest;
+arbitrary string content is represented only by byte count and SHA-256.
+
+Every mismatch names the affected parity contract IDs. A seeded difference
+returns Exit `1`; there is no “expected difference means success” mode.
+
+## PRD preservation
+
+PRD stays `migration-only`. The corpus records 12 planned PRD requirements
+covering all four frozen anchors without inventing golden output or copying
+private expression:
+
+- sufficient context and a completed WHAT/WHY artifact;
+- insufficient context, `needs_input`, blocking questions, and no artifact;
+- blocking versus deferred questions;
+- adaptive 5 Whys applied and skipped;
+- probable root cause with retained uncertainty;
+- adaptive 5W2H applied and skipped;
+- invalid structured output and fail-closed publication;
+- lineage drift and stale approval invalidation;
+- traceable spec revision;
+- content-bound approval.
+
+Planned entries contain requirement metadata but no executable path or golden
+observation. They become live only after an authorized publication-safe oracle
+capture exists and the TypeScript PRD driver can execute the same input. PRD
+parity still requires unit, differential, integration, and E2E evidence before
+the matrix can grant credit.
+
+## Fixture contract
+
+Executable scenarios are closed JSON documents validated by
+[`differential-scenario.v1.schema.json`](../../schemas/compatibility/differential-scenario.v1.schema.json).
+Their golden observations conform to
+[`differential-observation.v1.schema.json`](../../schemas/compatibility/differential-observation.v1.schema.json).
+
+Paths are POSIX-style relative names. Absolute paths, URLs, backslashes,
+traversal segments, empty segments, NUL/control characters, duplicates, and
+case-fold collisions fail before workspace mutation. A scenario contains at
+most 256 entries, 4 MiB of materialized UTF-8 input, 30 seconds of wall time,
+and 1 MiB per process stream.

--- a/docs/compatibility/differential-harness.md
+++ b/docs/compatibility/differential-harness.md
@@ -54,7 +54,8 @@ nonzero until both sides satisfy the same golden observation.
 - Exit `1`: at least one field differs; output contains scenario IDs, parity
   contract IDs, mismatch kinds, and JSON Pointers.
 - Exit `2`: usage, corpus/schema, runner provenance, unsafe path, or internal
-  harness validation failed.
+  harness validation failed. Selecting no runnable scenario is also Exit `2`,
+  because an empty run proves nothing and must never be reported as a pass.
 
 JSON is the default deterministic renderer. `--format human` prints one concise
 line per scenario and mismatch pointer. Normal comparison failures use stdout;
@@ -70,10 +71,14 @@ isolated. Executables are spawned directly with a literal argument vector and
 and proxy configuration are not inherited.
 
 Wall time and stdout/stderr bytes are bounded. Timeout or output overflow first
-terminates the process group and then escalates to a forced kill. Capture still
-runs after a nonzero exit, signal, timeout, crash, or partial mutation. Both
-temporary roots are removed in `finally`, and cleanup failure is a harness
-failure.
+terminates the process group and then escalates to a forced kill 250 ms later;
+the escalation is measured from that signal, so an overflowing run does not wait
+out the full scenario timeout. Overflow keeps the retained prefix that fits
+within the declared bound and classifies the run as `output_limit`; the reported
+byte count, SHA-256, and any disclosed content always describe that same
+retained prefix. Capture still runs after a nonzero exit, signal, timeout,
+crash, or partial mutation. Both temporary roots are removed in `finally`, and
+cleanup failure is a harness failure.
 
 The canonical observation includes:
 
@@ -94,10 +99,19 @@ operations are selected CRLF-to-LF conversion, workspace-token replacement,
 explicit JSON value tokens, keyed array sorting, and justified removal of one
 field. Wildcards and regular-expression rewriting are unavailable.
 
-Normalization cannot target process outcome/exit, result status/reason,
-filesystem mutations/unexpected files, or Git effects. Reports default to
-digest-only stream and artifact summaries. A digest field may show its digest;
-arbitrary string content is represented only by byte count and SHA-256.
+Normalization cannot target process outcome/exit, result `status`, `exitCode`,
+or `reasonCode`, filesystem mutations/unexpected files, or Git effects. These
+are the decision-bearing fields of the universal result contract; rewriting one
+would let a real behavioral difference be normalized away.
+
+Reports default to digest-only stream and artifact summaries. A digest field may
+show its digest; arbitrary string content is represented only by byte count and
+SHA-256. When `disclosure.artifacts` is `digest`, each captured structured value
+is compared as a single opaque digest rather than field by field, so a mismatch
+names only the artifact pointer. Neither private key names nor private scalar
+values from predecessor output can reach a report. Setting
+`disclosure.artifacts` to `content` is the explicit opt-in that enables
+field-level pointers, and it is reserved for original public fixtures.
 
 Every mismatch names the affected parity contract IDs. A seeded difference
 returns Exit `1`; there is no “expected difference means success” mode.

--- a/docs/compatibility/differential-harness.md
+++ b/docs/compatibility/differential-harness.md
@@ -7,16 +7,32 @@ workspaces, captures process/filesystem/structured/Git observations, applies
 only declared normalization, and reports stable field-level mismatches. It does
 not modify the source checkout.
 
-Public CI runs an original synthetic equality scenario:
+Public CI runs original synthetic scenarios:
 
 ```bash
 npm run differential:check
 ```
 
-The corpus contains one executable public self-test, two authorized live
-bootstrap scenarios, and 12 planned PRD requirements. The public self-test
-proves the harness; it is not Go parity evidence and does not change the current
-`0 / 400 (0.00%)` parity result.
+The corpus contains two executable public self-tests, two authorized live
+bootstrap scenarios, and 12 planned PRD requirements:
+
+| Scenario | Proves |
+| --- | --- |
+| `self-test-equality` | process outcome, exit code, stream digests, and an unchanged manifest |
+| `self-test-normalized-state` | all three normalization operations, added directory and file mutations, a `valid` captured artifact, and an `absent` one |
+
+`self-test-normalized-state` is not a tautology: the driver writes its array
+members in the opposite order and emits CRLF, so the scenario only matches its
+golden observation because sorting, token replacement, and line-ending
+normalization actually ran.
+
+Because both self-test sides run the same executable, the public corpus cannot
+by itself observe a Go-vs-TypeScript divergence. Divergence handling — seeded
+mismatches, timeouts, crashes, partial mutations, output overflow, and report
+redaction — is proven by the harness self-tests in `tests/differential-*.test.ts`.
+
+The public self-tests prove the harness; they are not Go parity evidence and do
+not change the current `0 / 400 (0.00%)` parity result.
 
 ## Authorized live comparison
 
@@ -87,10 +103,28 @@ The canonical observation includes:
 - selected canonical JSON state/result/event values;
 - optional Git HEAD, refs, status, staged diff, and unstaged diff summaries.
 
-Filesystem traversal uses `lstat` and never follows captured symlinks. Selected
-JSON must remain a regular file whose resolved path is below the workspace.
-Special files, unsafe links, malformed JSON, over-limit manifests, and
-case-fold-colliding fixture paths fail explicitly.
+Filesystem traversal uses `lstat` and never follows captured symlinks. A `.git`
+entry is recorded as a presence marker and never descended into, so creating or
+removing a repository stays visible as a mutation without importing
+nondeterministic repository internals. Special files, over-limit manifests,
+over-limit individual files, unsafe links, and case-fold-colliding fixture paths
+fail explicitly.
+
+Every selected artifact is always observable, because artifact behavior is
+exactly what the harness compares. Each carries one of four states:
+
+| State | Meaning |
+| --- | --- |
+| `absent` | the side produced no artifact at that path |
+| `unreadable` | the path exists but is not a regular file |
+| `invalid` | a regular file whose bytes are not JSON, reported as byte count and digest |
+| `valid` | parsed and canonicalized JSON |
+
+Only a path resolving outside the workspace is refused outright rather than
+observed; the harness never reads it. An unborn `HEAD` is captured as
+`head: null` rather than an error, so "did this side initialize a repository?"
+is comparable. A missing `git` executable is a harness failure, never a silent
+"not a repository" that both sides would agree on vacuously.
 
 ## Normalization and disclosure
 
@@ -112,6 +146,32 @@ names only the artifact pointer. Neither private key names nor private scalar
 values from predecessor output can reach a report. Setting
 `disclosure.artifacts` to `content` is the explicit opt-in that enables
 field-level pointers, and it is reserved for original public fixtures.
+
+Protection is prefix-symmetric: a rule is rejected both when it names a
+protected field and when it names an ancestor of one, because removing the
+ancestor removes the protected field with it. The only normalizable parts of a
+captured stream are the disclosed `content` bodies; when one is rewritten, its
+sibling `bytes` and `sha256` are recomputed so a stream summary never describes
+a buffer other than the one it reports.
+
+### The golden observation is post-normalization
+
+A scenario's `expected` block is never normalized. It must therefore be written
+as a **complete observation as it appears after normalization has run** — for
+example with `<TIMESTAMP>` already substituted and arrays already sorted.
+
+This invariant is what makes normalization safe. Each side is compared to the
+golden by total recursive equality over the union of keys, so equality with the
+golden implies the two sides equal each other, and a golden that omits a field
+fails closed rather than skipping it. Authoring a pre-normalization golden is
+the most common fixture mistake and shows up as a mismatch on the fields the
+rules touch.
+
+Because filesystem manifests are protected, a scenario whose artifact bytes are
+genuinely nondeterministic on disk (an embedded wall-clock timestamp, say)
+cannot be made to match by normalizing the captured value alone: the file's
+manifest digest still differs. Such scenarios need a deterministic artifact or
+an explicitly justified per-file rule.
 
 Every mismatch names the affected parity contract IDs. A seeded difference
 returns Exit `1`; there is no “expected difference means success” mode.

--- a/docs/compatibility/parity-inventory.md
+++ b/docs/compatibility/parity-inventory.md
@@ -151,6 +151,12 @@ cross-check, then mapped exactly once. New TypeScript-only behavior is not
 silently described as Go parity; an incompatibility needs a versioned contract
 and the complete intentional-difference approval chain.
 
+The [differential harness](differential-harness.md) now executes versioned
+golden scenarios in independent sandboxes and links field-level mismatches to
+these row IDs. Its public synthetic self-test is harness evidence, not behavior
+parity. The initial authorized help/version comparisons remain mismatches, so
+the objective result stays `0 / 400 (0.00%)`.
+
 ## Authorized source cross-check
 
 Public CI remains offline. An authorized maintainer can re-run mechanical

--- a/docs/development/toolchain.md
+++ b/docs/development/toolchain.md
@@ -40,6 +40,7 @@ clean and CI installations. Changing a dependency requires Node `24.18.0`, npm
 | `npm run oracle:verify` | Validate the public metadata-only Go v3 oracle catalog offline |
 | `npm run parity:check` | Validate exhaustive legacy coverage and report objective TypeScript parity |
 | `npm run result:check` | Validate the universal result schemas, 76 reason policies, and six exit examples |
+| `npm run differential:check` | Run the offline synthetic differential self-test without the private oracle |
 | `npm run build` | Rebuild the standalone runtime artifact |
 | `npm run package:verify` | Inspect and execute the staged artifact outside the checkout |
 | `npm run verify` | Run the complete offline validation chain in dependency order |
@@ -78,6 +79,7 @@ untrusted fork code without granting it repository write authority.
 packages/contracts/  host-neutral public types and versioned constants
 packages/adapters/   host adapter protocol boundary
 packages/runtime/    deterministic runtime composition and CLI
+packages/differential/ isolated validation, execution, capture, normalization, and comparison
 schemas/             versioned public runtime contracts
 fixtures/            compatibility and golden-scenario inputs
 tests/               black-box tests of the final bundle
@@ -119,6 +121,12 @@ discovery keys into 400 owned and independently verifiable compatibility rows.
 requirements, invalid evidence references, and unsupported parity claims. It
 currently reports `0 / 400 (0.00%)`: the worklist is complete, while behavior
 implementation and differential evidence remain future work.
+
+The [differential harness](../compatibility/differential-harness.md) now makes
+Go-versus-TypeScript comparison executable. Public `npm run differential:check`
+uses only an original synthetic fixture. Authorized live mode verifies an
+explicit Go binary digest before measuring the bootstrap bundle and currently
+reports the known help/version mismatch without granting parity.
 
 The [universal result contract](../compatibility/result-contract.md) preserves
 all 71 frozen reason names and predecessor exits 0 through 3, then adds five

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -113,7 +113,7 @@ git commit -s -m "feat: define differential scenario contracts"
 - Produces `compareGolden(side, expected, actual): readonly Mismatch[]`.
 - Produces `compareObservations(scenario, oracle, candidate): DifferentialReport`.
 
-- [ ] **Step 1: Write failing comparator tests**
+- [x] **Step 1: Write failing comparator tests**
 
 Cover exact equality, missing/unexpected/type/value differences, unexpected
 file, timeout, crash, partial mutation, and side-specific golden failure. Assert
@@ -129,7 +129,7 @@ expect(report.mismatches.map(({ pointer, kind }) => [pointer, kind])).toEqual([
 Prove LF/workspace/JSON-token/keyed-sort rules work, while rules targeting
 exit/status/reason/filesystem mutation/Git fail closed.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/differential-comparator.test.ts
@@ -137,7 +137,7 @@ npm test -- tests/differential-comparator.test.ts
 
 Expected: FAIL because comparator modules do not exist.
 
-- [ ] **Step 3: Implement normalization and comparison**
+- [x] **Step 3: Implement normalization and comparison**
 
 Use `structuredClone` and exact RFC 6901 traversal. Protect these prefixes and
 their parents from remove/replace operations:
@@ -159,7 +159,7 @@ partial_mutation`, scenario ID, real contract IDs, and disclosure-safe value
 summaries. Compare each side to the golden observation and then both sides,
 deduplicating only exact mismatch tuples.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm test -- tests/differential-comparator.test.ts tests/differential-contract.test.ts

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -315,7 +315,7 @@ git commit -s -m "feat: run bounded differential sandboxes"
 Cover default JSON self-test, human rendering, unknown/duplicate/missing options,
 missing live runners, wrong oracle digest before mutation, valid oracle with
 seeded version/help mismatch, and redaction of absolute paths, secrets, stack
-text, and nondisclosed streams.
+text, and undisclosed streams.
 
 - [x] **Step 2: Run RED**
 
@@ -351,7 +351,7 @@ sorts keys; human output prints scenario and mismatch pointers only. Add
 npm test -- tests/differential-cli.test.ts tests/differential-runner.test.ts
 npm run differential:check
 npm run build
-node scripts/run-differential.mjs --class live --oracle /home/thiago-botelho/.betaup/bin/yoda --candidate dist/plugin/runtime/yoda.mjs
+node scripts/run-differential.mjs --class live --oracle <authorized-go-v3-binary> --candidate dist/plugin/runtime/yoda.mjs
 ```
 
 Expected: tests/self-test PASS; authorized live comparison verifies the oracle,
@@ -385,7 +385,7 @@ git commit -s -m "test: add golden differential corpus"
 
 - Publishes operation, exit/redaction/security contracts, current live mismatch evidence, and honest unchanged parity until full row evidence exists.
 
-- [ ] **Step 1: Write documentation RED tests**
+- [x] **Step 1: Write documentation RED tests**
 
 Require docs to name public/live commands, exit 0/1/2, digest-only disclosure,
 temporary isolation, current known mismatch, source immutability, and PRD
@@ -393,7 +393,7 @@ temporary isolation, current known mismatch, source immutability, and PRD
 or secrets. Assert parity remains `0 / 400` if no row gained all four evidence
 classes.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/readme-honesty.test.ts tests/parity-inventory-matrix.test.ts
@@ -401,7 +401,7 @@ npm test -- tests/readme-honesty.test.ts tests/parity-inventory-matrix.test.ts
 
 Expected: FAIL because docs do not expose the harness.
 
-- [ ] **Step 3: Publish exact documentation**
+- [x] **Step 3: Publish exact documentation**
 
 Document scenario fields/limits, capture/normalization/mismatch semantics,
 public and authorized commands, exit codes, no-shell/path controls, disclosure
@@ -410,7 +410,7 @@ unit+differential+integration+E2E are required before parity. Keep CI on public
 `npm run verify`; add no oracle secret or private artifact. Check completed plan
 steps in this file.
 
-- [ ] **Step 4: Run final verification**
+- [x] **Step 4: Run final verification**
 
 ```bash
 export PATH=/tmp/tmp.qb2rcwG3r2/node-v24.18.0-linux-x64/bin:$PATH

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -183,14 +183,14 @@ git commit -s -m "feat: compare normalized differential observations"
 - Produces `captureBefore(project, selector): Promise<CaptureBaseline>`.
 - Produces `captureAfter(project, selector, baseline, process): Promise<DifferentialObservation>`.
 
-- [ ] **Step 1: Write failing capture tests**
+- [x] **Step 1: Write failing capture tests**
 
 Use external `mkdtemp` roots. Cover deterministic files/directories/executable
 mode/safe link manifests, selected JSON, Git HEAD/status/ref/diff digests,
 added/modified/deleted classifications, malformed JSON, unsafe link, special
 file, limit overflow, cleanup, and byte-identical source checkout status.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/differential-capture.test.ts
@@ -198,7 +198,7 @@ npm test -- tests/differential-capture.test.ts
 
 Expected: FAIL because capture modules do not exist.
 
-- [ ] **Step 3: Implement materialization and observation**
+- [x] **Step 3: Implement materialization and observation**
 
 Create directories, files with `flag: "wx"`, then links. Resolve each parent
 immediately before mutation and require it below project root. Require lexical
@@ -219,7 +219,7 @@ git for-each-ref --format=%(refname)%00%(objectname)
 Use isolated Git config and bounded output. Non-Git workspaces produce
 `git: null`; malformed selected JSON and unsafe/special files fail explicitly.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm test -- tests/differential-capture.test.ts tests/differential-comparator.test.ts

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -1,0 +1,443 @@
+# Golden-Fixture Differential Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a versioned, isolated, fail-closed harness that runs identical golden scenarios against frozen Go v3 and the TypeScript candidate and reports normalized field-level differences without mutating the developer checkout.
+
+**Architecture:** Strict JSON scenarios feed focused TypeScript units for validation, materialization, capture, normalization, comparison, and bounded process execution. A Node 24 CLI runs an original public self-test corpus by default or an authorized live corpus with explicit runners; only exact equality exits successfully.
+
+**Tech Stack:** Node.js 24.18.0, strict TypeScript 6, Vitest 4, AJV 8/JSON Schema 2020-12, native process/filesystem/Git APIs, SHA-256, and the existing repository verification toolchain.
+
+## Global Constraints
+
+- Live Go execution accepts only `go-v3-v0.6.5`, Linux SHA-256 `da4ec4a2394ae90a94722f633bcb9157ddc5ee0133f46540b7c2c700abe378b8`.
+- Keep repository content and delivery text English-only and DCO-sign every commit.
+- Never publish private predecessor code, prose, schemas, fixtures, help output, local paths, customer data, or secrets.
+- Keep PRD `prd-output.schema.json` at `migration-only` and its frozen digest `7fa4f468520fac2f2a0d3b766257e162d25f37520dd7507230616257f2fe503e` until every required PRD differential case passes.
+- Every scenario is an equality claim; any mismatch exits nonzero and grants no parity credit.
+- Spawn literal argument arrays with `shell: false`; scenario workspaces always live in external temporary roots removed in `finally`.
+- Reject absolute, traversing, backslash, URL, NUL, control-character, duplicate, and case-fold-colliding paths before mutation.
+- Normalization is closed and field-scoped and cannot alter process outcomes, reason/status, mutations, unexpected files, or Git effects.
+- Reports default to byte/digest summaries and never expose stack traces, absolute paths, environment secrets, or private output.
+
+---
+
+### Task 1: Freeze scenario and observation contracts
+
+**Files:**
+
+- Create: `packages/differential/package.json`
+- Create: `packages/differential/src/types.ts`
+- Create: `packages/differential/src/scenario.ts`
+- Create: `packages/differential/src/index.ts`
+- Create: `schemas/compatibility/differential-scenario.v1.schema.json`
+- Create: `schemas/compatibility/differential-observation.v1.schema.json`
+- Create: `tests/differential-contract.test.ts`
+- Modify: `tsconfig.json`
+- Modify: `package-lock.json`
+
+**Interfaces:**
+
+- Produces `loadScenario(path, matrixPath?): Promise<DifferentialScenario>` and `validateSafeRelativePath(path): string`.
+- Produces closed `DifferentialScenario`, `DifferentialObservation`, `GoldenAssertions`, `NormalizationRule`, `Mismatch`, and `DifferentialReport` types.
+- Consumes real row IDs from `compatibility/inventory/go-v3-v0.6.5/matrix.json`.
+
+- [ ] **Step 1: Write failing contract tests**
+
+Compile both schemas and validate one complete fixture. Mutate every object with
+an unknown key. Test missing/unknown/duplicate matrix IDs, timeout over `30000`,
+bad environment keys, duplicate/case-fold-colliding entries, and unsafe paths:
+
+```ts
+it.each(["../x", "/x", "C:\\x", "https://x.invalid", "a\\b", "a/./b", "a//b", "a\u0000b"])(
+  "rejects unsafe path %j",
+  (path) => expect(() => validateSafeRelativePath(path)).toThrow("Differential scenario path is unsafe"),
+);
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/differential-contract.test.ts
+```
+
+Expected: FAIL because package and schemas do not exist.
+
+- [ ] **Step 3: Implement closed contracts and loader**
+
+Define discriminated workspace entries and normalization operations:
+
+```ts
+export type WorkspaceEntry =
+  | { readonly type: "directory"; readonly path: string }
+  | { readonly type: "file"; readonly path: string; readonly content: string; readonly executable: boolean }
+  | { readonly type: "symlink"; readonly path: string; readonly target: string };
+
+export type NormalizationRule =
+  | { readonly operation: "line_endings"; readonly pointer: string }
+  | { readonly operation: "workspace_path"; readonly pointer: string }
+  | { readonly operation: "replace_json_value"; readonly pointer: string; readonly token: "<TIMESTAMP>" | "<DURATION>" }
+  | { readonly operation: "sort_json_array"; readonly pointer: string; readonly identityKey: string }
+  | { readonly operation: "remove_field"; readonly pointer: string; readonly justification: string };
+```
+
+Set `additionalProperties: false` recursively. Bound entries to 256, each file
+to 256 KiB, aggregate materialized bytes to 4 MiB, timeout to 50–30000 ms, and
+each process stream to 1 MiB. AJV errors expose scenario ID and keyword only.
+Validate matrix IDs and safe POSIX paths before returning. Add exact dependency
+`ajv: 8.20.0` and `allowImportingTsExtensions: true`.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm install --package-lock-only --ignore-scripts
+npm test -- tests/differential-contract.test.ts
+npm run typecheck
+npm run lint
+git add package-lock.json packages/differential schemas/compatibility tsconfig.json tests/differential-contract.test.ts
+git commit -s -m "feat: define differential scenario contracts"
+```
+
+### Task 2: Implement immutable normalization and comparison
+
+**Files:**
+
+- Create: `packages/differential/src/normalize.ts`
+- Create: `packages/differential/src/compare.ts`
+- Create: `tests/differential-comparator.test.ts`
+- Modify: `packages/differential/src/index.ts`
+
+**Interfaces:**
+
+- Produces `normalizeObservation(observation, rules, workspace): DifferentialObservation`.
+- Produces `compareGolden(side, expected, actual): readonly Mismatch[]`.
+- Produces `compareObservations(scenario, oracle, candidate): DifferentialReport`.
+
+- [ ] **Step 1: Write failing comparator tests**
+
+Cover exact equality, missing/unexpected/type/value differences, unexpected
+file, timeout, crash, partial mutation, and side-specific golden failure. Assert
+stable pointer ordering:
+
+```ts
+expect(report.mismatches.map(({ pointer, kind }) => [pointer, kind])).toEqual([
+  ["/candidate/filesystem/2", "unexpected"],
+  ["/candidate/process/exitCode", "value"],
+]);
+```
+
+Prove LF/workspace/JSON-token/keyed-sort rules work, while rules targeting
+exit/status/reason/filesystem mutation/Git fail closed.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/differential-comparator.test.ts
+```
+
+Expected: FAIL because comparator modules do not exist.
+
+- [ ] **Step 3: Implement normalization and comparison**
+
+Use `structuredClone` and exact RFC 6901 traversal. Protect these prefixes and
+their parents from remove/replace operations:
+
+```ts
+const protectedPointers = [
+  "/process/exitCode",
+  "/process/outcome",
+  "/structured/result/status",
+  "/structured/result/reasonCode",
+  "/filesystem",
+  "/git",
+] as const;
+```
+
+Compare objects by sorted key union and arrays by index. Emit stable JSON
+Pointers with `missing | unexpected | type | value | timeout | crash |
+partial_mutation`, scenario ID, real contract IDs, and disclosure-safe value
+summaries. Compare each side to the golden observation and then both sides,
+deduplicating only exact mismatch tuples.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm test -- tests/differential-comparator.test.ts tests/differential-contract.test.ts
+npm run typecheck
+npm run lint
+git add packages/differential/src tests/differential-comparator.test.ts
+git commit -s -m "feat: compare normalized differential observations"
+```
+
+### Task 3: Materialize and capture deterministic workspaces
+
+**Files:**
+
+- Create: `packages/differential/src/materialize.ts`
+- Create: `packages/differential/src/capture.ts`
+- Create: `tests/differential-capture.test.ts`
+
+**Interfaces:**
+
+- Produces `materializeWorkspace(root, entries): Promise<string>`.
+- Produces `captureBefore(project, selector): Promise<CaptureBaseline>`.
+- Produces `captureAfter(project, selector, baseline, process): Promise<DifferentialObservation>`.
+
+- [ ] **Step 1: Write failing capture tests**
+
+Use external `mkdtemp` roots. Cover deterministic files/directories/executable
+mode/safe link manifests, selected JSON, Git HEAD/status/ref/diff digests,
+added/modified/deleted classifications, malformed JSON, unsafe link, special
+file, limit overflow, cleanup, and byte-identical source checkout status.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/differential-capture.test.ts
+```
+
+Expected: FAIL because capture modules do not exist.
+
+- [ ] **Step 3: Implement materialization and observation**
+
+Create directories, files with `flag: "wx"`, then links. Resolve each parent
+immediately before mutation and require it below project root. Require lexical
+link targets below root. Use modes `0755`/`0644` and recheck aggregate bytes
+before the first write.
+
+Enumerate with `lstat`, never follow links, sort UTF-8 relative paths, hash file
+bytes, and represent mode classes rather than numeric modes. Canonicalize
+selected JSON object keys. Capture Git using literal `spawn` arguments:
+
+```text
+git status --porcelain=v2 --branch
+git diff --binary --no-ext-diff
+git diff --cached --binary --no-ext-diff
+git for-each-ref --format=%(refname)%00%(objectname)
+```
+
+Use isolated Git config and bounded output. Non-Git workspaces produce
+`git: null`; malformed selected JSON and unsafe/special files fail explicitly.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm test -- tests/differential-capture.test.ts tests/differential-comparator.test.ts
+npm run typecheck
+npm run lint
+git add packages/differential/src tests/differential-capture.test.ts
+git commit -s -m "feat: capture isolated differential workspaces"
+```
+
+### Task 4: Add bounded process runners
+
+**Files:**
+
+- Create: `packages/differential/src/runner.ts`
+- Create: `tests/differential-runner.test.ts`
+- Create: `tests/fixtures/differential/driver.mjs`
+- Modify: `packages/differential/src/index.ts`
+
+**Interfaces:**
+
+- Produces `runScenarioSide(options: RunSideOptions): Promise<SideRun>`.
+- Produces `runScenario(scenario, oracle, candidate): Promise<DifferentialReport>`.
+- `RunSideOptions` accepts an executable path and never a command string.
+
+- [ ] **Step 1: Write failing runner tests**
+
+The original driver supports `equal`, `normalize`, `unexpected-file`,
+`timeout`, `crash`, `partial-mutation`, `state`, and `git`. Assert independent
+equal seeds, retained mutations after failures, signal/timeout classification,
+child termination, isolated HOME/TMPDIR/Git config, dropped `NODE_OPTIONS` and
+secret variables, source immutability, and cleanup on every path.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/differential-runner.test.ts
+```
+
+Expected: FAIL because runner orchestration does not exist.
+
+- [ ] **Step 3: Implement bounded direct execution**
+
+Use this spawn shape:
+
+```ts
+spawn(executable, scenario.invocation.args, {
+  shell: false,
+  detached: process.platform !== "win32",
+  cwd: project,
+  env: safeEnvironment,
+  stdio: ["pipe", "pipe", "pipe"],
+});
+```
+
+Allow only necessary platform variables plus isolated `HOME`, `TMPDIR`, `PATH`,
+`LANG=C.UTF-8`, `LC_ALL=C.UTF-8`, `NO_COLOR=1`, `GIT_CONFIG_NOSYSTEM=1`, and
+declared overlays. Bound streams separately. On timeout/overflow send SIGTERM,
+wait 250 ms, then SIGKILL to the POSIX group with direct-child fallback. Always
+await close, capture after-state, and clean nested roots in `finally`. Hash
+runners before materialization and run independent sides sequentially.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm test -- tests/differential-runner.test.ts tests/differential-capture.test.ts tests/differential-comparator.test.ts
+npm run typecheck
+npm run lint
+git add packages/differential/src tests/differential-runner.test.ts tests/fixtures/differential/driver.mjs
+git commit -s -m "feat: run bounded differential sandboxes"
+```
+
+### Task 5: Publish corpus CLI and live evidence
+
+**Files:**
+
+- Create: `compatibility/fixtures/differential/v1/corpus.json`
+- Create: `compatibility/fixtures/differential/v1/scenarios/self-test-equality.json`
+- Create: `compatibility/fixtures/differential/v1/scenarios/live-version.json`
+- Create: `compatibility/fixtures/differential/v1/scenarios/live-help.json`
+- Create: `compatibility/fixtures/differential/v1/scenarios/prd-*.json`
+- Create: `scripts/run-differential.mjs`
+- Create: `tests/differential-cli.test.ts`
+- Modify: `package.json`
+- Modify: `eslint.config.mjs`
+
+**Interfaces:**
+
+- Produces `npm run differential:check` for public self-tests.
+- Live mode requires `--class live --oracle <path> --candidate <path>`.
+- Exit `0` means all selected scenarios equal, `1` means mismatch, and `2` means usage/contract/provenance/harness failure.
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Cover default JSON self-test, human rendering, unknown/duplicate/missing options,
+missing live runners, wrong oracle digest before mutation, valid oracle with
+seeded version/help mismatch, and redaction of absolute paths, secrets, stack
+text, and nondisclosed streams.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/differential-cli.test.ts
+```
+
+Expected: FAIL because CLI and corpus do not exist.
+
+- [ ] **Step 3: Add corpus and strict CLI**
+
+Classify corpus entries as `self-test`, `live`, or `planned`. Default mode runs
+the materialized original driver with `process.execPath` on both sides and a
+complete equal golden observation. Live `--version` and `--help` scenarios name
+real matrix IDs and store only issue #9 byte counts/digests. Planned PRD files
+name all four real PRD IDs and sufficient/insufficient context, `needs_input`,
+blocking/deferred questions, 5 Whys/5W2H applied/skipped, root cause, invalid
+structured output, lineage drift, revision, and content-bound approval; they
+contain no private anchor expression and cannot execute or count as evidence.
+
+Default runners are Node only for `self-test`. Live mode requires regular
+executable files and verifies Go SHA before loading scenarios. JSON recursively
+sorts keys; human output prints scenario and mismatch pointers only. Add
+`"differential:check": "node scripts/run-differential.mjs"` after
+`contracts:check` in `verify` and before build.
+
+- [ ] **Step 4: Run GREEN and authorized live evidence**
+
+```bash
+npm test -- tests/differential-cli.test.ts tests/differential-runner.test.ts
+npm run differential:check
+npm run build
+node scripts/run-differential.mjs --class live --oracle /home/thiago-botelho/.betaup/bin/yoda --candidate dist/plugin/runtime/yoda.mjs
+```
+
+Expected: tests/self-test PASS; authorized live comparison verifies the oracle,
+reports only safe version/help pointer/digest differences, and exits `1` because
+the candidate is not yet parity-complete.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add compatibility/fixtures/differential package.json eslint.config.mjs scripts/run-differential.mjs tests/differential-cli.test.ts
+git commit -s -m "test: add golden differential corpus"
+```
+
+### Task 6: Document, verify, review, and deliver
+
+**Files:**
+
+- Create: `docs/compatibility/differential-harness.md`
+- Modify: `README.md`
+- Modify: `fixtures/README.md`
+- Modify: `schemas/README.md`
+- Modify: `docs/compatibility/parity-inventory.md`
+- Modify: `docs/compatibility/contract-versioning.md`
+- Modify: `docs/development/toolchain.md`
+- Modify: `tests/readme-honesty.test.ts`
+- Modify: `tests/parity-inventory-matrix.test.ts`
+- Modify: `.github/workflows/ci.yml`
+- Modify: this plan
+
+**Interfaces:**
+
+- Publishes operation, exit/redaction/security contracts, current live mismatch evidence, and honest unchanged parity until full row evidence exists.
+
+- [ ] **Step 1: Write documentation RED tests**
+
+Require docs to name public/live commands, exit 0/1/2, digest-only disclosure,
+temporary isolation, current known mismatch, source immutability, and PRD
+`migration-only`. Require CI to run the public self-test without private paths
+or secrets. Assert parity remains `0 / 400` if no row gained all four evidence
+classes.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/readme-honesty.test.ts tests/parity-inventory-matrix.test.ts
+```
+
+Expected: FAIL because docs do not expose the harness.
+
+- [ ] **Step 3: Publish exact documentation**
+
+Document scenario fields/limits, capture/normalization/mismatch semantics,
+public and authorized commands, exit codes, no-shell/path controls, disclosure
+boundary, version/help differences, all planned PRD cases, and the rule that
+unit+differential+integration+E2E are required before parity. Keep CI on public
+`npm run verify`; add no oracle secret or private artifact. Check completed plan
+steps in this file.
+
+- [ ] **Step 4: Run final verification**
+
+```bash
+export PATH=/tmp/tmp.qb2rcwG3r2/node-v24.18.0-linux-x64/bin:$PATH
+npm test -- tests/differential-contract.test.ts tests/differential-comparator.test.ts tests/differential-capture.test.ts tests/differential-runner.test.ts tests/differential-cli.test.ts tests/readme-honesty.test.ts tests/parity-inventory-matrix.test.ts
+npm run differential:check
+npm run verify
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml .github/workflows/docs.yml
+npx markdownlint-cli2 "**/*.md" "#node_modules" "#.worktrees"
+rg --files -g '*.md' -g '!node_modules/**' -g '!.worktrees/**' -0 | xargs -0 /tmp/tmp.KmVAr8uMu3/lychee-x86_64-unknown-linux-gnu/lychee --config .lychee.toml
+git diff --check main...HEAD
+git status --short
+```
+
+Expected: all public gates PASS, live mismatch remains honest evidence, no
+unsupported parity claim, and only intended changes remain.
+
+- [ ] **Step 5: Commit and review**
+
+```bash
+git add .github/workflows/ci.yml README.md fixtures/README.md schemas/README.md docs tests/readme-honesty.test.ts tests/parity-inventory-matrix.test.ts
+git commit -s -m "docs: publish differential harness workflow"
+```
+
+Use `requesting-code-review` against `main...HEAD`; resolve every Critical and
+Important finding with `receiving-code-review`, then rerun Step 4.
+
+- [ ] **Step 6: Deliver and close #13**
+
+Push, open an English PR with `Closes #13`, include exact commands and the
+redacted nonzero live evidence, wait for GitHub checks, squash merge, confirm
+issue `#13` closed, mark only `#13` in epic `#8`, fast-forward `main`, and remove this owned
+worktree/branch before proceeding to #14.

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -244,7 +244,7 @@ git commit -s -m "feat: capture isolated differential workspaces"
 - Produces `runScenario(scenario, oracle, candidate): Promise<DifferentialReport>`.
 - `RunSideOptions` accepts an executable path and never a command string.
 
-- [ ] **Step 1: Write failing runner tests**
+- [x] **Step 1: Write failing runner tests**
 
 The original driver supports `equal`, `normalize`, `unexpected-file`,
 `timeout`, `crash`, `partial-mutation`, `state`, and `git`. Assert independent
@@ -252,7 +252,7 @@ equal seeds, retained mutations after failures, signal/timeout classification,
 child termination, isolated HOME/TMPDIR/Git config, dropped `NODE_OPTIONS` and
 secret variables, source immutability, and cleanup on every path.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/differential-runner.test.ts
@@ -260,7 +260,7 @@ npm test -- tests/differential-runner.test.ts
 
 Expected: FAIL because runner orchestration does not exist.
 
-- [ ] **Step 3: Implement bounded direct execution**
+- [x] **Step 3: Implement bounded direct execution**
 
 Use this spawn shape:
 
@@ -281,7 +281,7 @@ wait 250 ms, then SIGKILL to the POSIX group with direct-child fallback. Always
 await close, capture after-state, and clean nested roots in `finally`. Hash
 runners before materialization and run independent sides sequentially.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm test -- tests/differential-runner.test.ts tests/differential-capture.test.ts tests/differential-comparator.test.ts

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -427,7 +427,7 @@ git status --short
 Expected: all public gates PASS, live mismatch remains honest evidence, no
 unsupported parity claim, and only intended changes remain.
 
-- [ ] **Step 5: Commit and review**
+- [x] **Step 5: Commit and review**
 
 ```bash
 git add .github/workflows/ci.yml README.md fixtures/README.md schemas/README.md docs tests/readme-honesty.test.ts tests/parity-inventory-matrix.test.ts
@@ -436,6 +436,24 @@ git commit -s -m "docs: publish differential harness workflow"
 
 Use `requesting-code-review` against `main...HEAD`; resolve every Critical and
 Important finding with `receiving-code-review`, then rerun Step 4.
+
+Two review rounds ran. The first round found a vacuous pass on an empty
+selection, a disclosure leak through structured values, an unprotected result
+`exitCode`, and a bounded-output capture that retained nothing.
+
+The second round found one Critical defect and eight Important ones, all fixed:
+an unhandled stdin `EPIPE` that leaked the sandbox and returned the mismatch
+exit code for a harness crash; capture converting a missing artifact, an unborn
+`HEAD`, and a created repository into harness errors or silent equality;
+protection that ignored the parents of protected fields; and the planned
+source-immutability, special-file, and entry-limit assertions that were never
+written. The plan's oracle-versus-candidate comparison was deliberately not
+added: equality with the golden is a total recursive relation, so it already
+implies mutual equality, and the invariant this depends on is now documented.
+
+One Minor finding is deferred: `packages/differential/src` is not yet under the
+repository's 100% coverage gate. Adding it requires exhaustive error-path tests
+beyond this issue's scope.
 
 - [ ] **Step 6: Deliver and close #13**
 

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -42,7 +42,7 @@
 - Produces closed `DifferentialScenario`, `DifferentialObservation`, `GoldenAssertions`, `NormalizationRule`, `Mismatch`, and `DifferentialReport` types.
 - Consumes real row IDs from `compatibility/inventory/go-v3-v0.6.5/matrix.json`.
 
-- [ ] **Step 1: Write failing contract tests**
+- [x] **Step 1: Write failing contract tests**
 
 Compile both schemas and validate one complete fixture. Mutate every object with
 an unknown key. Test missing/unknown/duplicate matrix IDs, timeout over `30000`,
@@ -55,7 +55,7 @@ it.each(["../x", "/x", "C:\\x", "https://x.invalid", "a\\b", "a/./b", "a//b", "a
 );
 ```
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/differential-contract.test.ts
@@ -63,7 +63,7 @@ npm test -- tests/differential-contract.test.ts
 
 Expected: FAIL because package and schemas do not exist.
 
-- [ ] **Step 3: Implement closed contracts and loader**
+- [x] **Step 3: Implement closed contracts and loader**
 
 Define discriminated workspace entries and normalization operations:
 
@@ -87,7 +87,7 @@ each process stream to 1 MiB. AJV errors expose scenario ID and keyword only.
 Validate matrix IDs and safe POSIX paths before returning. Add exact dependency
 `ajv: 8.20.0` and `allowImportingTsExtensions: true`.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm install --package-lock-only --ignore-scripts

--- a/docs/superpowers/plans/2026-08-07-differential-harness.md
+++ b/docs/superpowers/plans/2026-08-07-differential-harness.md
@@ -299,7 +299,6 @@ git commit -s -m "feat: run bounded differential sandboxes"
 - Create: `compatibility/fixtures/differential/v1/scenarios/self-test-equality.json`
 - Create: `compatibility/fixtures/differential/v1/scenarios/live-version.json`
 - Create: `compatibility/fixtures/differential/v1/scenarios/live-help.json`
-- Create: `compatibility/fixtures/differential/v1/scenarios/prd-*.json`
 - Create: `scripts/run-differential.mjs`
 - Create: `tests/differential-cli.test.ts`
 - Modify: `package.json`
@@ -311,14 +310,14 @@ git commit -s -m "feat: run bounded differential sandboxes"
 - Live mode requires `--class live --oracle <path> --candidate <path>`.
 - Exit `0` means all selected scenarios equal, `1` means mismatch, and `2` means usage/contract/provenance/harness failure.
 
-- [ ] **Step 1: Write failing CLI tests**
+- [x] **Step 1: Write failing CLI tests**
 
 Cover default JSON self-test, human rendering, unknown/duplicate/missing options,
 missing live runners, wrong oracle digest before mutation, valid oracle with
 seeded version/help mismatch, and redaction of absolute paths, secrets, stack
 text, and nondisclosed streams.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/differential-cli.test.ts
@@ -326,16 +325,19 @@ npm test -- tests/differential-cli.test.ts
 
 Expected: FAIL because CLI and corpus do not exist.
 
-- [ ] **Step 3: Add corpus and strict CLI**
+- [x] **Step 3: Add corpus and strict CLI**
 
-Classify corpus entries as `self-test`, `live`, or `planned`. Default mode runs
+Classify corpus entries as `self-test`, `live`, or `planned`. Runnable entries
+have a scenario path; planned entries instead have an ID, real contract IDs,
+and explicit observable requirements, with no invented golden output. Default mode runs
 the materialized original driver with `process.execPath` on both sides and a
 complete equal golden observation. Live `--version` and `--help` scenarios name
-real matrix IDs and store only issue #9 byte counts/digests. Planned PRD files
+real matrix IDs and store only issue #9 byte counts/digests. Planned PRD entries
 name all four real PRD IDs and sufficient/insufficient context, `needs_input`,
 blocking/deferred questions, 5 Whys/5W2H applied/skipped, root cause, invalid
 structured output, lineage drift, revision, and content-bound approval; they
-contain no private anchor expression and cannot execute or count as evidence.
+contain no private anchor expression, executable path, or golden observation
+and cannot execute or count as evidence.
 
 Default runners are Node only for `self-test`. Live mode requires regular
 executable files and verifies Go SHA before loading scenarios. JSON recursively
@@ -343,7 +345,7 @@ sorts keys; human output prints scenario and mismatch pointers only. Add
 `"differential:check": "node scripts/run-differential.mjs"` after
 `contracts:check` in `verify` and before build.
 
-- [ ] **Step 4: Run GREEN and authorized live evidence**
+- [x] **Step 4: Run GREEN and authorized live evidence**
 
 ```bash
 npm test -- tests/differential-cli.test.ts tests/differential-runner.test.ts
@@ -356,7 +358,7 @@ Expected: tests/self-test PASS; authorized live comparison verifies the oracle,
 reports only safe version/help pointer/digest differences, and exits `1` because
 the candidate is not yet parity-complete.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add compatibility/fixtures/differential package.json eslint.config.mjs scripts/run-differential.mjs tests/differential-cli.test.ts

--- a/docs/superpowers/specs/2026-08-07-differential-harness-design.md
+++ b/docs/superpowers/specs/2026-08-07-differential-harness-design.md
@@ -1,0 +1,291 @@
+# Golden-Fixture Differential Harness Design
+
+- Status: Approved
+- Decision date: 2026-08-07
+- Tracking issue: [#13](https://github.com/thiagocorreanet/mestre-yoda/issues/13)
+- Parent epic: [#8](https://github.com/thiagocorreanet/mestre-yoda/issues/8)
+- Depends on: issues [#9](https://github.com/thiagocorreanet/mestre-yoda/issues/9), [#10](https://github.com/thiagocorreanet/mestre-yoda/issues/10), [#11](https://github.com/thiagocorreanet/mestre-yoda/issues/11), and [#12](https://github.com/thiagocorreanet/mestre-yoda/issues/12)
+- Approval basis: maintainer-authorized autonomous recommendation
+
+## 1. Purpose
+
+Issue #13 creates the executable measurement boundary between frozen Go v3
+release `go-v3-v0.6.5` and the TypeScript candidate. A versioned scenario must
+be materialized twice, executed in two independent sandboxes, observed through
+the same capture pipeline, normalized only by rules declared in that scenario,
+and compared without modifying the source checkout.
+
+The harness proves what is equal and reports what is different. It never turns
+an expected mismatch, a missing runner, a normalized-away field, or a recorded
+oracle observation into a parity claim. The current TypeScript runtime only
+implements its bootstrap CLI, so this issue delivers the comparison machinery
+and a representative initial corpus without claiming that the broader runtime
+or PRD flow already exists.
+
+## 2. Design choice
+
+Three approaches were considered:
+
+| Approach | Strength | Limitation | Decision |
+| --- | --- | --- | --- |
+| CLI-specific comparator | Small first implementation | Cannot represent PRD, adapters, migrations, state, or non-CLI drivers | Rejected |
+| Container per runner | Strong process isolation | Requires an image toolchain, complicates local and public CI, and does not improve deterministic fixture semantics | Rejected |
+| Declarative scenarios plus process sandboxes | Works offline, supports any executable driver, and keeps capture and comparison runtime-neutral | Requires a strict scenario contract and careful path controls | Selected |
+
+The selected approach separates four responsibilities:
+
+1. a scenario contract describes redistributable inputs, invocation, expected
+   observations, normalization, disclosure, and parity contract IDs;
+2. an isolated runner creates a fresh workspace and process environment for
+   one executable without using a shell;
+3. an observer captures process, filesystem, state, event, and Git effects into
+   one canonical result;
+4. a comparator applies allowlisted normalization and emits stable field-level
+   mismatches.
+
+## 3. Repository layout
+
+```text
+compatibility/
+└── fixtures/
+    └── differential/v1/
+        ├── corpus.json
+        └── scenarios/*.json
+packages/
+└── differential/
+    └── src/
+        ├── capture.ts
+        ├── compare.ts
+        ├── index.ts
+        ├── normalize.ts
+        ├── runner.ts
+        └── scenario.ts
+scripts/
+└── run-differential.mjs
+schemas/
+└── compatibility/
+    ├── differential-observation.v1.schema.json
+    └── differential-scenario.v1.schema.json
+tests/
+├── differential-cli.test.ts
+├── differential-comparator.test.ts
+├── differential-contract.test.ts
+└── differential-runner.test.ts
+docs/compatibility/
+└── differential-harness.md
+```
+
+The package contains reusable TypeScript primitives. The CLI is a thin public
+entry point. Checked-in fixtures contain only original synthetic project data
+and public metadata; no private predecessor code, prose, schemas, fixtures, or
+help output is copied.
+
+## 4. Scenario contract
+
+Every scenario declares:
+
+- `schemaVersion`, fixed at `1`;
+- a stable lowercase `id` and nonempty `parityContractIds` from the issue #10
+  matrix;
+- `workspace`, a closed list of relative directories, UTF-8 files, executable
+  files, and safe symbolic links to materialize below the sandbox root;
+- `invocation`, containing literal arguments, optional UTF-8 stdin, a bounded
+  timeout, and an allowlisted environment overlay;
+- `capture`, selecting filesystem roots, JSON state/event files, and Git
+  observations that are meaningful for the scenario;
+- `normalization`, a closed list of field-scoped transformations;
+- `disclosure`, which defaults all process and artifact contents to digest-only
+  mismatch reporting;
+- `expected`, a closed set of golden assertions for process outcome, stream
+  bytes or digests, required and forbidden mutations, structured result fields,
+  and Git effects.
+
+Paths are POSIX-style repository-relative names. Empty segments, `.`, `..`,
+backslashes, absolute paths, URLs, NUL, control characters, and paths escaping
+through symbolic links are rejected before either workspace is created.
+Duplicate and case-fold-colliding paths are invalid. Fixture files have
+explicit size limits, and the full materialized workspace has a fixed limit.
+
+Every scenario is an equality claim: both observations must satisfy the golden
+assertions and must match each other after approved normalization. Seeded
+differences live only in harness self-tests, must exit nonzero, and are never
+valid matrix evidence. Golden assertions may use byte count and digest instead
+of private or nondisclosable text.
+
+## 5. Runner isolation and lifecycle
+
+The CLI receives runner executables as explicit paths:
+
+```text
+node scripts/run-differential.mjs \
+  --oracle <authorized-go-v3-binary> \
+  --candidate <typescript-bundle> \
+  --corpus compatibility/fixtures/differential/v1/corpus.json
+```
+
+It never searches home directories or downloads a runtime. The oracle path is
+verified against the frozen Linux digest before a live Go comparison. The
+candidate path is recorded by digest but may evolve between commits.
+
+For each side, the runner:
+
+1. creates a unique temporary root outside the repository;
+2. materializes the same validated workspace without following links;
+3. creates isolated `HOME`, `TMPDIR`, and Git configuration below that root;
+4. spawns the executable directly with a literal argument vector, no shell,
+   safe inherited platform variables, and only the declared environment
+   overlay;
+5. bounds wall time and stdout/stderr bytes, killing the process group on
+   timeout or overflow;
+6. captures observations even after nonzero exit, signal, timeout, crash, or
+   partial mutation;
+7. removes both roots in `finally`, reporting cleanup failure as a harness
+   error.
+
+The original repository is never the working directory and is not writable by
+normal harness operations. The runner rejects scenario paths that identify it.
+Tests additionally snapshot the developer checkout before and after execution.
+
+## 6. Canonical observations
+
+Both sides produce the same closed observation object:
+
+- `process`: exit code or signal, timeout/crash classification, stdout and
+  stderr byte counts, SHA-256 digests, and content only when disclosure allows;
+- `filesystem`: a sorted manifest of relative path, type, mode class, size,
+  digest, and safe link target, plus a before/after mutation classification;
+- `structured`: selected JSON result, state, and event files parsed with exact
+  JSON syntax validation and represented canonically;
+- `git`: whether a repository exists, HEAD/ref identity, porcelain-v2 status,
+  staged and unstaged patch digests, and a sorted ref manifest;
+- `runner`: executable digest and bounded timing metadata that is recorded but
+  excluded from parity comparison unless a scenario explicitly selects it.
+
+Special files, sockets, devices, unsafe links, unreadable paths, manifest
+overflow, invalid UTF-8 in a disclosed text field, and malformed selected JSON
+are explicit observations or harness failures; they are never silently skipped.
+Filesystem enumeration is deterministic and does not follow symlinks.
+
+## 7. Normalization policy
+
+Normalization is intentionally weaker than arbitrary search-and-replace. The
+allowed operations are:
+
+- convert CRLF to LF for an explicitly selected text field;
+- replace the two generated sandbox roots with the token `<WORKSPACE>`;
+- replace values at explicit JSON Pointers with a named stable token, such as
+  `<TIMESTAMP>` or `<DURATION>`;
+- sort an explicitly selected JSON array only when the scenario declares the
+  stable identity key proving that order is not contractual;
+- remove one explicitly selected observation field whose nondeterminism and
+  justification are both named.
+
+Rules are applied in declared order and included in the report. Wildcard JSON
+Pointers, regular expressions, recursive key removal, rounding unknown numeric
+fields, broad path stripping, and transformations of exit/reason/status fields
+are forbidden. Normalization cannot erase an unexpected file, a mutation
+classification, a process outcome, or a Git change.
+
+## 8. Comparison and diagnostics
+
+The comparator recursively compares canonical observations by type and emits a
+stable sorted mismatch list. Each item contains:
+
+- JSON Pointer to the differing field;
+- mismatch kind such as missing, unexpected, type, value, timeout, crash, or
+  partial mutation;
+- oracle and candidate value summaries permitted by disclosure policy;
+- affected parity contract IDs;
+- scenario ID and normalization rules that touched the field.
+
+Digest-only fields report byte count and digest, not private text. A normal
+comparison mismatch exits `1`; malformed fixture, unsafe path, invalid option,
+unverified oracle, or internal harness error exits `2`. A matching corpus exits
+`0`. Reports use deterministic JSON by default and an optional concise human
+renderer. They contain no caller-supplied absolute paths, environment secrets,
+stack traces, or workspace contents beyond explicit disclosure.
+
+## 9. Public CI and authorized oracle execution
+
+Public CI cannot contain the private Go binary. Therefore the repository gate
+runs the complete harness self-test corpus with two original test drivers that
+exercise the same runner boundary. This proves isolation, capture, comparison,
+normalization, diagnostics, and nonzero failures without pretending to be Go
+parity.
+
+Authorized local verification supplies the installed binary whose digest is
+already frozen by issue #9 and the freshly built TypeScript bundle. The initial
+live corpus covers public-safe bootstrap behavior and produces a redacted
+comparison summary. Current known TypeScript differences remain failures and
+do not update issue #10 matrix rows to `parity`.
+
+The checked-in corpus catalog records for each scenario whether it is:
+
+- `self-test`, safe and mandatory in public CI;
+- `live`, requiring the authorized oracle and candidate;
+- `planned`, contract-complete but blocked on a missing candidate behavior.
+
+A planned scenario is not executed and cannot count as evidence.
+
+## 10. PRD compatibility boundary
+
+PRD remains the highest-priority compatibility boundary. The design reserves
+dedicated scenarios for all four frozen anchors:
+
+- `PRD-RESEARCHER`;
+- `PRD-OUTPUT-SCHEMA`;
+- `PRD-PROBLEM-DISCOVERY`;
+- `PRD-TEMPLATE`.
+
+The planned PRD corpus covers sufficient and insufficient context, the
+no-artifact `needs_input` outcome, blocking and deferred questions, adaptive
+5 Whys applied and skipped, probable-root-cause handling, adaptive 5W2H applied
+and skipped, invalid structured output, lineage drift, spec revision, and
+content-bound approval. Comparisons include the structured result, whether an
+artifact exists, artifact digest, state/event effects, and WHAT/WHY ownership.
+
+Private prompt, reference, schema, and template expression stays outside the
+public repository. Authorized runners may consume an external projection only
+through explicit paths and may publish digests and permitted synthetic
+observations only. The current manifest keeps `prd-output.schema.json` at
+`migration-only`; issue #13 does not change it until the TypeScript PRD driver
+exists and every required scenario passes byte-preserving differential checks.
+
+This preserves the maintainer requirement that the new PRD process be 100%
+compatible with the old process while preventing a premature parity claim.
+
+## 11. Tests and evidence
+
+Development is test-first. Required self-tests prove:
+
+1. exact equality across process, filesystem, structured state/events, and Git;
+2. an approved timestamp/path/newline normalization;
+3. an unexpected file with a field-level path;
+4. timeout classification and child-process termination;
+5. crash/signal classification;
+6. partial mutation retained after failure;
+7. deterministic mismatch ordering and nonzero exit;
+8. safe-path, symlink, case-collision, size, output, and disclosure limits;
+9. source repository immutability and temporary-root cleanup;
+10. matrix contract IDs and corpus classifications are real and unique;
+11. a wrong oracle digest fails before scenario materialization;
+12. diagnostic mismatches cannot become parity evidence.
+
+The live evidence command runs the representative initial corpus against
+`/home/thiago-botelho/.betaup/bin/yoda` and the newly built bundle. Its report
+must identify the verified oracle as `go-v3-v0.6.5`, identify the candidate by
+digest, remain redacted, and return nonzero for current behavioral differences.
+That nonzero result is expected evidence of an honest harness, not a CI pass.
+
+Repository verification adds a public `npm run differential:check` self-test
+gate before the build/package checks. The final delivery also runs the complete
+`npm run verify`, documentation lint, link validation, and Actionlint.
+
+## 12. Scope boundaries
+
+This issue does not implement missing runtime commands, PRD generation, host
+adapters, state migration, containers, network orchestration, platform-native
+execution, performance benchmarking, or issue #14 distribution semantics. It
+does not copy or publish private legacy content and does not award parity to
+any row without the complete unit, differential, integration, and E2E evidence
+required by issue #10.

--- a/docs/superpowers/specs/2026-08-07-differential-harness-design.md
+++ b/docs/superpowers/specs/2026-08-07-differential-harness-design.md
@@ -223,9 +223,14 @@ The checked-in corpus catalog records for each scenario whether it is:
 
 - `self-test`, safe and mandatory in public CI;
 - `live`, requiring the authorized oracle and candidate;
-- `planned`, contract-complete but blocked on a missing candidate behavior.
+- `planned`, requirement-complete metadata blocked on a missing candidate
+  behavior and therefore lacking an executable scenario path or golden output.
 
-A planned scenario is not executed and cannot count as evidence.
+A planned entry names real parity contract IDs and explicit observable
+requirements, but it is not an executable scenario. It has no invented golden
+observation, is not executed, and cannot count as evidence. It becomes a live
+entry only after authorized oracle capture can provide a complete,
+publication-safe golden observation and a candidate driver exists.
 
 ## 10. PRD compatibility boundary
 

--- a/docs/superpowers/specs/2026-08-07-differential-harness-design.md
+++ b/docs/superpowers/specs/2026-08-07-differential-harness-design.md
@@ -110,7 +110,7 @@ Every scenario is an equality claim: both observations must satisfy the golden
 assertions and must match each other after approved normalization. Seeded
 differences live only in harness self-tests, must exit nonzero, and are never
 valid matrix evidence. Golden assertions may use byte count and digest instead
-of private or nondisclosable text.
+of private or unpublished text.
 
 ## 5. Runner isolation and lifecycle
 
@@ -276,8 +276,8 @@ Development is test-first. Required self-tests prove:
 11. a wrong oracle digest fails before scenario materialization;
 12. diagnostic mismatches cannot become parity evidence.
 
-The live evidence command runs the representative initial corpus against
-`/home/thiago-botelho/.betaup/bin/yoda` and the newly built bundle. Its report
+The live evidence command runs the representative initial corpus against an
+explicit authorized Go v3 binary and the newly built bundle. Its report
 must identify the verified oracle as `go-v3-v0.6.5`, identify the candidate by
 digest, remain redacted, and return nonzero for current behavioral differences.
 That nonzero result is expected evidence of an honest harness, not a CI pass.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -22,3 +22,10 @@ Its `version-cases.json` table covers current, previous, future, malformed,
 untrimmed, non-string, and missing family identities. These fixtures are
 independently authored public examples; they do not reproduce private Go v3
 payloads.
+
+The executable golden corpus lives at
+[`compatibility/fixtures/differential/v1`](../compatibility/fixtures/differential/v1).
+It contains one public synthetic self-test, digest-only live help/version
+scenarios, and requirement-only PRD plans. Planned entries have no executable
+path or invented golden output. See the
+[differential harness guide](../docs/compatibility/differential-harness.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1416,6 +1416,10 @@
       "resolved": "packages/contracts",
       "link": true
     },
+    "node_modules/@mestre-yoda/differential": {
+      "resolved": "packages/differential",
+      "link": true
+    },
     "node_modules/@mestre-yoda/runtime": {
       "resolved": "packages/runtime",
       "link": true
@@ -2172,7 +2176,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2856,7 +2859,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -2887,7 +2889,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
       "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3241,7 +3242,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -3848,7 +3848,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4389,6 +4388,13 @@
     "packages/contracts": {
       "name": "@mestre-yoda/contracts",
       "version": "0.0.0-development"
+    },
+    "packages/differential": {
+      "name": "@mestre-yoda/differential",
+      "version": "0.0.0-development",
+      "dependencies": {
+        "ajv": "8.20.0"
+      }
     },
     "packages/runtime": {
       "name": "@mestre-yoda/runtime",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "result:check": "node scripts/check-result-contract.mjs",
     "contracts:generate": "node scripts/generate-contract-types.mjs",
     "contracts:check": "node scripts/check-contracts.mjs",
+    "differential:check": "node scripts/run-differential.mjs",
     "build": "node scripts/build.mjs",
     "package:verify": "node scripts/verify-package.mjs",
-    "verify": "npm run format:check && npm run spellcheck && npm run lint && npm run typecheck && npm test && npm run test:coverage && npm run oracle:verify && npm run parity:check && npm run result:check && npm run contracts:check && npm run build && npm run package:verify"
+    "verify": "npm run format:check && npm run spellcheck && npm run lint && npm run typecheck && npm test && npm run test:coverage && npm run oracle:verify && npm run parity:check && npm run result:check && npm run contracts:check && npm run differential:check && npm run build && npm run package:verify"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/packages/differential/package.json
+++ b/packages/differential/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@mestre-yoda/differential",
+  "version": "0.0.0-development",
+  "private": true,
+  "type": "module",
+  "exports": "./src/index.ts",
+  "dependencies": {
+    "ajv": "8.20.0"
+  }
+}

--- a/packages/differential/src/capture.ts
+++ b/packages/differential/src/capture.ts
@@ -11,10 +11,12 @@ import type {
   ManifestEntry,
   Mutation,
   ProcessObservation,
+  StructuredObservation,
 } from "./types.ts";
 
 const executeFile = promisify(execFile);
 const maximumManifestEntries = 4096;
+const maximumFileBytes = 8 * 1024 * 1024;
 
 export interface CaptureSelector {
   structured: readonly { id: string; path: string }[];
@@ -54,12 +56,28 @@ async function manifest(project: string): Promise<ManifestEntry[]> {
     for (const name of children) {
       const absolute = join(directory, name);
       const path = relative(project, absolute).split(sep).join("/");
-      if (path === ".git" || path.startsWith(".git/")) continue;
       const stats = await lstat(absolute);
+      if (path === ".git") {
+        // Record that a repository exists without importing its
+        // nondeterministic internals. Creating or removing a repository stays
+        // visible as a mutation; `capture.git` observes its semantics.
+        entries.push({
+          path,
+          type: stats.isDirectory() ? "directory" : "file",
+          mode: stats.isDirectory() ? "directory" : "file",
+          size: 0,
+        });
+        continue;
+      }
       if (stats.isDirectory()) {
         entries.push({ path, type: "directory", mode: "directory", size: 0 });
         await visit(absolute);
       } else if (stats.isFile()) {
+        if (stats.size > maximumFileBytes) {
+          throw new Error(
+            "Differential filesystem capture exceeds the file limit",
+          );
+        }
         const content = await readFile(absolute);
         entries.push({
           path,
@@ -138,6 +156,31 @@ function stream(value: string, disclosure: "digest" | "content") {
   };
 }
 
+/**
+ * A missing `git` binary is a harness failure. Recording it as "not a
+ * repository" would make both sides agree vacuously on every Git scenario.
+ */
+function assertGitRunnable(error: unknown): void {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  ) {
+    throw new Error("Differential Git capture cannot run git");
+  }
+}
+
+/** An unborn HEAD is a real repository state, not an error. */
+async function captureHead(project: string): Promise<string | null> {
+  try {
+    return (await gitOutput(project, ["rev-parse", "HEAD"])).trim() || null;
+  } catch (error) {
+    assertGitRunnable(error);
+    return null;
+  }
+}
+
 async function captureGit(
   project: string,
   disclosure: "digest" | "content",
@@ -150,20 +193,17 @@ async function captureGit(
     ) {
       return null;
     }
-  } catch {
+  } catch (error) {
+    assertGitRunnable(error);
     return null;
   }
-  const [headText, status, worktreeDiff, indexDiff, refsText] =
-    await Promise.all([
-      gitOutput(project, ["rev-parse", "HEAD"]),
-      gitOutput(project, ["status", "--porcelain=v2", "--branch"]),
-      gitOutput(project, ["diff", "--binary", "--no-ext-diff"]),
-      gitOutput(project, ["diff", "--cached", "--binary", "--no-ext-diff"]),
-      gitOutput(project, [
-        "for-each-ref",
-        "--format=%(refname)%00%(objectname)",
-      ]),
-    ]);
+  const [head, status, worktreeDiff, indexDiff, refsText] = await Promise.all([
+    captureHead(project),
+    gitOutput(project, ["status", "--porcelain=v2", "--branch"]),
+    gitOutput(project, ["diff", "--binary", "--no-ext-diff"]),
+    gitOutput(project, ["diff", "--cached", "--binary", "--no-ext-diff"]),
+    gitOutput(project, ["for-each-ref", "--format=%(refname)%00%(objectname)"]),
+  ]);
   const refs = refsText
     .trim()
     .split("\n")
@@ -177,7 +217,7 @@ async function captureGit(
     })
     .sort((left, right) => left.name.localeCompare(right.name, "en-US"));
   return {
-    head: headText.trim() || null,
+    head,
     status: stream(status, disclosure),
     worktreeDiff: stream(worktreeDiff, disclosure),
     indexDiff: stream(indexDiff, disclosure),
@@ -202,29 +242,46 @@ export async function captureAfter(
 ): Promise<DifferentialObservation> {
   const after = await manifest(project);
   const structured = await Promise.all(
-    selector.structured.map(async ({ id, path }) => {
-      try {
-        validateSafeRelativePath(path);
-      } catch {
-        throw new Error("Differential structured capture path is unsafe");
-      }
-      const absolute = join(project, path);
-      const [stats, resolved] = await Promise.all([
-        lstat(absolute),
-        realpath(absolute),
-      ]);
-      if (!stats.isFile() || !inside(project, resolved)) {
-        throw new Error("Differential structured capture path is unsafe");
-      }
-      const source = await readFile(resolved, "utf8");
-      try {
-        return { id, path, value: canonicalize(JSON.parse(source) as unknown) };
-      } catch {
-        throw new Error(
-          `Differential structured capture ${id} contains invalid JSON`,
-        );
-      }
-    }),
+    selector.structured.map(
+      async ({ id, path }): Promise<StructuredObservation> => {
+        try {
+          validateSafeRelativePath(path);
+        } catch {
+          throw new Error("Differential structured capture path is unsafe");
+        }
+        const absolute = join(project, path);
+        let resolved: string;
+        try {
+          resolved = await realpath(absolute);
+        } catch {
+          // Missing, or a link with no target: the side produced no artifact.
+          return { id, path, state: "absent" };
+        }
+        // Escaping the sandbox is never an observation; refuse to read it.
+        if (!inside(project, resolved)) {
+          throw new Error("Differential structured capture path is unsafe");
+        }
+        const stats = await lstat(resolved);
+        if (!stats.isFile()) return { id, path, state: "unreadable" };
+        const source = await readFile(resolved);
+        try {
+          return {
+            id,
+            path,
+            state: "valid",
+            value: canonicalize(JSON.parse(source.toString("utf8")) as unknown),
+          };
+        } catch {
+          return {
+            id,
+            path,
+            state: "invalid",
+            bytes: source.byteLength,
+            sha256: digest(source),
+          };
+        }
+      },
+    ),
   );
   return {
     process: processObservation,

--- a/packages/differential/src/capture.ts
+++ b/packages/differential/src/capture.ts
@@ -1,0 +1,239 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { lstat, readFile, readdir, readlink, realpath } from "node:fs/promises";
+import { promisify } from "node:util";
+import { join, relative, sep } from "node:path";
+
+import { validateSafeRelativePath } from "./scenario.ts";
+import type {
+  DifferentialObservation,
+  GitObservation,
+  ManifestEntry,
+  Mutation,
+  ProcessObservation,
+} from "./types.ts";
+
+const executeFile = promisify(execFile);
+const maximumManifestEntries = 4096;
+
+export interface CaptureSelector {
+  structured: readonly { id: string; path: string }[];
+  git: boolean;
+}
+
+export interface CaptureBaseline {
+  manifest: readonly ManifestEntry[];
+}
+
+function digest(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function inside(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith(`..${sep}`) && path !== "..");
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right, "en-US"))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  return value;
+}
+
+async function manifest(project: string): Promise<ManifestEntry[]> {
+  const entries: ManifestEntry[] = [];
+  async function visit(directory: string): Promise<void> {
+    const children = await readdir(directory);
+    children.sort((left, right) => left.localeCompare(right, "en-US"));
+    for (const name of children) {
+      const absolute = join(directory, name);
+      const path = relative(project, absolute).split(sep).join("/");
+      if (path === ".git" || path.startsWith(".git/")) continue;
+      const stats = await lstat(absolute);
+      if (stats.isDirectory()) {
+        entries.push({ path, type: "directory", mode: "directory", size: 0 });
+        await visit(absolute);
+      } else if (stats.isFile()) {
+        const content = await readFile(absolute);
+        entries.push({
+          path,
+          type: "file",
+          mode: (stats.mode & 0o111) === 0 ? "file" : "executable",
+          size: content.byteLength,
+          sha256: digest(content),
+        });
+      } else if (stats.isSymbolicLink()) {
+        const target = await readlink(absolute);
+        entries.push({
+          path,
+          type: "symlink",
+          mode: "symlink",
+          size: Buffer.byteLength(target),
+          target,
+        });
+      } else {
+        throw new Error("Differential filesystem capture found a special file");
+      }
+      if (entries.length > maximumManifestEntries) {
+        throw new Error(
+          "Differential filesystem capture exceeds the entry limit",
+        );
+      }
+    }
+  }
+  await visit(project);
+  return entries;
+}
+
+function mutations(
+  before: readonly ManifestEntry[],
+  after: readonly ManifestEntry[],
+): Mutation[] {
+  const previous = new Map(before.map((entry) => [entry.path, entry]));
+  const current = new Map(after.map((entry) => [entry.path, entry]));
+  const paths = [...new Set([...previous.keys(), ...current.keys()])].sort(
+    (left, right) => left.localeCompare(right, "en-US"),
+  );
+  return paths.flatMap((path): Mutation[] => {
+    const left = previous.get(path);
+    const right = current.get(path);
+    if (left === undefined) return [{ path, kind: "added" }];
+    if (right === undefined) return [{ path, kind: "deleted" }];
+    return JSON.stringify(left) === JSON.stringify(right)
+      ? []
+      : [{ path, kind: "modified" }];
+  });
+}
+
+async function gitOutput(
+  project: string,
+  args: readonly string[],
+): Promise<string> {
+  const result = await executeFile("git", args, {
+    cwd: project,
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      LC_ALL: "C",
+    },
+    maxBuffer: 1024 * 1024,
+    timeout: 5_000,
+  });
+  return result.stdout;
+}
+
+function stream(value: string, disclosure: "digest" | "content") {
+  return {
+    bytes: Buffer.byteLength(value),
+    sha256: digest(value),
+    ...(disclosure === "content" ? { content: value } : {}),
+  };
+}
+
+async function captureGit(
+  project: string,
+  disclosure: "digest" | "content",
+): Promise<GitObservation | null> {
+  try {
+    if (
+      (
+        await gitOutput(project, ["rev-parse", "--is-inside-work-tree"])
+      ).trim() !== "true"
+    ) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  const [headText, status, worktreeDiff, indexDiff, refsText] =
+    await Promise.all([
+      gitOutput(project, ["rev-parse", "HEAD"]),
+      gitOutput(project, ["status", "--porcelain=v2", "--branch"]),
+      gitOutput(project, ["diff", "--binary", "--no-ext-diff"]),
+      gitOutput(project, ["diff", "--cached", "--binary", "--no-ext-diff"]),
+      gitOutput(project, [
+        "for-each-ref",
+        "--format=%(refname)%00%(objectname)",
+      ]),
+    ]);
+  const refs = refsText
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [name, object] = line.split("\0");
+      if (name === undefined || object === undefined) {
+        throw new Error("Differential Git capture returned an invalid ref");
+      }
+      return { name, object };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name, "en-US"));
+  return {
+    head: headText.trim() || null,
+    status: stream(status, disclosure),
+    worktreeDiff: stream(worktreeDiff, disclosure),
+    indexDiff: stream(indexDiff, disclosure),
+    refs,
+  };
+}
+
+export async function captureBefore(
+  project: string,
+  selector: CaptureSelector,
+): Promise<CaptureBaseline> {
+  void selector;
+  return { manifest: await manifest(project) };
+}
+
+export async function captureAfter(
+  project: string,
+  selector: CaptureSelector,
+  baseline: CaptureBaseline,
+  processObservation: ProcessObservation,
+  disclosure: "digest" | "content",
+): Promise<DifferentialObservation> {
+  const after = await manifest(project);
+  const structured = await Promise.all(
+    selector.structured.map(async ({ id, path }) => {
+      try {
+        validateSafeRelativePath(path);
+      } catch {
+        throw new Error("Differential structured capture path is unsafe");
+      }
+      const absolute = join(project, path);
+      const [stats, resolved] = await Promise.all([
+        lstat(absolute),
+        realpath(absolute),
+      ]);
+      if (!stats.isFile() || !inside(project, resolved)) {
+        throw new Error("Differential structured capture path is unsafe");
+      }
+      const source = await readFile(resolved, "utf8");
+      try {
+        return { id, path, value: canonicalize(JSON.parse(source) as unknown) };
+      } catch {
+        throw new Error(
+          `Differential structured capture ${id} contains invalid JSON`,
+        );
+      }
+    }),
+  );
+  return {
+    process: processObservation,
+    filesystem: {
+      before: baseline.manifest,
+      after,
+      mutations: mutations(baseline.manifest, after),
+    },
+    structured,
+    git: selector.git ? await captureGit(project, disclosure) : null,
+  };
+}

--- a/packages/differential/src/compare.ts
+++ b/packages/differential/src/compare.ts
@@ -43,6 +43,43 @@ function safeSummary(value: unknown, pointer: string): unknown {
   return { type: Array.isArray(value) ? "array" : typeof value };
 }
 
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonical(entry)).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    const body = Object.keys(value)
+      .sort((left, right) => left.localeCompare(right, "en-US"))
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(",");
+    return `{${body}}`;
+  }
+  if (value === undefined) return "null";
+  return JSON.stringify(value);
+}
+
+/**
+ * Summarize a captured artifact as bytes and a digest so that mismatch reports
+ * never disclose private key names or scalar values from predecessor output.
+ */
+function artifactDigest(value: unknown): { bytes: number; sha256: string } {
+  const serialized = canonical(value);
+  return {
+    bytes: Buffer.byteLength(serialized),
+    sha256: createHash("sha256").update(serialized).digest("hex"),
+  };
+}
+
+function isOpaqueArtifact(
+  pointer: string,
+  scenario: DifferentialScenario,
+): boolean {
+  return (
+    scenario.disclosure.artifacts === "digest" &&
+    /^\/structured\/\d+\/value$/u.test(pointer)
+  );
+}
+
 function mismatchKind(
   pointer: string,
   expected: unknown,
@@ -79,6 +116,21 @@ function collect(
   output: Mismatch[],
 ): void {
   if (Object.is(expected, actual)) return;
+  if (isOpaqueArtifact(pointer, scenario)) {
+    const oracle =
+      expected === undefined ? undefined : artifactDigest(expected);
+    const candidate = actual === undefined ? undefined : artifactDigest(actual);
+    if (oracle?.sha256 === candidate?.sha256) return;
+    output.push({
+      pointer: `/${side}${pointer}`,
+      kind: mismatchKind(pointer, expected, actual, observation),
+      scenarioId: scenario.id,
+      parityContractIds: scenario.parityContractIds,
+      ...(oracle === undefined ? {} : { oracle }),
+      ...(candidate === undefined ? {} : { candidate }),
+    });
+    return;
+  }
   if (Array.isArray(expected) && Array.isArray(actual)) {
     const length = Math.max(expected.length, actual.length);
     for (let index = 0; index < length; index += 1) {

--- a/packages/differential/src/compare.ts
+++ b/packages/differential/src/compare.ts
@@ -15,7 +15,7 @@ function escapePointer(segment: string): string {
   return segment.replaceAll("~", "~0").replaceAll("/", "~1");
 }
 
-function safeSummary(value: unknown): unknown {
+function safeSummary(value: unknown, pointer: string): unknown {
   if (
     value === null ||
     typeof value === "boolean" ||
@@ -24,6 +24,9 @@ function safeSummary(value: unknown): unknown {
     return value;
   }
   if (typeof value === "string") {
+    if (pointer.endsWith("/sha256") && /^[a-f0-9]{64}$/u.test(value)) {
+      return value;
+    }
     return {
       type: "string",
       bytes: Buffer.byteLength(value),
@@ -113,8 +116,8 @@ function collect(
     kind: mismatchKind(pointer, expected, actual, observation),
     scenarioId: scenario.id,
     parityContractIds: scenario.parityContractIds,
-    oracle: safeSummary(expected),
-    candidate: safeSummary(actual),
+    oracle: safeSummary(expected, pointer),
+    candidate: safeSummary(actual, pointer),
   });
 }
 

--- a/packages/differential/src/compare.ts
+++ b/packages/differential/src/compare.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+
+import type {
+  DifferentialObservation,
+  DifferentialReport,
+  DifferentialScenario,
+  Mismatch,
+} from "./types.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapePointer(segment: string): string {
+  return segment.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+function safeSummary(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return {
+      type: "string",
+      bytes: Buffer.byteLength(value),
+      sha256: createHash("sha256").update(value).digest("hex"),
+    };
+  }
+  if (
+    isRecord(value) &&
+    typeof value.bytes === "number" &&
+    typeof value.sha256 === "string"
+  ) {
+    return { bytes: value.bytes, sha256: value.sha256 };
+  }
+  return { type: Array.isArray(value) ? "array" : typeof value };
+}
+
+function mismatchKind(
+  pointer: string,
+  expected: unknown,
+  actual: unknown,
+  candidate: DifferentialObservation,
+): Mismatch["kind"] {
+  if (pointer === "/process/outcome" && actual === "timeout") return "timeout";
+  if (pointer === "/process/outcome" && actual === "signal") return "crash";
+  if (
+    pointer.startsWith("/filesystem/mutations/") &&
+    (candidate.process.outcome !== "exit" || candidate.process.exitCode !== 0)
+  ) {
+    return "partial_mutation";
+  }
+  if (expected === undefined) return "unexpected";
+  if (actual === undefined) return "missing";
+  if (
+    (Array.isArray(expected) !== Array.isArray(actual) &&
+      (Array.isArray(expected) || Array.isArray(actual))) ||
+    typeof expected !== typeof actual
+  ) {
+    return "type";
+  }
+  return "value";
+}
+
+function collect(
+  expected: unknown,
+  actual: unknown,
+  pointer: string,
+  side: "oracle" | "candidate",
+  scenario: DifferentialScenario,
+  observation: DifferentialObservation,
+  output: Mismatch[],
+): void {
+  if (Object.is(expected, actual)) return;
+  if (Array.isArray(expected) && Array.isArray(actual)) {
+    const length = Math.max(expected.length, actual.length);
+    for (let index = 0; index < length; index += 1) {
+      collect(
+        expected[index],
+        actual[index],
+        `${pointer}/${String(index)}`,
+        side,
+        scenario,
+        observation,
+        output,
+      );
+    }
+    return;
+  }
+  if (isRecord(expected) && isRecord(actual)) {
+    const keys = [
+      ...new Set([...Object.keys(expected), ...Object.keys(actual)]),
+    ].sort();
+    for (const key of keys) {
+      collect(
+        expected[key],
+        actual[key],
+        `${pointer}/${escapePointer(key)}`,
+        side,
+        scenario,
+        observation,
+        output,
+      );
+    }
+    return;
+  }
+  output.push({
+    pointer: `/${side}${pointer}`,
+    kind: mismatchKind(pointer, expected, actual, observation),
+    scenarioId: scenario.id,
+    parityContractIds: scenario.parityContractIds,
+    oracle: safeSummary(expected),
+    candidate: safeSummary(actual),
+  });
+}
+
+export function compareGolden(
+  side: "oracle" | "candidate",
+  scenario: DifferentialScenario,
+  actual: DifferentialObservation,
+): readonly Mismatch[] {
+  const mismatches: Mismatch[] = [];
+  collect(scenario.expected, actual, "", side, scenario, actual, mismatches);
+  return mismatches;
+}
+
+export function compareObservations(
+  scenario: DifferentialScenario,
+  oracle: DifferentialObservation,
+  candidate: DifferentialObservation,
+): DifferentialReport {
+  const mismatches = [
+    ...compareGolden("oracle", scenario, oracle),
+    ...compareGolden("candidate", scenario, candidate),
+  ].sort((left, right) =>
+    `${left.pointer}\u0000${left.kind}`.localeCompare(
+      `${right.pointer}\u0000${right.kind}`,
+      "en-US",
+    ),
+  );
+  return {
+    scenarioId: scenario.id,
+    parityContractIds: scenario.parityContractIds,
+    equal: mismatches.length === 0,
+    mismatches,
+    normalization: scenario.normalization,
+  };
+}

--- a/packages/differential/src/compare.ts
+++ b/packages/differential/src/compare.ts
@@ -15,6 +15,17 @@ function escapePointer(segment: string): string {
   return segment.replaceAll("~", "~0").replaceAll("/", "~1");
 }
 
+/**
+ * Manifest and artifact paths are validated safe relative names and, for public
+ * fixtures, are public by construction. Naming them is what makes a report
+ * actionable; their contents stay digested.
+ */
+function isDisclosablePath(pointer: string): boolean {
+  return /^\/(?:filesystem\/(?:before|after|mutations)\/\d+|structured\/\d+)\/(?:path|id)$/u.test(
+    pointer,
+  );
+}
+
 function safeSummary(value: unknown, pointer: string): unknown {
   if (
     value === null ||
@@ -27,6 +38,7 @@ function safeSummary(value: unknown, pointer: string): unknown {
     if (pointer.endsWith("/sha256") && /^[a-f0-9]{64}$/u.test(value)) {
       return value;
     }
+    if (isDisclosablePath(pointer)) return value;
     return {
       type: "string",
       bytes: Buffer.byteLength(value),
@@ -39,6 +51,11 @@ function safeSummary(value: unknown, pointer: string): unknown {
     typeof value.sha256 === "string"
   ) {
     return { bytes: value.bytes, sha256: value.sha256 };
+  }
+  // A whole manifest entry that appeared or vanished is only actionable if the
+  // report says which path it was.
+  if (isRecord(value) && typeof value.path === "string") {
+    return { path: value.path };
   }
   return { type: Array.isArray(value) ? "array" : typeof value };
 }

--- a/packages/differential/src/index.ts
+++ b/packages/differential/src/index.ts
@@ -1,4 +1,7 @@
+export { captureAfter, captureBefore } from "./capture.ts";
+export type { CaptureBaseline, CaptureSelector } from "./capture.ts";
 export { compareGolden, compareObservations } from "./compare.ts";
+export { materializeWorkspace } from "./materialize.ts";
 export { normalizeObservation } from "./normalize.ts";
 export { loadScenario, validateSafeRelativePath } from "./scenario.ts";
 export type {

--- a/packages/differential/src/index.ts
+++ b/packages/differential/src/index.ts
@@ -3,6 +3,8 @@ export type { CaptureBaseline, CaptureSelector } from "./capture.ts";
 export { compareGolden, compareObservations } from "./compare.ts";
 export { materializeWorkspace } from "./materialize.ts";
 export { normalizeObservation } from "./normalize.ts";
+export { runScenario, runScenarioSide } from "./runner.ts";
+export type { RunSideOptions, SideRun } from "./runner.ts";
 export { loadScenario, validateSafeRelativePath } from "./scenario.ts";
 export type {
   CapturedStream,

--- a/packages/differential/src/index.ts
+++ b/packages/differential/src/index.ts
@@ -1,0 +1,16 @@
+export { loadScenario, validateSafeRelativePath } from "./scenario.ts";
+export type {
+  CapturedStream,
+  DifferentialObservation,
+  DifferentialReport,
+  DifferentialScenario,
+  GitObservation,
+  GoldenAssertions,
+  ManifestEntry,
+  Mismatch,
+  Mutation,
+  NormalizationRule,
+  ProcessObservation,
+  StructuredObservation,
+  WorkspaceEntry,
+} from "./types.ts";

--- a/packages/differential/src/index.ts
+++ b/packages/differential/src/index.ts
@@ -1,3 +1,5 @@
+export { compareGolden, compareObservations } from "./compare.ts";
+export { normalizeObservation } from "./normalize.ts";
 export { loadScenario, validateSafeRelativePath } from "./scenario.ts";
 export type {
   CapturedStream,

--- a/packages/differential/src/materialize.ts
+++ b/packages/differential/src/materialize.ts
@@ -1,0 +1,104 @@
+import { chmod, mkdir, realpath, symlink, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import { validateSafeRelativePath } from "./scenario.ts";
+import type { WorkspaceEntry } from "./types.ts";
+
+const maximumWorkspaceBytes = 4 * 1024 * 1024;
+
+function inside(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith(`..${sep}`) && path !== "..");
+}
+
+function safePath(path: string): string {
+  try {
+    return validateSafeRelativePath(path);
+  } catch {
+    throw new Error("Differential workspace path is unsafe");
+  }
+}
+
+async function verifyParent(
+  project: string,
+  destination: string,
+): Promise<void> {
+  const parent = await realpath(dirname(destination));
+  if (!inside(project, parent)) {
+    throw new Error("Differential workspace path is unsafe");
+  }
+}
+
+export async function materializeWorkspace(
+  root: string,
+  entries: readonly WorkspaceEntry[],
+): Promise<string> {
+  const resolvedRoot = await realpath(root);
+  const aggregateBytes = entries.reduce(
+    (total, entry) =>
+      total +
+      (entry.type === "file" ? Buffer.byteLength(entry.content, "utf8") : 0),
+    0,
+  );
+  if (aggregateBytes > maximumWorkspaceBytes) {
+    throw new Error("Differential workspace exceeds the byte limit");
+  }
+  const foldedPaths = new Set<string>();
+  for (const entry of entries) {
+    safePath(entry.path);
+    if (entry.type === "symlink") safePath(entry.target);
+    const folded = entry.path.toLocaleLowerCase("en-US");
+    if (foldedPaths.has(folded)) {
+      throw new Error("Differential workspace paths collide");
+    }
+    foldedPaths.add(folded);
+  }
+
+  const project = join(resolvedRoot, "project");
+  await mkdir(project, { mode: 0o755 });
+  const resolvedProject = await realpath(project);
+
+  const directories = entries
+    .filter(
+      (entry): entry is Extract<WorkspaceEntry, { type: "directory" }> =>
+        entry.type === "directory",
+    )
+    .sort(
+      (left, right) =>
+        left.path.split("/").length - right.path.split("/").length,
+    );
+  const files = entries.filter(
+    (entry): entry is Extract<WorkspaceEntry, { type: "file" }> =>
+      entry.type === "file",
+  );
+  const links = entries.filter(
+    (entry): entry is Extract<WorkspaceEntry, { type: "symlink" }> =>
+      entry.type === "symlink",
+  );
+
+  for (const entry of directories) {
+    const destination = join(resolvedProject, safePath(entry.path));
+    await verifyParent(resolvedProject, destination);
+    await mkdir(destination, { mode: 0o755 });
+  }
+  for (const entry of files) {
+    const destination = join(resolvedProject, safePath(entry.path));
+    await verifyParent(resolvedProject, destination);
+    await writeFile(destination, entry.content, {
+      encoding: "utf8",
+      flag: "wx",
+    });
+    await chmod(destination, entry.executable ? 0o755 : 0o644);
+  }
+  for (const entry of links) {
+    const destination = join(resolvedProject, safePath(entry.path));
+    const target = safePath(entry.target);
+    await verifyParent(resolvedProject, destination);
+    const resolvedTarget = resolve(dirname(destination), target);
+    if (isAbsolute(target) || !inside(resolvedProject, resolvedTarget)) {
+      throw new Error("Differential workspace path is unsafe");
+    }
+    await symlink(target, destination);
+  }
+  return resolvedProject;
+}

--- a/packages/differential/src/normalize.ts
+++ b/packages/differential/src/normalize.ts
@@ -22,7 +22,9 @@ function isProtected(pointer: string): boolean {
     pointer.startsWith("/filesystem/") ||
     pointer === "/git" ||
     pointer.startsWith("/git/") ||
-    /^\/structured\/\d+\/value\/(?:status|reasonCode)(?:\/|$)/u.test(pointer)
+    /^\/structured\/\d+\/value\/(?:status|exitCode|reasonCode)(?:\/|$)/u.test(
+      pointer,
+    )
   );
 }
 

--- a/packages/differential/src/normalize.ts
+++ b/packages/differential/src/normalize.ts
@@ -1,0 +1,156 @@
+import type { DifferentialObservation, NormalizationRule } from "./types.ts";
+
+function decodePointer(pointer: string): string[] {
+  if (!pointer.startsWith("/") || pointer === "/") {
+    throw new Error("Differential normalization pointer is invalid");
+  }
+  return pointer
+    .slice(1)
+    .split("/")
+    .map((segment) => segment.replaceAll("~1", "/").replaceAll("~0", "~"));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isProtected(pointer: string): boolean {
+  return (
+    pointer === "/process/exitCode" ||
+    pointer === "/process/outcome" ||
+    pointer === "/filesystem" ||
+    pointer.startsWith("/filesystem/") ||
+    pointer === "/git" ||
+    pointer.startsWith("/git/") ||
+    /^\/structured\/\d+\/value\/(?:status|reasonCode)(?:\/|$)/u.test(pointer)
+  );
+}
+
+function locateParent(
+  root: unknown,
+  pointer: string,
+): { parent: Record<string, unknown> | unknown[]; key: string } {
+  const segments = decodePointer(pointer);
+  const key = segments.pop();
+  if (key === undefined) {
+    throw new Error("Differential normalization pointer is invalid");
+  }
+  let current = root;
+  for (const segment of segments) {
+    if (Array.isArray(current)) {
+      const index = Number.parseInt(segment, 10);
+      if (String(index) !== segment || current[index] === undefined) {
+        throw new Error("Differential normalization pointer does not exist");
+      }
+      current = current[index];
+    } else if (isRecord(current) && segment in current) {
+      current = current[segment];
+    } else {
+      throw new Error("Differential normalization pointer does not exist");
+    }
+  }
+  if (!Array.isArray(current) && !isRecord(current)) {
+    throw new Error("Differential normalization pointer does not exist");
+  }
+  return { parent: current, key };
+}
+
+function readValue(
+  parent: Record<string, unknown> | unknown[],
+  key: string,
+): unknown {
+  if (Array.isArray(parent)) {
+    const index = Number.parseInt(key, 10);
+    if (String(index) !== key || parent[index] === undefined) {
+      throw new Error("Differential normalization pointer does not exist");
+    }
+    return parent[index];
+  }
+  if (!(key in parent)) {
+    throw new Error("Differential normalization pointer does not exist");
+  }
+  return parent[key];
+}
+
+function writeValue(
+  parent: Record<string, unknown> | unknown[],
+  key: string,
+  value: unknown,
+): void {
+  if (Array.isArray(parent)) {
+    const index = Number.parseInt(key, 10);
+    parent[index] = value;
+  } else {
+    parent[key] = value;
+  }
+}
+
+function identity(value: unknown, key: string): string {
+  if (!isRecord(value) || !(key in value)) {
+    throw new Error("Differential normalization sort identity is missing");
+  }
+  const candidate = value[key];
+  if (typeof candidate !== "string" && typeof candidate !== "number") {
+    throw new Error("Differential normalization sort identity is invalid");
+  }
+  return `${typeof candidate}:${String(candidate)}`;
+}
+
+export function normalizeObservation(
+  observation: DifferentialObservation,
+  rules: readonly NormalizationRule[],
+  workspace: string,
+): DifferentialObservation {
+  const normalized = structuredClone(observation);
+  for (const rule of rules) {
+    if (isProtected(rule.pointer)) {
+      throw new Error("Differential normalization targets a protected field");
+    }
+    const { parent, key } = locateParent(normalized, rule.pointer);
+    const value = readValue(parent, key);
+    switch (rule.operation) {
+      case "line_endings": {
+        if (typeof value !== "string") {
+          throw new Error("Differential normalization requires a string");
+        }
+        writeValue(parent, key, value.replaceAll("\r\n", "\n"));
+        break;
+      }
+      case "workspace_path": {
+        if (typeof value !== "string" || workspace.length === 0) {
+          throw new Error(
+            "Differential normalization requires a workspace string",
+          );
+        }
+        writeValue(parent, key, value.replaceAll(workspace, "<WORKSPACE>"));
+        break;
+      }
+      case "replace_json_value": {
+        writeValue(parent, key, rule.token);
+        break;
+      }
+      case "sort_json_array": {
+        if (!Array.isArray(value)) {
+          throw new Error("Differential normalization requires an array");
+        }
+        value.sort((left, right) =>
+          identity(left, rule.identityKey).localeCompare(
+            identity(right, rule.identityKey),
+            "en-US",
+          ),
+        );
+        break;
+      }
+      case "remove_field": {
+        if (Array.isArray(parent)) {
+          throw new Error(
+            "Differential normalization cannot remove array items",
+          );
+        }
+        Reflect.deleteProperty(parent, key);
+        break;
+      }
+    }
+  }
+  return normalized;
+}

--- a/packages/differential/src/normalize.ts
+++ b/packages/differential/src/normalize.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { DifferentialObservation, NormalizationRule } from "./types.ts";
 
 function decodePointer(pointer: string): string[] {
@@ -14,17 +16,52 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Fields of the universal result contract that decide an outcome. Rewriting one
+ * at any depth of a captured artifact would normalize away the very difference
+ * the harness exists to detect.
+ */
+const decisionFields = new Set([
+  "status",
+  "exitCode",
+  "reasonCode",
+  "stateChanged",
+  "retryable",
+]);
+
+/**
+ * Protection is prefix-symmetric: a rule is rejected both when it targets a
+ * protected field and when it targets an ancestor of one, because removing the
+ * ancestor removes the protected field with it.
+ */
 function isProtected(pointer: string): boolean {
+  // The only normalizable parts of a stream are the disclosed content bodies.
+  if (
+    pointer === "/process/stdout/content" ||
+    pointer === "/process/stderr/content"
+  ) {
+    return false;
+  }
+  for (const root of ["/process", "/filesystem", "/git"]) {
+    if (
+      pointer === root ||
+      pointer.startsWith(`${root}/`) ||
+      root.startsWith(`${pointer}/`)
+    ) {
+      return true;
+    }
+  }
+  const structured = /^\/structured(?:\/(\d+)(?:\/(.*))?)?$/u.exec(pointer);
+  if (structured === null) return false;
+  const rest = structured[2];
+  // `/structured`, `/structured/N`, and `/structured/N/value` are all ancestors
+  // of a decision field.
+  if (rest === undefined) return true;
+  const segments = rest.split("/");
+  if (segments[0] !== "value") return true;
   return (
-    pointer === "/process/exitCode" ||
-    pointer === "/process/outcome" ||
-    pointer === "/filesystem" ||
-    pointer.startsWith("/filesystem/") ||
-    pointer === "/git" ||
-    pointer.startsWith("/git/") ||
-    /^\/structured\/\d+\/value\/(?:status|exitCode|reasonCode)(?:\/|$)/u.test(
-      pointer,
-    )
+    segments.length === 1 ||
+    segments.slice(1).some((s) => decisionFields.has(s))
   );
 }
 
@@ -98,6 +135,36 @@ function identity(value: unknown, key: string): string {
   return `${typeof candidate}:${String(candidate)}`;
 }
 
+/**
+ * Keep a stream's `bytes` and `sha256` describing the content they accompany
+ * after that content is normalized.
+ */
+function resynchronizeStream(
+  parent: Record<string, unknown> | unknown[],
+  key: string,
+): void {
+  if (key !== "content" || Array.isArray(parent)) return;
+  const content = parent[key];
+  if (typeof content !== "string") return;
+  parent.bytes = Buffer.byteLength(content);
+  parent.sha256 = createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * A rule that reaches into an artifact a side never produced is skipped, so the
+ * missing artifact is reported as the behavioral difference it is instead of
+ * failing the whole run. A missing pointer inside a `valid` artifact remains an
+ * error, so a mistyped rule is still caught.
+ */
+function targetsAbsentArtifact(
+  observation: DifferentialObservation,
+  pointer: string,
+): boolean {
+  const match = /^\/structured\/(\d+)\/value(?:\/|$)/u.exec(pointer);
+  if (match?.[1] === undefined) return false;
+  return observation.structured[Number(match[1])]?.state !== "valid";
+}
+
 export function normalizeObservation(
   observation: DifferentialObservation,
   rules: readonly NormalizationRule[],
@@ -108,6 +175,7 @@ export function normalizeObservation(
     if (isProtected(rule.pointer)) {
       throw new Error("Differential normalization targets a protected field");
     }
+    if (targetsAbsentArtifact(normalized, rule.pointer)) continue;
     const { parent, key } = locateParent(normalized, rule.pointer);
     const value = readValue(parent, key);
     switch (rule.operation) {
@@ -116,6 +184,7 @@ export function normalizeObservation(
           throw new Error("Differential normalization requires a string");
         }
         writeValue(parent, key, value.replaceAll("\r\n", "\n"));
+        resynchronizeStream(parent, key);
         break;
       }
       case "workspace_path": {
@@ -125,6 +194,7 @@ export function normalizeObservation(
           );
         }
         writeValue(parent, key, value.replaceAll(workspace, "<WORKSPACE>"));
+        resynchronizeStream(parent, key);
         break;
       }
       case "replace_json_value": {

--- a/packages/differential/src/runner.ts
+++ b/packages/differential/src/runner.ts
@@ -99,14 +99,17 @@ function terminate(child: ChildProcess, signal: NodeJS.Signals): void {
   }
 }
 
+/**
+ * Summarize the retained stream prefix. `bytes`, `sha256`, and `content` always
+ * describe the same buffer so a bounded capture stays internally consistent.
+ */
 function capturedStream(
   chunks: readonly Buffer[],
-  bytes: number,
   disclosure: "digest" | "content",
 ): CapturedStream {
   const value = Buffer.concat(chunks);
   return {
-    bytes,
+    bytes: value.byteLength,
     sha256: digest(value),
     ...(disclosure === "content" ? { content: value.toString("utf8") } : {}),
   };
@@ -134,19 +137,37 @@ async function execute(
     outcome: "exit",
   };
 
+  let escalation: NodeJS.Timeout | undefined;
+
+  /** Send SIGTERM once, then escalate to SIGKILL after a fixed grace period. */
+  function requestTermination(): void {
+    if (escalation !== undefined) return;
+    terminate(child, "SIGTERM");
+    escalation = setTimeout(() => {
+      terminate(child, "SIGKILL");
+    }, 250);
+  }
+
+  /**
+   * Retain only the prefix that fits within the declared bound, then stop the
+   * child. Dropping the whole overflowing chunk would discard evidence and
+   * leave the reported byte count describing data that was never hashed.
+   */
   function collect(
     chunk: Buffer,
     target: Buffer[],
     current: number,
     maximum: number,
   ): number {
-    const next = current + chunk.byteLength;
-    if (next <= maximum) target.push(chunk);
-    else {
-      termination.outcome = "output_limit";
-      terminate(child, "SIGTERM");
+    const remaining = maximum - current;
+    if (chunk.byteLength <= remaining) {
+      target.push(chunk);
+      return current + chunk.byteLength;
     }
-    return next;
+    if (remaining > 0) target.push(chunk.subarray(0, remaining));
+    termination.outcome = "output_limit";
+    requestTermination();
+    return maximum;
   }
 
   child.stdout.on("data", (chunk: Buffer) => {
@@ -172,16 +193,8 @@ async function execute(
 
   const timeout = setTimeout(() => {
     if (termination.outcome === "exit") termination.outcome = "timeout";
-    terminate(child, "SIGTERM");
+    requestTermination();
   }, scenario.invocation.timeoutMs);
-  const escalation = setTimeout(() => {
-    if (
-      termination.outcome === "timeout" ||
-      termination.outcome === "output_limit"
-    ) {
-      terminate(child, "SIGKILL");
-    }
-  }, scenario.invocation.timeoutMs + 250);
 
   const closed = await new Promise<{
     code: number | null;
@@ -192,7 +205,7 @@ async function execute(
     });
   });
   clearTimeout(timeout);
-  clearTimeout(escalation);
+  if (escalation !== undefined) clearTimeout(escalation);
 
   const outcome =
     termination.outcome === "exit" && closed.signal !== null
@@ -204,8 +217,8 @@ async function execute(
       outcome,
       exitCode: closed.code,
       signal: closed.signal,
-      stdout: capturedStream(stdout, stdoutBytes, scenario.disclosure.stdout),
-      stderr: capturedStream(stderr, stderrBytes, scenario.disclosure.stderr),
+      stdout: capturedStream(stdout, scenario.disclosure.stdout),
+      stderr: capturedStream(stderr, scenario.disclosure.stderr),
     },
   };
 }

--- a/packages/differential/src/runner.ts
+++ b/packages/differential/src/runner.ts
@@ -1,0 +1,282 @@
+import { createHash } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { captureAfter, captureBefore } from "./capture.ts";
+import { compareObservations } from "./compare.ts";
+import { materializeWorkspace } from "./materialize.ts";
+import { normalizeObservation } from "./normalize.ts";
+import type {
+  CapturedStream,
+  DifferentialObservation,
+  DifferentialReport,
+  DifferentialScenario,
+  ProcessObservation,
+} from "./types.ts";
+
+export interface RunSideOptions {
+  side: "oracle" | "candidate";
+  executable: string;
+  scenario: DifferentialScenario;
+  temporaryParent?: string;
+}
+
+export interface SideRun {
+  side: "oracle" | "candidate";
+  executableSha256: string;
+  durationMs: number;
+  observation: DifferentialObservation;
+}
+
+interface ProcessRun {
+  observation: ProcessObservation;
+  durationMs: number;
+}
+
+function digest(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function verifyExecutable(
+  path: string,
+): Promise<{ path: string; sha256: string }> {
+  const resolved = await realpath(path);
+  const stats = await lstat(resolved);
+  if (!stats.isFile()) {
+    throw new Error("Differential runner executable is not a regular file");
+  }
+  return { path: resolved, sha256: digest(await readFile(resolved)) };
+}
+
+function safeEnvironment(
+  root: string,
+  scenario: DifferentialScenario,
+): NodeJS.ProcessEnv {
+  const inherited = ["PATH", "SystemRoot", "WINDIR", "PATHEXT"] as const;
+  const environment: NodeJS.ProcessEnv = {};
+  for (const key of inherited) {
+    const value = process.env[key];
+    if (value !== undefined) environment[key] = value;
+  }
+  return {
+    ...environment,
+    ...scenario.invocation.environment,
+    HOME: join(root, "home"),
+    TMPDIR: join(root, "tmp"),
+    LANG: "C.UTF-8",
+    LC_ALL: "C.UTF-8",
+    NO_COLOR: "1",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+  };
+}
+
+function terminate(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (
+    child.pid === undefined ||
+    child.exitCode !== null ||
+    child.signalCode !== null
+  )
+    return;
+  try {
+    if (process.platform !== "win32") process.kill(-child.pid, signal);
+    else child.kill(signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process already exited between the state check and signal.
+    }
+  }
+}
+
+function capturedStream(
+  chunks: readonly Buffer[],
+  bytes: number,
+  disclosure: "digest" | "content",
+): CapturedStream {
+  const value = Buffer.concat(chunks);
+  return {
+    bytes,
+    sha256: digest(value),
+    ...(disclosure === "content" ? { content: value.toString("utf8") } : {}),
+  };
+}
+
+async function execute(
+  executable: string,
+  project: string,
+  root: string,
+  scenario: DifferentialScenario,
+): Promise<ProcessRun> {
+  const started = performance.now();
+  const child = spawn(executable, scenario.invocation.args, {
+    shell: false,
+    detached: process.platform !== "win32",
+    cwd: project,
+    env: safeEnvironment(root, scenario),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  const termination: { outcome: ProcessObservation["outcome"] } = {
+    outcome: "exit",
+  };
+
+  function collect(
+    chunk: Buffer,
+    target: Buffer[],
+    current: number,
+    maximum: number,
+  ): number {
+    const next = current + chunk.byteLength;
+    if (next <= maximum) target.push(chunk);
+    else {
+      termination.outcome = "output_limit";
+      terminate(child, "SIGTERM");
+    }
+    return next;
+  }
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdoutBytes = collect(
+      chunk,
+      stdout,
+      stdoutBytes,
+      scenario.invocation.maxStdoutBytes,
+    );
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderrBytes = collect(
+      chunk,
+      stderr,
+      stderrBytes,
+      scenario.invocation.maxStderrBytes,
+    );
+  });
+  child.on("error", () => {
+    termination.outcome = "spawn_error";
+  });
+  child.stdin.end(scenario.invocation.stdin);
+
+  const timeout = setTimeout(() => {
+    if (termination.outcome === "exit") termination.outcome = "timeout";
+    terminate(child, "SIGTERM");
+  }, scenario.invocation.timeoutMs);
+  const escalation = setTimeout(() => {
+    if (
+      termination.outcome === "timeout" ||
+      termination.outcome === "output_limit"
+    ) {
+      terminate(child, "SIGKILL");
+    }
+  }, scenario.invocation.timeoutMs + 250);
+
+  const closed = await new Promise<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }>((resolve) => {
+    child.on("close", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+  clearTimeout(timeout);
+  clearTimeout(escalation);
+
+  const outcome =
+    termination.outcome === "exit" && closed.signal !== null
+      ? "signal"
+      : termination.outcome;
+  return {
+    durationMs: Math.max(0, performance.now() - started),
+    observation: {
+      outcome,
+      exitCode: closed.code,
+      signal: closed.signal,
+      stdout: capturedStream(stdout, stdoutBytes, scenario.disclosure.stdout),
+      stderr: capturedStream(stderr, stderrBytes, scenario.disclosure.stderr),
+    },
+  };
+}
+
+export async function runScenarioSide(
+  options: RunSideOptions,
+): Promise<SideRun> {
+  const executable = await verifyExecutable(options.executable);
+  const parent = options.temporaryParent ?? tmpdir();
+  const root = await mkdtemp(
+    join(parent, `yoda-differential-${options.side}-`),
+  );
+  try {
+    await Promise.all([
+      mkdir(join(root, "home"), { mode: 0o700 }),
+      mkdir(join(root, "tmp"), { mode: 0o700 }),
+    ]);
+    const project = await materializeWorkspace(
+      root,
+      options.scenario.workspace.entries,
+    );
+    const baseline = await captureBefore(project, options.scenario.capture);
+    const processRun = await execute(
+      executable.path,
+      project,
+      root,
+      options.scenario,
+    );
+    const captured = await captureAfter(
+      project,
+      options.scenario.capture,
+      baseline,
+      processRun.observation,
+      options.scenario.disclosure.artifacts,
+    );
+    return {
+      side: options.side,
+      executableSha256: executable.sha256,
+      durationMs: processRun.durationMs,
+      observation: normalizeObservation(
+        captured,
+        options.scenario.normalization,
+        project,
+      ),
+    };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+export async function runScenario(
+  scenario: DifferentialScenario,
+  oracleExecutable: string,
+  candidateExecutable: string,
+  temporaryParent?: string,
+): Promise<DifferentialReport> {
+  const oracle = await runScenarioSide({
+    side: "oracle",
+    executable: oracleExecutable,
+    scenario,
+    ...(temporaryParent === undefined ? {} : { temporaryParent }),
+  });
+  const candidate = await runScenarioSide({
+    side: "candidate",
+    executable: candidateExecutable,
+    scenario,
+    ...(temporaryParent === undefined ? {} : { temporaryParent }),
+  });
+  return compareObservations(
+    scenario,
+    oracle.observation,
+    candidate.observation,
+  );
+}

--- a/packages/differential/src/runner.ts
+++ b/packages/differential/src/runner.ts
@@ -189,6 +189,13 @@ async function execute(
   child.on("error", () => {
     termination.outcome = "spawn_error";
   });
+  // A child is free to exit without draining stdin, which fails the pending
+  // write with EPIPE. That is observable through the child's own outcome, so
+  // it must not become an unhandled rejection that bypasses cleanup, leaks the
+  // sandbox, prints a stack trace, and exits with the mismatch code.
+  child.stdin.on("error", () => {
+    // Deliberately ignored; see above.
+  });
   child.stdin.end(scenario.invocation.stdin);
 
   const timeout = setTimeout(() => {
@@ -231,6 +238,7 @@ export async function runScenarioSide(
   const root = await mkdtemp(
     join(parent, `yoda-differential-${options.side}-`),
   );
+  let run: SideRun;
   try {
     await Promise.all([
       mkdir(join(root, "home"), { mode: 0o700 }),
@@ -254,7 +262,7 @@ export async function runScenarioSide(
       processRun.observation,
       options.scenario.disclosure.artifacts,
     );
-    return {
+    run = {
       side: options.side,
       executableSha256: executable.sha256,
       durationMs: processRun.durationMs,
@@ -264,9 +272,16 @@ export async function runScenarioSide(
         project,
       ),
     };
-  } finally {
-    await rm(root, { recursive: true, force: true });
+  } catch (error) {
+    // Clean up without letting a cleanup failure replace and hide the real
+    // cause of the run failure.
+    await rm(root, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
   }
+  // On the success path a failed cleanup is itself a harness failure: a leaked
+  // sandbox must never pass silently.
+  await rm(root, { recursive: true, force: true });
+  return run;
 }
 
 export async function runScenario(

--- a/packages/differential/src/scenario.ts
+++ b/packages/differential/src/scenario.ts
@@ -1,0 +1,108 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { Ajv2020, type AnySchemaObject } from "ajv/dist/2020.js";
+
+import type { DifferentialScenario } from "./types.ts";
+
+const defaultSchemaPath = join(
+  import.meta.dirname,
+  "../../../schemas/compatibility/differential-scenario.v1.schema.json",
+);
+const defaultObservationSchemaPath = join(
+  import.meta.dirname,
+  "../../../schemas/compatibility/differential-observation.v1.schema.json",
+);
+const defaultMatrixPath = join(
+  import.meta.dirname,
+  "../../../compatibility/inventory/go-v3-v0.6.5/matrix.json",
+);
+const unsafePath =
+  /(?:^|\/)(?:\.{1,2}|)(?:\/|$)|\\|^[A-Za-z]:|^[a-z][a-z0-9+.-]*:/iu;
+
+interface MatrixDocument {
+  rows: readonly { id: string }[];
+}
+
+function publicScenarioId(value: unknown): string {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    /^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(value.id)
+  ) {
+    return value.id;
+  }
+  return "unknown";
+}
+
+export function validateSafeRelativePath(path: string): string {
+  let hasControlCharacter = false;
+  for (let index = 0; index < path.length; index += 1) {
+    const code = path.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) {
+      hasControlCharacter = true;
+      break;
+    }
+  }
+  if (
+    path.length === 0 ||
+    path.startsWith("/") ||
+    path.endsWith("/") ||
+    path.includes("//") ||
+    hasControlCharacter ||
+    unsafePath.test(path)
+  ) {
+    throw new Error("Differential scenario path is unsafe");
+  }
+  return path;
+}
+
+export async function loadScenario(
+  path: string,
+  matrixPath = defaultMatrixPath,
+): Promise<DifferentialScenario> {
+  const [scenarioSource, schemaSource, observationSchemaSource, matrixSource] =
+    await Promise.all([
+      readFile(path, "utf8"),
+      readFile(defaultSchemaPath, "utf8"),
+      readFile(defaultObservationSchemaPath, "utf8"),
+      readFile(matrixPath, "utf8"),
+    ]);
+  const candidate: unknown = JSON.parse(scenarioSource);
+  const scenarioId = publicScenarioId(candidate);
+  const ajv = new Ajv2020({ allErrors: false, strict: true });
+  ajv.addSchema(JSON.parse(observationSchemaSource) as AnySchemaObject);
+  const validate = ajv.compile(JSON.parse(schemaSource) as AnySchemaObject);
+  if (!validate(candidate)) {
+    const keyword = validate.errors?.[0]?.keyword ?? "schema";
+    throw new Error(
+      `Differential scenario ${scenarioId} is invalid: ${keyword}`,
+    );
+  }
+
+  const scenario = candidate as DifferentialScenario;
+  const matrix = JSON.parse(matrixSource) as MatrixDocument;
+  const rowIds = new Set(matrix.rows.map(({ id }) => id));
+  if (scenario.parityContractIds.some((id) => !rowIds.has(id))) {
+    throw new Error(
+      `Differential scenario ${scenario.id} references an unknown parity contract`,
+    );
+  }
+
+  const foldedPaths = new Set<string>();
+  for (const entry of scenario.workspace.entries) {
+    validateSafeRelativePath(entry.path);
+    if (entry.type === "symlink") validateSafeRelativePath(entry.target);
+    const folded = entry.path.toLocaleLowerCase("en-US");
+    if (foldedPaths.has(folded)) {
+      throw new Error(
+        `Differential scenario ${scenario.id} contains colliding workspace paths`,
+      );
+    }
+    foldedPaths.add(folded);
+  }
+
+  return scenario;
+}

--- a/packages/differential/src/types.ts
+++ b/packages/differential/src/types.ts
@@ -55,11 +55,22 @@ export interface Mutation {
   kind: "added" | "modified" | "deleted";
 }
 
-export interface StructuredObservation {
-  id: string;
-  path: string;
-  value: unknown;
-}
+/**
+ * A selected artifact is always observable. Absence, an unreadable path, and
+ * unparsable content are behavioral differences to compare, not harness
+ * failures, so each is a distinct explicit state.
+ */
+export type StructuredObservation =
+  | { id: string; path: string; state: "absent" }
+  | { id: string; path: string; state: "unreadable" }
+  | {
+      id: string;
+      path: string;
+      state: "invalid";
+      bytes: number;
+      sha256: string;
+    }
+  | { id: string; path: string; state: "valid"; value: unknown };
 
 export interface GitObservation {
   head: string | null;

--- a/packages/differential/src/types.ts
+++ b/packages/differential/src/types.ts
@@ -1,0 +1,133 @@
+export type WorkspaceEntry =
+  | { type: "directory"; path: string }
+  | {
+      type: "file";
+      path: string;
+      content: string;
+      executable: boolean;
+    }
+  | { type: "symlink"; path: string; target: string };
+
+export type NormalizationRule =
+  | { operation: "line_endings"; pointer: string }
+  | { operation: "workspace_path"; pointer: string }
+  | {
+      operation: "replace_json_value";
+      pointer: string;
+      token: "<TIMESTAMP>" | "<DURATION>";
+    }
+  | {
+      operation: "sort_json_array";
+      pointer: string;
+      identityKey: string;
+    }
+  | {
+      operation: "remove_field";
+      pointer: string;
+      justification: string;
+    };
+
+export interface CapturedStream {
+  bytes: number;
+  sha256: string;
+  content?: string;
+}
+
+export interface ProcessObservation {
+  outcome: "exit" | "signal" | "timeout" | "output_limit" | "spawn_error";
+  exitCode: number | null;
+  signal: string | null;
+  stdout: CapturedStream;
+  stderr: CapturedStream;
+}
+
+export interface ManifestEntry {
+  path: string;
+  type: "directory" | "file" | "symlink";
+  mode: "directory" | "file" | "executable" | "symlink";
+  size: number;
+  sha256?: string;
+  target?: string;
+}
+
+export interface Mutation {
+  path: string;
+  kind: "added" | "modified" | "deleted";
+}
+
+export interface StructuredObservation {
+  id: string;
+  path: string;
+  value: unknown;
+}
+
+export interface GitObservation {
+  head: string | null;
+  status: CapturedStream;
+  worktreeDiff: CapturedStream;
+  indexDiff: CapturedStream;
+  refs: readonly { name: string; object: string }[];
+}
+
+export interface DifferentialObservation {
+  process: ProcessObservation;
+  filesystem: {
+    before: readonly ManifestEntry[];
+    after: readonly ManifestEntry[];
+    mutations: readonly Mutation[];
+  };
+  structured: readonly StructuredObservation[];
+  git: GitObservation | null;
+}
+
+export type GoldenAssertions = DifferentialObservation;
+
+export interface DifferentialScenario {
+  schemaVersion: 1;
+  id: string;
+  parityContractIds: string[];
+  workspace: { entries: WorkspaceEntry[] };
+  invocation: {
+    args: string[];
+    stdin: string;
+    environment: Record<string, string>;
+    timeoutMs: number;
+    maxStdoutBytes: number;
+    maxStderrBytes: number;
+  };
+  capture: {
+    structured: { id: string; path: string }[];
+    git: boolean;
+  };
+  normalization: NormalizationRule[];
+  disclosure: {
+    stdout: "digest" | "content";
+    stderr: "digest" | "content";
+    artifacts: "digest" | "content";
+  };
+  expected: GoldenAssertions;
+}
+
+export interface Mismatch {
+  pointer: string;
+  kind:
+    | "missing"
+    | "unexpected"
+    | "type"
+    | "value"
+    | "timeout"
+    | "crash"
+    | "partial_mutation";
+  scenarioId: string;
+  parityContractIds: readonly string[];
+  oracle?: unknown;
+  candidate?: unknown;
+}
+
+export interface DifferentialReport {
+  scenarioId: string;
+  parityContractIds: readonly string[];
+  equal: boolean;
+  mismatches: readonly Mismatch[];
+  normalization: readonly NormalizationRule[];
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -28,6 +28,13 @@ The host family contains
 [`adapter-message.v1.schema.json`](host/adapter-message.v1.schema.json), and the
 registry format is
 [`contract-manifest.v1.schema.json`](contracts/contract-manifest.v1.schema.json).
+
+The compatibility test family contains the closed
+[`differential-scenario.v1.schema.json`](compatibility/differential-scenario.v1.schema.json)
+and
+[`differential-observation.v1.schema.json`](compatibility/differential-observation.v1.schema.json)
+contracts. They bound isolated inputs, capture selection, normalization,
+disclosure, and golden observations; they do not claim runtime parity.
 See the [contract versioning guide](../docs/compatibility/contract-versioning.md)
 for compatibility windows, provenance, and PRD guarantees.
 

--- a/schemas/compatibility/differential-observation.v1.schema.json
+++ b/schemas/compatibility/differential-observation.v1.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mestre-yoda.dev/schemas/compatibility/differential-observation.v1.schema.json",
+  "title": "Mestre Yoda differential observation v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["process", "filesystem", "structured", "git"],
+  "properties": {
+    "process": { "$ref": "#/$defs/process" },
+    "filesystem": { "$ref": "#/$defs/filesystem" },
+    "structured": {
+      "type": "array",
+      "maxItems": 64,
+      "items": { "$ref": "#/$defs/structured" }
+    },
+    "git": {
+      "anyOf": [{ "$ref": "#/$defs/git" }, { "type": "null" }]
+    }
+  },
+  "$defs": {
+    "digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "safePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?![a-zA-Z][a-zA-Z0-9+.-]*:)(?!.*\\\\)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*//)(?!.*[\\u0000-\\u001f\\u007f]).+(?<!/)$"
+    },
+    "stream": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bytes", "sha256"],
+      "properties": {
+        "bytes": { "type": "integer", "minimum": 0, "maximum": 1048576 },
+        "sha256": { "$ref": "#/$defs/digest" },
+        "content": { "type": "string", "maxLength": 1048576 }
+      }
+    },
+    "process": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome", "exitCode", "signal", "stdout", "stderr"],
+      "properties": {
+        "outcome": {
+          "enum": ["exit", "signal", "timeout", "output_limit", "spawn_error"]
+        },
+        "exitCode": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0, "maximum": 255 },
+            { "type": "null" }
+          ]
+        },
+        "signal": {
+          "anyOf": [
+            { "type": "string", "pattern": "^SIG[A-Z0-9]+$" },
+            { "type": "null" }
+          ]
+        },
+        "stdout": { "$ref": "#/$defs/stream" },
+        "stderr": { "$ref": "#/$defs/stream" }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "type", "mode", "size"],
+      "properties": {
+        "path": { "$ref": "#/$defs/safePath" },
+        "type": { "enum": ["directory", "file", "symlink"] },
+        "mode": { "enum": ["directory", "file", "executable", "symlink"] },
+        "size": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "sha256": { "$ref": "#/$defs/digest" },
+        "target": { "$ref": "#/$defs/safePath" }
+      }
+    },
+    "mutation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind"],
+      "properties": {
+        "path": { "$ref": "#/$defs/safePath" },
+        "kind": { "enum": ["added", "modified", "deleted"] }
+      }
+    },
+    "filesystem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["before", "after", "mutations"],
+      "properties": {
+        "before": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": { "$ref": "#/$defs/manifest" }
+        },
+        "after": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": { "$ref": "#/$defs/manifest" }
+        },
+        "mutations": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": { "$ref": "#/$defs/mutation" }
+        }
+      }
+    },
+    "structured": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "path", "value"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" },
+        "path": { "$ref": "#/$defs/safePath" },
+        "value": true
+      }
+    },
+    "ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "object": { "type": "string", "pattern": "^[a-f0-9]{40,64}$" }
+      }
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["head", "status", "worktreeDiff", "indexDiff", "refs"],
+      "properties": {
+        "head": {
+          "anyOf": [
+            { "type": "string", "pattern": "^[a-f0-9]{40,64}$" },
+            { "type": "null" }
+          ]
+        },
+        "status": { "$ref": "#/$defs/stream" },
+        "worktreeDiff": { "$ref": "#/$defs/stream" },
+        "indexDiff": { "$ref": "#/$defs/stream" },
+        "refs": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": { "$ref": "#/$defs/ref" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/compatibility/differential-observation.v1.schema.json
+++ b/schemas/compatibility/differential-observation.v1.schema.json
@@ -6,19 +6,35 @@
   "additionalProperties": false,
   "required": ["process", "filesystem", "structured", "git"],
   "properties": {
-    "process": { "$ref": "#/$defs/process" },
-    "filesystem": { "$ref": "#/$defs/filesystem" },
+    "process": {
+      "$ref": "#/$defs/process"
+    },
+    "filesystem": {
+      "$ref": "#/$defs/filesystem"
+    },
     "structured": {
       "type": "array",
       "maxItems": 64,
-      "items": { "$ref": "#/$defs/structured" }
+      "items": {
+        "$ref": "#/$defs/structured"
+      }
     },
     "git": {
-      "anyOf": [{ "$ref": "#/$defs/git" }, { "type": "null" }]
+      "anyOf": [
+        {
+          "$ref": "#/$defs/git"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "$defs": {
-    "digest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "digest": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
     "safePath": {
       "type": "string",
       "minLength": 1,
@@ -30,9 +46,18 @@
       "additionalProperties": false,
       "required": ["bytes", "sha256"],
       "properties": {
-        "bytes": { "type": "integer", "minimum": 0, "maximum": 1048576 },
-        "sha256": { "$ref": "#/$defs/digest" },
-        "content": { "type": "string", "maxLength": 1048576 }
+        "bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1048576
+        },
+        "sha256": {
+          "$ref": "#/$defs/digest"
+        },
+        "content": {
+          "type": "string",
+          "maxLength": 1048576
+        }
       }
     },
     "process": {
@@ -45,18 +70,33 @@
         },
         "exitCode": {
           "anyOf": [
-            { "type": "integer", "minimum": 0, "maximum": 255 },
-            { "type": "null" }
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "signal": {
           "anyOf": [
-            { "type": "string", "pattern": "^SIG[A-Z0-9]+$" },
-            { "type": "null" }
+            {
+              "type": "string",
+              "pattern": "^SIG[A-Z0-9]+$"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
-        "stdout": { "$ref": "#/$defs/stream" },
-        "stderr": { "$ref": "#/$defs/stream" }
+        "stdout": {
+          "$ref": "#/$defs/stream"
+        },
+        "stderr": {
+          "$ref": "#/$defs/stream"
+        }
       }
     },
     "manifest": {
@@ -64,16 +104,26 @@
       "additionalProperties": false,
       "required": ["path", "type", "mode", "size"],
       "properties": {
-        "path": { "$ref": "#/$defs/safePath" },
-        "type": { "enum": ["directory", "file", "symlink"] },
-        "mode": { "enum": ["directory", "file", "executable", "symlink"] },
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "type": {
+          "enum": ["directory", "file", "symlink"]
+        },
+        "mode": {
+          "enum": ["directory", "file", "executable", "symlink"]
+        },
         "size": {
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
         },
-        "sha256": { "$ref": "#/$defs/digest" },
-        "target": { "$ref": "#/$defs/safePath" }
+        "sha256": {
+          "$ref": "#/$defs/digest"
+        },
+        "target": {
+          "$ref": "#/$defs/safePath"
+        }
       }
     },
     "mutation": {
@@ -81,8 +131,12 @@
       "additionalProperties": false,
       "required": ["path", "kind"],
       "properties": {
-        "path": { "$ref": "#/$defs/safePath" },
-        "kind": { "enum": ["added", "modified", "deleted"] }
+        "path": {
+          "$ref": "#/$defs/safePath"
+        },
+        "kind": {
+          "enum": ["added", "modified", "deleted"]
+        }
       }
     },
     "filesystem": {
@@ -93,37 +147,121 @@
         "before": {
           "type": "array",
           "maxItems": 4096,
-          "items": { "$ref": "#/$defs/manifest" }
+          "items": {
+            "$ref": "#/$defs/manifest"
+          }
         },
         "after": {
           "type": "array",
           "maxItems": 4096,
-          "items": { "$ref": "#/$defs/manifest" }
+          "items": {
+            "$ref": "#/$defs/manifest"
+          }
         },
         "mutations": {
           "type": "array",
           "maxItems": 4096,
-          "items": { "$ref": "#/$defs/mutation" }
+          "items": {
+            "$ref": "#/$defs/mutation"
+          }
         }
       }
     },
     "structured": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["id", "path", "value"],
-      "properties": {
-        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" },
-        "path": { "$ref": "#/$defs/safePath" },
-        "value": true
-      }
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "path", "state"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]{0,63}$"
+            },
+            "path": {
+              "$ref": "#/$defs/safePath"
+            },
+            "state": {
+              "const": "absent"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "path", "state"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]{0,63}$"
+            },
+            "path": {
+              "$ref": "#/$defs/safePath"
+            },
+            "state": {
+              "const": "unreadable"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "path", "state", "bytes", "sha256"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]{0,63}$"
+            },
+            "path": {
+              "$ref": "#/$defs/safePath"
+            },
+            "state": {
+              "const": "invalid"
+            },
+            "bytes": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1048576
+            },
+            "sha256": {
+              "$ref": "#/$defs/digest"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "path", "state", "value"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]{0,63}$"
+            },
+            "path": {
+              "$ref": "#/$defs/safePath"
+            },
+            "state": {
+              "const": "valid"
+            },
+            "value": true
+          }
+        }
+      ]
     },
     "ref": {
       "type": "object",
       "additionalProperties": false,
       "required": ["name", "object"],
       "properties": {
-        "name": { "type": "string", "minLength": 1, "maxLength": 512 },
-        "object": { "type": "string", "pattern": "^[a-f0-9]{40,64}$" }
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "object": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40,64}$"
+        }
       }
     },
     "git": {
@@ -133,17 +271,30 @@
       "properties": {
         "head": {
           "anyOf": [
-            { "type": "string", "pattern": "^[a-f0-9]{40,64}$" },
-            { "type": "null" }
+            {
+              "type": "string",
+              "pattern": "^[a-f0-9]{40,64}$"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
-        "status": { "$ref": "#/$defs/stream" },
-        "worktreeDiff": { "$ref": "#/$defs/stream" },
-        "indexDiff": { "$ref": "#/$defs/stream" },
+        "status": {
+          "$ref": "#/$defs/stream"
+        },
+        "worktreeDiff": {
+          "$ref": "#/$defs/stream"
+        },
+        "indexDiff": {
+          "$ref": "#/$defs/stream"
+        },
         "refs": {
           "type": "array",
           "maxItems": 4096,
-          "items": { "$ref": "#/$defs/ref" }
+          "items": {
+            "$ref": "#/$defs/ref"
+          }
         }
       }
     }

--- a/schemas/compatibility/differential-scenario.v1.schema.json
+++ b/schemas/compatibility/differential-scenario.v1.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mestre-yoda.dev/schemas/compatibility/differential-scenario.v1.schema.json",
+  "title": "Mestre Yoda differential scenario v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "parityContractIds",
+    "workspace",
+    "invocation",
+    "capture",
+    "normalization",
+    "disclosure",
+    "expected"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "maxLength": 96
+    },
+    "parityContractIds": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": { "type": "string", "pattern": "^[A-Z0-9]+(?:-[A-Z0-9]+)*$" }
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["entries"],
+      "properties": {
+        "entries": {
+          "type": "array",
+          "maxItems": 256,
+          "items": { "$ref": "#/$defs/workspaceEntry" }
+        }
+      }
+    },
+    "invocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "args",
+        "stdin",
+        "environment",
+        "timeoutMs",
+        "maxStdoutBytes",
+        "maxStderrBytes"
+      ],
+      "properties": {
+        "args": {
+          "type": "array",
+          "maxItems": 128,
+          "items": { "type": "string", "maxLength": 4096 }
+        },
+        "stdin": { "type": "string", "maxLength": 1048576 },
+        "environment": {
+          "type": "object",
+          "maxProperties": 32,
+          "propertyNames": { "pattern": "^[A-Z][A-Z0-9_]{0,63}$" },
+          "additionalProperties": { "type": "string", "maxLength": 4096 }
+        },
+        "timeoutMs": { "type": "integer", "minimum": 50, "maximum": 30000 },
+        "maxStdoutBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1048576
+        },
+        "maxStderrBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1048576
+        }
+      }
+    },
+    "capture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["structured", "git"],
+      "properties": {
+        "structured": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/structuredSelector" }
+        },
+        "git": { "type": "boolean" }
+      }
+    },
+    "normalization": {
+      "type": "array",
+      "maxItems": 32,
+      "items": { "$ref": "#/$defs/normalization" }
+    },
+    "disclosure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stdout", "stderr", "artifacts"],
+      "properties": {
+        "stdout": { "enum": ["digest", "content"] },
+        "stderr": { "enum": ["digest", "content"] },
+        "artifacts": { "enum": ["digest", "content"] }
+      }
+    },
+    "expected": {
+      "$ref": "https://mestre-yoda.dev/schemas/compatibility/differential-observation.v1.schema.json"
+    }
+  },
+  "$defs": {
+    "safePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?![a-zA-Z][a-zA-Z0-9+.-]*:)(?!.*\\\\)(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*//)(?!.*[\\u0000-\\u001f\\u007f]).+(?<!/)$"
+    },
+    "workspaceEntry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "path"],
+          "properties": {
+            "type": { "const": "directory" },
+            "path": { "$ref": "#/$defs/safePath" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "path", "content", "executable"],
+          "properties": {
+            "type": { "const": "file" },
+            "path": { "$ref": "#/$defs/safePath" },
+            "content": { "type": "string", "maxLength": 262144 },
+            "executable": { "type": "boolean" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "path", "target"],
+          "properties": {
+            "type": { "const": "symlink" },
+            "path": { "$ref": "#/$defs/safePath" },
+            "target": { "$ref": "#/$defs/safePath" }
+          }
+        }
+      ]
+    },
+    "structuredSelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "path"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]{0,63}$" },
+        "path": { "$ref": "#/$defs/safePath" }
+      }
+    },
+    "pointer": { "type": "string", "pattern": "^(?:/(?:[^~/]|~0|~1)*)+$" },
+    "normalization": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operation", "pointer"],
+          "properties": {
+            "operation": { "enum": ["line_endings", "workspace_path"] },
+            "pointer": { "$ref": "#/$defs/pointer" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operation", "pointer", "token"],
+          "properties": {
+            "operation": { "const": "replace_json_value" },
+            "pointer": { "$ref": "#/$defs/pointer" },
+            "token": { "enum": ["<TIMESTAMP>", "<DURATION>"] }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operation", "pointer", "identityKey"],
+          "properties": {
+            "operation": { "const": "sort_json_array" },
+            "pointer": { "$ref": "#/$defs/pointer" },
+            "identityKey": {
+              "type": "string",
+              "pattern": "^[A-Za-z][A-Za-z0-9_-]{0,63}$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operation", "pointer", "justification"],
+          "properties": {
+            "operation": { "const": "remove_field" },
+            "pointer": { "$ref": "#/$defs/pointer" },
+            "justification": {
+              "type": "string",
+              "minLength": 8,
+              "maxLength": 256,
+              "pattern": "^[^\\r\\n]+$"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/scripts/run-differential.mjs
+++ b/scripts/run-differential.mjs
@@ -171,10 +171,16 @@ async function main() {
 
   const corpusPath = resolve(options.corpus);
   const corpusDirectory = dirname(corpusPath);
-  let corpus;
+  let rowIds;
   try {
     const matrix = JSON.parse(await readFile(parityMatrix, "utf8"));
-    const rowIds = new Set(matrix.rows.map(({ id }) => id));
+    rowIds = new Set(matrix.rows.map(({ id }) => id));
+  } catch {
+    // Distinguish a broken repository install from a bad corpus.
+    throw new Error("Differential parity matrix is unreadable");
+  }
+  let corpus;
+  try {
     corpus = validateCorpus(
       JSON.parse(await readFile(corpusPath, "utf8")),
       rowIds,

--- a/scripts/run-differential.mjs
+++ b/scripts/run-differential.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+
+import {
+  loadScenario,
+  runScenario,
+  validateSafeRelativePath,
+} from "@mestre-yoda/differential";
+
+const defaultCorpus = join(
+  import.meta.dirname,
+  "../compatibility/fixtures/differential/v1/corpus.json",
+);
+const parityMatrix = join(
+  import.meta.dirname,
+  "../compatibility/inventory/go-v3-v0.6.5/matrix.json",
+);
+const frozenOracleDigest =
+  "da4ec4a2394ae90a94722f633bcb9157ddc5ee0133f46540b7c2c700abe378b8";
+
+class UsageError extends Error {}
+class ProvenanceError extends Error {}
+
+function exactKeys(value, allowed) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).every((key) => allowed.includes(key))
+  );
+}
+
+function parseOptions(args) {
+  const options = {
+    className: "self-test",
+    format: "json",
+    corpus: defaultCorpus,
+    oracle: undefined,
+    candidate: undefined,
+  };
+  const seen = new Set();
+  const names = new Map([
+    ["--class", "className"],
+    ["--format", "format"],
+    ["--corpus", "corpus"],
+    ["--oracle", "oracle"],
+    ["--candidate", "candidate"],
+  ]);
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    if (!names.has(name)) throw new UsageError("unknown option");
+    if (seen.has(name)) throw new UsageError("duplicate option");
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new UsageError("missing value");
+    }
+    seen.add(name);
+    options[names.get(name)] = value;
+  }
+  if (!["self-test", "live"].includes(options.className)) {
+    throw new UsageError("invalid class");
+  }
+  if (!["json", "human"].includes(options.format)) {
+    throw new UsageError("invalid format");
+  }
+  if (
+    options.className === "live" &&
+    (options.oracle === undefined || options.candidate === undefined)
+  ) {
+    throw new UsageError("live runners are required");
+  }
+  return options;
+}
+
+function inside(root, candidate) {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith(`..${sep}`) && path !== "..");
+}
+
+function validateCorpus(candidate, rowIds) {
+  if (
+    !exactKeys(candidate, ["schemaVersion", "oracleId", "entries"]) ||
+    candidate.schemaVersion !== 1 ||
+    candidate.oracleId !== "go-v3-v0.6.5" ||
+    !Array.isArray(candidate.entries)
+  ) {
+    throw new Error("Differential corpus is invalid");
+  }
+  const ids = new Set();
+  for (const entry of candidate.entries) {
+    if (
+      exactKeys(entry, ["class", "path"]) &&
+      ["self-test", "live"].includes(entry.class) &&
+      typeof entry.path === "string"
+    ) {
+      validateSafeRelativePath(entry.path);
+      continue;
+    }
+    if (
+      !exactKeys(entry, ["class", "id", "parityContractIds", "requirements"]) ||
+      entry.class !== "planned" ||
+      typeof entry.id !== "string" ||
+      !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(entry.id) ||
+      !Array.isArray(entry.parityContractIds) ||
+      entry.parityContractIds.length === 0 ||
+      !entry.parityContractIds.every(
+        (id) => typeof id === "string" && rowIds.has(id),
+      ) ||
+      !Array.isArray(entry.requirements) ||
+      entry.requirements.length === 0 ||
+      !entry.requirements.every(
+        (requirement) =>
+          typeof requirement === "string" && requirement.trim().length >= 20,
+      ) ||
+      ids.has(entry.id)
+    ) {
+      throw new Error("Differential corpus is invalid");
+    }
+    ids.add(entry.id);
+  }
+  return candidate;
+}
+
+async function verifyOracle(path) {
+  try {
+    const stats = await lstat(path);
+    if (!stats.isFile()) throw new ProvenanceError();
+    const digest = createHash("sha256")
+      .update(await readFile(path))
+      .digest("hex");
+    if (digest !== frozenOracleDigest) throw new ProvenanceError();
+  } catch (error) {
+    if (error instanceof ProvenanceError) throw error;
+    throw new ProvenanceError();
+  }
+}
+
+function sorted(value) {
+  if (Array.isArray(value)) return value.map((entry) => sorted(entry));
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right, "en-US"))
+        .map(([key, entry]) => [key, sorted(entry)]),
+    );
+  }
+  return value;
+}
+
+function renderHuman(report) {
+  const status = report.equal ? "PASS" : "FAIL";
+  const count = report.scenarios.length;
+  const lines = [
+    `Differential corpus ${report.class}: ${status} (${count} scenario${count === 1 ? "" : "s"}; ${report.planned} planned)`,
+  ];
+  for (const scenario of report.scenarios) {
+    lines.push(`${scenario.equal ? "PASS" : "FAIL"} ${scenario.id}`);
+    for (const mismatch of scenario.mismatches) {
+      lines.push(`  ${mismatch.kind} ${mismatch.pointer}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  if (options.className === "live") await verifyOracle(options.oracle);
+
+  const corpusPath = resolve(options.corpus);
+  const corpusDirectory = dirname(corpusPath);
+  let corpus;
+  try {
+    const matrix = JSON.parse(await readFile(parityMatrix, "utf8"));
+    const rowIds = new Set(matrix.rows.map(({ id }) => id));
+    corpus = validateCorpus(
+      JSON.parse(await readFile(corpusPath, "utf8")),
+      rowIds,
+    );
+  } catch {
+    throw new Error("Differential corpus is invalid");
+  }
+  const selected = corpus.entries.filter(
+    (entry) => entry.class === options.className,
+  );
+  const planned = corpus.entries.filter(
+    (entry) => entry.class === "planned",
+  ).length;
+  const scenarios = [];
+  for (const entry of selected) {
+    const scenarioPath = resolve(corpusDirectory, entry.path);
+    if (!inside(corpusDirectory, scenarioPath)) {
+      throw new Error("Differential corpus is invalid");
+    }
+    const scenario = await loadScenario(scenarioPath);
+    const result = await runScenario(
+      scenario,
+      options.oracle ?? process.execPath,
+      options.candidate ?? process.execPath,
+    );
+    scenarios.push({
+      id: result.scenarioId,
+      equal: result.equal,
+      mismatches: result.mismatches,
+      parityContractIds: result.parityContractIds,
+      normalization: result.normalization,
+    });
+  }
+  const report = {
+    schemaVersion: 1,
+    oracleId:
+      options.className === "live"
+        ? "go-v3-v0.6.5"
+        : "synthetic-public-self-test",
+    class: options.className,
+    equal: scenarios.every(({ equal }) => equal),
+    planned,
+    scenarios,
+  };
+  process.stdout.write(
+    options.format === "human"
+      ? renderHuman(report)
+      : `${JSON.stringify(sorted(report))}\n`,
+  );
+  process.exitCode = report.equal ? 0 : 1;
+}
+
+try {
+  await main();
+} catch (error) {
+  process.exitCode = 2;
+  if (error instanceof UsageError) {
+    process.stderr.write(
+      `Differential harness usage error: ${error.message}\n`,
+    );
+  } else if (error instanceof ProvenanceError) {
+    process.stderr.write(
+      "Differential harness provenance error: oracle digest does not match go-v3-v0.6.5\n",
+    );
+  } else {
+    process.stderr.write("Differential harness error: execution failed\n");
+  }
+}

--- a/scripts/run-differential.mjs
+++ b/scripts/run-differential.mjs
@@ -185,6 +185,11 @@ async function main() {
   const selected = corpus.entries.filter(
     (entry) => entry.class === options.className,
   );
+  // An empty selection would otherwise report a vacuous pass, because every
+  // scenario is an equality claim and `[].every(...)` is true.
+  if (selected.length === 0) {
+    throw new Error("Differential corpus selected no runnable scenario");
+  }
   const planned = corpus.entries.filter(
     (entry) => entry.class === "planned",
   ).length;

--- a/tests/ci-workflow-contract.test.ts
+++ b/tests/ci-workflow-contract.test.ts
@@ -97,6 +97,7 @@ describe("pull-request CI workflow", () => {
       "Run unit tests",
       "Run coverage tests",
       "Validate GitHub template schemas",
+      "Run differential self-tests",
       "Build bundle",
       "Verify package contents",
       "Upload failure diagnostics",
@@ -121,7 +122,7 @@ describe("pull-request CI workflow", () => {
     const jobs = object(workflow.jobs, "jobs");
     const quality = object(jobs.quality, "quality");
     const steps = quality.steps as JsonObject[];
-    const commandSteps = steps.slice(3, 14);
+    const commandSteps = steps.slice(3, 15);
     const expectedCommands = [
       "node --version",
       "npm ci",
@@ -132,6 +133,7 @@ describe("pull-request CI workflow", () => {
       "npm test",
       "npm run test:coverage",
       "npm run templates:validate",
+      "npm run differential:check",
       "npm run build",
       "npm run package:verify",
     ];

--- a/tests/differential-capture.test.ts
+++ b/tests/differential-capture.test.ts
@@ -1,0 +1,213 @@
+import { execFileSync } from "node:child_process";
+import {
+  lstat,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  captureAfter,
+  captureBefore,
+  materializeWorkspace,
+  type ProcessObservation,
+} from "@mestre-yoda/differential";
+import { afterEach, describe, expect, it } from "vitest";
+
+const emptyDigest =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const temporaryRoots: string[] = [];
+const processObservation: ProcessObservation = {
+  outcome: "exit",
+  exitCode: 0,
+  signal: null,
+  stdout: { bytes: 0, sha256: emptyDigest },
+  stderr: { bytes: 0, sha256: emptyDigest },
+};
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-differential-capture-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("differential workspace capture", () => {
+  it("materializes and classifies deterministic filesystem and JSON changes", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      { type: "directory", path: ".brain" },
+      {
+        type: "file",
+        path: ".brain/state.json",
+        content: '{"revision":1,"stateContract":"1.0.0"}\n',
+        executable: false,
+      },
+      {
+        type: "file",
+        path: "tool.mjs",
+        content: "process.exit(0);\n",
+        executable: true,
+      },
+      { type: "symlink", path: "state-link.json", target: ".brain/state.json" },
+    ]);
+    const capture = {
+      structured: [{ id: "state", path: ".brain/state.json" }],
+      git: false,
+    };
+    const baseline = await captureBefore(project, capture);
+
+    await writeFile(
+      join(project, ".brain/state.json"),
+      '{"revision":2,"stateContract":"1.0.0"}\n',
+      "utf8",
+    );
+    await writeFile(join(project, "created.txt"), "created\n", "utf8");
+    await unlink(join(project, "tool.mjs"));
+
+    const result = await captureAfter(
+      project,
+      capture,
+      baseline,
+      processObservation,
+      "digest",
+    );
+    expect(result.filesystem.before.map(({ path }) => path)).toEqual([
+      ".brain",
+      ".brain/state.json",
+      "state-link.json",
+      "tool.mjs",
+    ]);
+    expect(result.filesystem.mutations).toEqual([
+      { path: ".brain/state.json", kind: "modified" },
+      { path: "created.txt", kind: "added" },
+      { path: "tool.mjs", kind: "deleted" },
+    ]);
+    expect(result.structured).toEqual([
+      {
+        id: "state",
+        path: ".brain/state.json",
+        value: { revision: 2, stateContract: "1.0.0" },
+      },
+    ]);
+    expect(result.git).toBeNull();
+    expect(await readFile(join(project, "state-link.json"), "utf8")).toContain(
+      '"revision":2',
+    );
+  });
+
+  it("captures Git identity, status, refs, and worktree differences", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      {
+        type: "file",
+        path: "tracked.txt",
+        content: "before\n",
+        executable: false,
+      },
+    ]);
+    execFileSync("git", ["init", "-q", "--initial-branch=main"], {
+      cwd: project,
+    });
+    execFileSync("git", ["add", "tracked.txt"], { cwd: project });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Differential Test",
+        "-c",
+        "user.email=differential@example.invalid",
+        "commit",
+        "-qm",
+        "fixture",
+      ],
+      { cwd: project },
+    );
+    const capture = { structured: [], git: true };
+    const baseline = await captureBefore(project, capture);
+    await writeFile(join(project, "tracked.txt"), "after\n", "utf8");
+
+    const result = await captureAfter(
+      project,
+      capture,
+      baseline,
+      processObservation,
+      "digest",
+    );
+    expect(result.git?.head).toMatch(/^[a-f0-9]{40}$/u);
+    expect(result.git?.status.bytes).toBeGreaterThan(0);
+    expect(result.git?.worktreeDiff.bytes).toBeGreaterThan(0);
+    expect(result.git?.indexDiff.bytes).toBe(0);
+    expect(result.git?.refs).toEqual([
+      { name: "refs/heads/main", object: result.git?.head },
+    ]);
+  });
+
+  it("rejects unsafe links before writing a workspace", async () => {
+    const root = await temporaryRoot();
+    await expect(
+      materializeWorkspace(root, [
+        { type: "symlink", path: "escape", target: "../outside" },
+      ]),
+    ).rejects.toThrow("Differential workspace path is unsafe");
+    await expect(lstat(join(root, "project"))).rejects.toThrow();
+  });
+
+  it("rejects a selected JSON file replaced by an escaping symlink", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      {
+        type: "file",
+        path: "state.json",
+        content: '{"safe":true}\n',
+        executable: false,
+      },
+    ]);
+    const capture = {
+      structured: [{ id: "state", path: "state.json" }],
+      git: false,
+    };
+    const baseline = await captureBefore(project, capture);
+    await writeFile(join(root, "outside.json"), '{"private":true}\n', "utf8");
+    await unlink(join(project, "state.json"));
+    await symlink("../outside.json", join(project, "state.json"));
+
+    await expect(
+      captureAfter(project, capture, baseline, processObservation, "digest"),
+    ).rejects.toThrow("Differential structured capture path is unsafe");
+  });
+
+  it("fails explicitly for malformed selected JSON", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      {
+        type: "file",
+        path: "state.json",
+        content: "{invalid\n",
+        executable: false,
+      },
+    ]);
+    const capture = {
+      structured: [{ id: "state", path: "state.json" }],
+      git: false,
+    };
+    const baseline = await captureBefore(project, capture);
+    await expect(
+      captureAfter(project, capture, baseline, processObservation, "digest"),
+    ).rejects.toThrow(
+      "Differential structured capture state contains invalid JSON",
+    );
+  });
+});

--- a/tests/differential-capture.test.ts
+++ b/tests/differential-capture.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   lstat,
   mkdtemp,
@@ -22,6 +23,10 @@ import { afterEach, describe, expect, it } from "vitest";
 const emptyDigest =
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 const temporaryRoots: string[] = [];
+
+function digestOf(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
 const processObservation: ProcessObservation = {
   outcome: "exit",
   exitCode: 0,
@@ -99,6 +104,7 @@ describe("differential workspace capture", () => {
       {
         id: "state",
         path: ".brain/state.json",
+        state: "valid",
         value: { revision: 2, stateContract: "1.0.0" },
       },
     ]);
@@ -189,7 +195,7 @@ describe("differential workspace capture", () => {
     ).rejects.toThrow("Differential structured capture path is unsafe");
   });
 
-  it("fails explicitly for malformed selected JSON", async () => {
+  it("observes malformed selected JSON as a comparable digest", async () => {
     const root = await temporaryRoot();
     const project = await materializeWorkspace(root, [
       {
@@ -204,10 +210,157 @@ describe("differential workspace capture", () => {
       git: false,
     };
     const baseline = await captureBefore(project, capture);
-    await expect(
-      captureAfter(project, capture, baseline, processObservation, "digest"),
-    ).rejects.toThrow(
-      "Differential structured capture state contains invalid JSON",
+    const result = await captureAfter(
+      project,
+      capture,
+      baseline,
+      processObservation,
+      "digest",
+    );
+
+    // Invalid structured output is a behavioral difference the harness must be
+    // able to compare, not a harness failure.
+    expect(result.structured).toEqual([
+      {
+        id: "state",
+        path: "state.json",
+        state: "invalid",
+        bytes: 9,
+        sha256: digestOf("{invalid\n"),
+      },
+    ]);
+  });
+
+  it("observes a missing selected artifact instead of failing", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      {
+        type: "file",
+        path: "keep.txt",
+        content: "keep\n",
+        executable: false,
+      },
+    ]);
+    const capture = {
+      structured: [{ id: "result", path: "result.json" }],
+      git: false,
+    };
+    const baseline = await captureBefore(project, capture);
+    const result = await captureAfter(
+      project,
+      capture,
+      baseline,
+      processObservation,
+      "digest",
+    );
+
+    // "The candidate produced no artifact" is the single most important
+    // comparison; it must be a field-level mismatch, not an opaque exit 2.
+    expect(result.structured).toEqual([
+      { id: "result", path: "result.json", state: "absent" },
+    ]);
+  });
+
+  it("observes a selected path that is not a regular file", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      { type: "directory", path: "result.json" },
+    ]);
+    const capture = {
+      structured: [{ id: "result", path: "result.json" }],
+      git: false,
+    };
+    const baseline = await captureBefore(project, capture);
+    const result = await captureAfter(
+      project,
+      capture,
+      baseline,
+      processObservation,
+      "digest",
+    );
+
+    expect(result.structured).toEqual([
+      { id: "result", path: "result.json", state: "unreadable" },
+    ]);
+  });
+
+  it("captures an unborn HEAD as a null identity", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      {
+        type: "file",
+        path: "untracked.txt",
+        content: "new\n",
+        executable: false,
+      },
+    ]);
+    execFileSync("git", ["init", "-q", "--initial-branch=main"], {
+      cwd: project,
+    });
+    const capture = { structured: [], git: true };
+    const baseline = await captureBefore(project, capture);
+
+    const result = await captureAfter(
+      project,
+      capture,
+      baseline,
+      processObservation,
+      "digest",
+    );
+
+    // "Did the tool initialize a repository?" must be observable.
+    expect(result.git).not.toBeNull();
+    expect(result.git?.head).toBeNull();
+    expect(result.git?.refs).toEqual([]);
+  });
+
+  it("fails closed when Git is required but unavailable", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      { type: "file", path: "keep.txt", content: "keep\n", executable: false },
+    ]);
+    const capture = { structured: [], git: true };
+    const baseline = await captureBefore(project, capture);
+    const originalPath = process.env.PATH;
+    process.env.PATH = join(root, "empty-path");
+    try {
+      // A missing Git binary must not be silently recorded as "not a
+      // repository" on both sides, which would be a vacuous equality.
+      await expect(
+        captureAfter(project, capture, baseline, processObservation, "digest"),
+      ).rejects.toThrow("Differential Git capture cannot run git");
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it("rejects a workspace containing a special file", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      { type: "file", path: "keep.txt", content: "keep\n", executable: false },
+    ]);
+    execFileSync("mkfifo", [join(project, "pipe")]);
+    const capture = { structured: [], git: false };
+
+    await expect(captureBefore(project, capture)).rejects.toThrow(
+      "Differential filesystem capture found a special file",
+    );
+  });
+
+  it("rejects a workspace that exceeds the manifest entry limit", async () => {
+    const root = await temporaryRoot();
+    const project = await materializeWorkspace(root, [
+      { type: "file", path: "keep.txt", content: "keep\n", executable: false },
+    ]);
+    await Promise.all(
+      Array.from({ length: 4_100 }, (_unused, index) =>
+        writeFile(join(project, `f${String(index)}.txt`), "x", "utf8"),
+      ),
+    );
+    const capture = { structured: [], git: false };
+
+    await expect(captureBefore(project, capture)).rejects.toThrow(
+      "Differential filesystem capture exceeds the entry limit",
     );
   });
 });

--- a/tests/differential-cli.test.ts
+++ b/tests/differential-cli.test.ts
@@ -1,0 +1,121 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+const cli = join(repositoryRoot, "scripts/run-differential.mjs");
+const temporaryRoots: string[] = [];
+
+function invoke(args: readonly string[] = []) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      TMPDIR: process.env.TMPDIR,
+      YODA_TEST_SECRET: "must-not-leak",
+    },
+  });
+}
+
+async function temporaryExecutable(source: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-differential-cli-"));
+  temporaryRoots.push(root);
+  const path = join(root, "candidate.mjs");
+  await writeFile(path, source, "utf8");
+  await chmod(path, 0o755);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("differential harness CLI", () => {
+  it("runs the public self-test corpus as deterministic JSON", () => {
+    const result = invoke();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      schemaVersion: 1,
+      oracleId: "synthetic-public-self-test",
+      class: "self-test",
+      equal: true,
+      planned: 12,
+      scenarios: [{ id: "self-test-equality", equal: true, mismatches: [] }],
+    });
+  });
+
+  it("renders a concise human report", () => {
+    const result = invoke(["--format", "human"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(
+      "Differential corpus self-test: PASS (1 scenario; 12 planned)\nPASS self-test-equality\n",
+    );
+    expect(result.stderr).toBe("");
+  });
+
+  it.each([
+    [["--unknown"], "unknown option"],
+    [["--format"], "missing value"],
+    [["--format", "yaml"], "invalid format"],
+    [["--class", "live"], "live runners are required"],
+  ] as const)("rejects invalid usage: %s", (args, message) => {
+    const result = invoke(args);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      `Differential harness usage error: ${message}\n`,
+    );
+    expect(result.stderr).not.toContain(" at ");
+  });
+
+  it("rejects a wrong live oracle digest before scenario execution", async () => {
+    const executable = await temporaryExecutable(
+      "#!/usr/bin/env node\nprocess.stdout.write('not the oracle\\n');\n",
+    );
+    const result = invoke([
+      "--class",
+      "live",
+      "--oracle",
+      executable,
+      "--candidate",
+      process.execPath,
+    ]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "Differential harness provenance error: oracle digest does not match go-v3-v0.6.5\n",
+    );
+    expect(result.stderr).not.toContain(executable);
+  });
+
+  it("returns one and field pointers for a seeded behavioral difference", async () => {
+    const candidate = await temporaryExecutable(
+      "#!/usr/bin/env node\nawait import('node:fs/promises').then(({writeFile}) => writeFile('unexpected.txt', 'x'));\n",
+    );
+    const result = invoke(["--candidate", candidate]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    const report = JSON.parse(result.stdout) as {
+      equal: boolean;
+      scenarios: { mismatches: { pointer: string }[] }[];
+    };
+    expect(report.equal).toBe(false);
+    expect(
+      report.scenarios[0]?.mismatches.some(({ pointer }) =>
+        pointer.includes("filesystem"),
+      ),
+    ).toBe(true);
+    expect(result.stdout).not.toContain(candidate);
+    expect(result.stdout).not.toContain("must-not-leak");
+  });
+});

--- a/tests/differential-cli.test.ts
+++ b/tests/differential-cli.test.ts
@@ -50,7 +50,10 @@ describe("differential harness CLI", () => {
       class: "self-test",
       equal: true,
       planned: 12,
-      scenarios: [{ id: "self-test-equality", equal: true, mismatches: [] }],
+      scenarios: [
+        { id: "self-test-equality", equal: true, mismatches: [] },
+        { id: "self-test-normalized-state", equal: true, mismatches: [] },
+      ],
     });
   });
 
@@ -58,7 +61,9 @@ describe("differential harness CLI", () => {
     const result = invoke(["--format", "human"]);
     expect(result.status).toBe(0);
     expect(result.stdout).toBe(
-      "Differential corpus self-test: PASS (1 scenario; 12 planned)\nPASS self-test-equality\n",
+      "Differential corpus self-test: PASS (2 scenarios; 12 planned)\n" +
+        "PASS self-test-equality\n" +
+        "PASS self-test-normalized-state\n",
     );
     expect(result.stderr).toBe("");
   });

--- a/tests/differential-cli.test.ts
+++ b/tests/differential-cli.test.ts
@@ -63,6 +63,28 @@ describe("differential harness CLI", () => {
     expect(result.stderr).toBe("");
   });
 
+  it("rejects a corpus with no selected runnable scenarios", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-differential-cli-corpus-"));
+    temporaryRoots.push(root);
+    const corpus = join(root, "corpus.json");
+    await writeFile(
+      corpus,
+      JSON.stringify({
+        schemaVersion: 1,
+        oracleId: "go-v3-v0.6.5",
+        entries: [],
+      }),
+      "utf8",
+    );
+
+    const result = invoke(["--corpus", corpus]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "Differential harness error: execution failed\n",
+    );
+  });
+
   it.each([
     [["--unknown"], "unknown option"],
     [["--format"], "missing value"],

--- a/tests/differential-comparator.test.ts
+++ b/tests/differential-comparator.test.ts
@@ -112,6 +112,27 @@ describe("differential observation comparison", () => {
     });
   });
 
+  it("does not disclose private structured keys or scalar values in digest mode", () => {
+    const expected = observation();
+    expected.structured = [
+      { id: "result", path: "result.json", value: { privateField: 123 } },
+    ];
+    const candidate: DifferentialObservation = {
+      ...structuredClone(expected),
+      structured: [
+        { id: "result", path: "result.json", value: { privateField: 456 } },
+      ],
+    };
+
+    const report = compareObservations(scenario(expected), expected, candidate);
+    const serialized = JSON.stringify(report);
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0]?.pointer).toBe("/candidate/structured/0/value");
+    expect(serialized).not.toContain("privateField");
+    expect(serialized).not.toContain("123");
+    expect(serialized).not.toContain("456");
+  });
+
   it.each([
     ["timeout", "timeout"],
     ["signal", "crash"],
@@ -195,6 +216,7 @@ describe("differential observation comparison", () => {
     "/process/exitCode",
     "/process/outcome",
     "/structured/0/value/status",
+    "/structured/0/value/exitCode",
     "/structured/0/value/reasonCode",
     "/filesystem/mutations",
     "/git",

--- a/tests/differential-comparator.test.ts
+++ b/tests/differential-comparator.test.ts
@@ -115,12 +115,22 @@ describe("differential observation comparison", () => {
   it("does not disclose private structured keys or scalar values in digest mode", () => {
     const expected = observation();
     expected.structured = [
-      { id: "result", path: "result.json", value: { privateField: 123 } },
+      {
+        id: "result",
+        path: "result.json",
+        state: "valid",
+        value: { privateField: 123 },
+      },
     ];
     const candidate: DifferentialObservation = {
       ...structuredClone(expected),
       structured: [
-        { id: "result", path: "result.json", value: { privateField: 456 } },
+        {
+          id: "result",
+          path: "result.json",
+          state: "valid",
+          value: { privateField: 456 },
+        },
       ],
     };
 
@@ -172,6 +182,7 @@ describe("differential observation comparison", () => {
       {
         id: "result",
         path: "result.json",
+        state: "valid",
         value: {
           timestamp: "2026-08-07T00:00:00Z",
           entries: [{ id: "b" }, { id: "a" }],
@@ -205,19 +216,99 @@ describe("differential observation comparison", () => {
     );
 
     expect(normalized.process.stdout.content).toBe("<WORKSPACE>/a\n");
-    expect(normalized.structured[0]?.value).toEqual({
+    const artifact = normalized.structured[0];
+    expect(artifact?.state).toBe("valid");
+    expect(artifact?.state === "valid" ? artifact.value : undefined).toEqual({
       timestamp: "<TIMESTAMP>",
       entries: [{ id: "a" }, { id: "b" }],
     });
     expect(input.process.stdout.content).toContain("\r\n");
   });
 
+  it("skips artifact rules when a side produced no artifact", () => {
+    const input = observation();
+    input.structured = [{ id: "state", path: "state.json", state: "absent" }];
+
+    // A side that produced nothing is a behavioral difference to report, not a
+    // normalization failure that would surface as a harness error.
+    const normalized = normalizeObservation(
+      input,
+      [
+        {
+          operation: "replace_json_value",
+          pointer: "/structured/0/value/generatedAt",
+          token: "<TIMESTAMP>",
+        },
+      ],
+      "/tmp/oracle-root",
+    );
+    expect(normalized.structured[0]).toEqual({
+      id: "state",
+      path: "state.json",
+      state: "absent",
+    });
+  });
+
+  it("still rejects a rule whose pointer is missing from a valid artifact", () => {
+    const input = observation();
+    input.structured = [
+      { id: "state", path: "state.json", state: "valid", value: { a: 1 } },
+    ];
+    expect(() =>
+      normalizeObservation(
+        input,
+        [
+          {
+            operation: "replace_json_value",
+            pointer: "/structured/0/value/typo",
+            token: "<TIMESTAMP>",
+          },
+        ],
+        "/tmp/oracle-root",
+      ),
+    ).toThrow("Differential normalization pointer does not exist");
+  });
+
+  it("recomputes stream digests after normalizing disclosed content", () => {
+    const input = observation();
+    input.process.stdout = {
+      bytes: 3,
+      sha256: emptyDigest,
+      content: "a\r\n",
+    };
+
+    const normalized = normalizeObservation(
+      input,
+      [{ operation: "line_endings", pointer: "/process/stdout/content" }],
+      "/tmp/oracle-root",
+    );
+
+    // A stream summary must never describe a buffer other than the one it
+    // reports, or a normalized scenario could never match on digest.
+    expect(normalized.process.stdout).toEqual({
+      bytes: 2,
+      sha256:
+        "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7",
+      content: "a\n",
+    });
+  });
+
   it.each([
+    "/process",
     "/process/exitCode",
     "/process/outcome",
+    "/process/signal",
+    "/process/stdout",
+    "/structured/0",
+    "/structured/0/state",
+    "/structured/0/value",
     "/structured/0/value/status",
     "/structured/0/value/exitCode",
     "/structured/0/value/reasonCode",
+    "/structured/0/value/result/status",
+    "/structured/0/value/result/stateChanged",
+    "/structured/0/value/result/retryable",
+    "/filesystem",
     "/filesystem/mutations",
     "/git",
   ])("rejects normalization of protected field %s", (pointer) => {

--- a/tests/differential-comparator.test.ts
+++ b/tests/differential-comparator.test.ts
@@ -1,0 +1,199 @@
+import {
+  compareObservations,
+  normalizeObservation,
+  type DifferentialObservation,
+  type DifferentialScenario,
+} from "@mestre-yoda/differential";
+import { describe, expect, it } from "vitest";
+
+const emptyDigest =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+function observation(): DifferentialObservation {
+  return {
+    process: {
+      outcome: "exit",
+      exitCode: 0,
+      signal: null,
+      stdout: { bytes: 0, sha256: emptyDigest },
+      stderr: { bytes: 0, sha256: emptyDigest },
+    },
+    filesystem: { before: [], after: [], mutations: [] },
+    structured: [],
+    git: null,
+  };
+}
+
+function scenario(
+  expected: DifferentialObservation,
+  normalization: DifferentialScenario["normalization"] = [],
+): DifferentialScenario {
+  return {
+    schemaVersion: 1,
+    id: "comparator-self-test",
+    parityContractIds: ["CLI-VERSION"],
+    workspace: { entries: [] },
+    invocation: {
+      args: [],
+      stdin: "",
+      environment: {},
+      timeoutMs: 1_000,
+      maxStdoutBytes: 1_048_576,
+      maxStderrBytes: 1_048_576,
+    },
+    capture: { structured: [], git: false },
+    normalization,
+    disclosure: {
+      stdout: "digest",
+      stderr: "digest",
+      artifacts: "digest",
+    },
+    expected,
+  };
+}
+
+describe("differential observation comparison", () => {
+  it("reports exact equality", () => {
+    const expected = observation();
+    expect(
+      compareObservations(
+        scenario(expected),
+        expected,
+        structuredClone(expected),
+      ),
+    ).toEqual({
+      scenarioId: "comparator-self-test",
+      parityContractIds: ["CLI-VERSION"],
+      equal: true,
+      mismatches: [],
+      normalization: [],
+    });
+  });
+
+  it("sorts field-level candidate mismatches deterministically", () => {
+    const expected = observation();
+    const candidate = structuredClone(expected);
+    candidate.process.exitCode = 2;
+    candidate.filesystem.after = [
+      {
+        path: "unexpected.txt",
+        type: "file",
+        mode: "file",
+        size: 1,
+        sha256:
+          "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      },
+    ];
+
+    const report = compareObservations(scenario(expected), expected, candidate);
+    expect(report.equal).toBe(false);
+    expect(
+      report.mismatches.map(({ pointer, kind }) => [pointer, kind]),
+    ).toEqual([
+      ["/candidate/filesystem/after/0", "unexpected"],
+      ["/candidate/process/exitCode", "value"],
+    ]);
+  });
+
+  it.each([
+    ["timeout", "timeout"],
+    ["signal", "crash"],
+  ] as const)("classifies %s outcomes", (outcome, kind) => {
+    const expected = observation();
+    const candidate = structuredClone(expected);
+    candidate.process.outcome = outcome;
+    candidate.process.exitCode = null;
+    candidate.process.signal = outcome === "signal" ? "SIGABRT" : null;
+    const report = compareObservations(scenario(expected), expected, candidate);
+    expect(report.mismatches.some((mismatch) => mismatch.kind === kind)).toBe(
+      true,
+    );
+  });
+
+  it("classifies retained mutations after failure", () => {
+    const expected = observation();
+    const candidate = structuredClone(expected);
+    candidate.process.exitCode = 1;
+    candidate.filesystem.mutations = [
+      { path: ".brain/state.json", kind: "added" },
+    ];
+    const report = compareObservations(scenario(expected), expected, candidate);
+    expect(
+      report.mismatches.some(({ kind }) => kind === "partial_mutation"),
+    ).toBe(true);
+  });
+
+  it("normalizes only explicitly selected values without mutating input", () => {
+    const input = observation();
+    input.process.stdout = {
+      bytes: 32,
+      sha256: emptyDigest,
+      content: "/tmp/oracle-root/a\r\n",
+    };
+    input.structured = [
+      {
+        id: "result",
+        path: "result.json",
+        value: {
+          timestamp: "2026-08-07T00:00:00Z",
+          entries: [{ id: "b" }, { id: "a" }],
+          duration: 42,
+        },
+      },
+    ];
+
+    const normalized = normalizeObservation(
+      input,
+      [
+        { operation: "line_endings", pointer: "/process/stdout/content" },
+        { operation: "workspace_path", pointer: "/process/stdout/content" },
+        {
+          operation: "replace_json_value",
+          pointer: "/structured/0/value/timestamp",
+          token: "<TIMESTAMP>",
+        },
+        {
+          operation: "sort_json_array",
+          pointer: "/structured/0/value/entries",
+          identityKey: "id",
+        },
+        {
+          operation: "remove_field",
+          pointer: "/structured/0/value/duration",
+          justification: "Measured process duration is nondeterministic.",
+        },
+      ],
+      "/tmp/oracle-root",
+    );
+
+    expect(normalized.process.stdout.content).toBe("<WORKSPACE>/a\n");
+    expect(normalized.structured[0]?.value).toEqual({
+      timestamp: "<TIMESTAMP>",
+      entries: [{ id: "a" }, { id: "b" }],
+    });
+    expect(input.process.stdout.content).toContain("\r\n");
+  });
+
+  it.each([
+    "/process/exitCode",
+    "/process/outcome",
+    "/structured/0/value/status",
+    "/structured/0/value/reasonCode",
+    "/filesystem/mutations",
+    "/git",
+  ])("rejects normalization of protected field %s", (pointer) => {
+    expect(() =>
+      normalizeObservation(
+        observation(),
+        [
+          {
+            operation: "remove_field",
+            pointer,
+            justification: "This should never be accepted by the harness.",
+          },
+        ],
+        "/tmp/workspace",
+      ),
+    ).toThrow("Differential normalization targets a protected field");
+  });
+});

--- a/tests/differential-comparator.test.ts
+++ b/tests/differential-comparator.test.ts
@@ -95,6 +95,23 @@ describe("differential observation comparison", () => {
     ]);
   });
 
+  it("reports digest fields directly without disclosing stream content", () => {
+    const expected = observation();
+    const candidate = structuredClone(expected);
+    candidate.process.stdout.sha256 =
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const mismatch = compareObservations(
+      scenario(expected),
+      expected,
+      candidate,
+    ).mismatches.find(({ pointer }) => pointer.endsWith("/stdout/sha256"));
+    expect(mismatch).toMatchObject({
+      oracle: emptyDigest,
+      candidate:
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+  });
+
   it.each([
     ["timeout", "timeout"],
     ["signal", "crash"],

--- a/tests/differential-contract.test.ts
+++ b/tests/differential-contract.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  loadScenario,
+  validateSafeRelativePath,
+  type DifferentialScenario,
+} from "@mestre-yoda/differential";
+import { Ajv2020, type AnySchemaObject } from "ajv/dist/2020.js";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+const emptyDigest =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+const validScenario: DifferentialScenario = {
+  schemaVersion: 1,
+  id: "self-test-equality",
+  parityContractIds: ["CLI-VERSION"],
+  workspace: {
+    entries: [
+      { type: "directory", path: "input" },
+      {
+        type: "file",
+        path: "input/context.txt",
+        content: "synthetic context\n",
+        executable: false,
+      },
+    ],
+  },
+  invocation: {
+    args: ["--version"],
+    stdin: "",
+    environment: {},
+    timeoutMs: 5_000,
+    maxStdoutBytes: 1_048_576,
+    maxStderrBytes: 1_048_576,
+  },
+  capture: { structured: [], git: false },
+  normalization: [],
+  disclosure: {
+    stdout: "digest",
+    stderr: "digest",
+    artifacts: "digest",
+  },
+  expected: {
+    process: {
+      outcome: "exit",
+      exitCode: 0,
+      signal: null,
+      stdout: { bytes: 0, sha256: emptyDigest },
+      stderr: { bytes: 0, sha256: emptyDigest },
+    },
+    filesystem: {
+      before: [],
+      after: [],
+      mutations: [],
+    },
+    structured: [],
+    git: null,
+  },
+};
+
+async function withScenario(
+  value: unknown,
+  run: (path: string) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(
+    join(tmpdir(), "yoda-differential-contract-"),
+  );
+  const path = join(directory, "scenario.json");
+  try {
+    await writeFile(path, `${JSON.stringify(value)}\n`, "utf8");
+    await run(path);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe("differential JSON contracts", () => {
+  it("provides valid linked JSON Schema 2020-12 documents", async () => {
+    const [scenarioSource, observationSource] = await Promise.all([
+      readFile(
+        join(
+          repositoryRoot,
+          "schemas/compatibility/differential-scenario.v1.schema.json",
+        ),
+        "utf8",
+      ),
+      readFile(
+        join(
+          repositoryRoot,
+          "schemas/compatibility/differential-observation.v1.schema.json",
+        ),
+        "utf8",
+      ),
+    ]);
+    expect(() => {
+      const ajv = new Ajv2020({ strict: true });
+      ajv.addSchema(JSON.parse(observationSource) as AnySchemaObject);
+      ajv.compile(JSON.parse(scenarioSource) as AnySchemaObject);
+    }).not.toThrow();
+  });
+
+  it("loads a closed scenario tied to a real parity row", async () => {
+    await withScenario(validScenario, async (path) => {
+      await expect(loadScenario(path)).resolves.toEqual(validScenario);
+    });
+  });
+
+  it("rejects unknown fields without echoing their values", async () => {
+    const candidate = {
+      ...structuredClone(validScenario),
+      secret: "do-not-print",
+    };
+    await withScenario(candidate, async (path) => {
+      await expect(loadScenario(path)).rejects.toThrow(
+        "Differential scenario self-test-equality is invalid: additionalProperties",
+      );
+      await expect(loadScenario(path)).rejects.not.toThrow("do-not-print");
+    });
+  });
+
+  it("rejects an unknown parity contract ID", async () => {
+    const candidate = {
+      ...structuredClone(validScenario),
+      parityContractIds: ["PRD-NOT-REAL"],
+    };
+    await withScenario(candidate, async (path) => {
+      await expect(loadScenario(path)).rejects.toThrow(
+        "Differential scenario self-test-equality references an unknown parity contract",
+      );
+    });
+  });
+
+  it.each([
+    "../escape",
+    "/absolute",
+    "C:\\escape",
+    "https://private.invalid/file",
+    "a\\b",
+    "a/./b",
+    "a//b",
+    "a\u0000b",
+  ])("rejects unsafe fixture path %j", (path) => {
+    expect(() => validateSafeRelativePath(path)).toThrow(
+      "Differential scenario path is unsafe",
+    );
+  });
+
+  it("rejects duplicate and case-fold-colliding paths", async () => {
+    for (const paths of [
+      ["same.txt", "same.txt"],
+      ["README.md", "Readme.md"],
+    ]) {
+      const candidate = structuredClone(validScenario);
+      candidate.workspace.entries = paths.map((path) => ({
+        type: "file" as const,
+        path,
+        content: "safe\n",
+        executable: false,
+      }));
+      await withScenario(candidate, async (path) => {
+        await expect(loadScenario(path)).rejects.toThrow(
+          "Differential scenario self-test-equality contains colliding workspace paths",
+        );
+      });
+    }
+  });
+});

--- a/tests/differential-contract.test.ts
+++ b/tests/differential-contract.test.ts
@@ -79,6 +79,58 @@ async function withScenario(
 }
 
 describe("differential JSON contracts", () => {
+  it("tracks every planned PRD case with real frozen matrix IDs", async () => {
+    const [corpusSource, matrixSource] = await Promise.all([
+      readFile(
+        join(
+          repositoryRoot,
+          "compatibility/fixtures/differential/v1/corpus.json",
+        ),
+        "utf8",
+      ),
+      readFile(
+        join(
+          repositoryRoot,
+          "compatibility/inventory/go-v3-v0.6.5/matrix.json",
+        ),
+        "utf8",
+      ),
+    ]);
+    const corpus = JSON.parse(corpusSource) as {
+      entries: {
+        class: string;
+        id?: string;
+        parityContractIds?: string[];
+        requirements?: string[];
+      }[];
+    };
+    const matrix = JSON.parse(matrixSource) as { rows: { id: string }[] };
+    const rowIds = new Set(matrix.rows.map(({ id }) => id));
+    const planned = corpus.entries.filter(
+      ({ class: kind }) => kind === "planned",
+    );
+    expect(planned).toHaveLength(12);
+    expect(
+      new Set(planned.flatMap(({ parityContractIds }) => parityContractIds)),
+    ).toEqual(
+      new Set([
+        "PRD-OUTPUT-SCHEMA",
+        "PRD-PROBLEM-DISCOVERY",
+        "PRD-RESEARCHER",
+        "PRD-TEMPLATE",
+      ]),
+    );
+    for (const entry of planned) {
+      expect(entry.id).toMatch(/^prd-/u);
+      expect(entry.requirements?.every((value) => value.length >= 20)).toBe(
+        true,
+      );
+      expect(entry.parityContractIds?.every((id) => rowIds.has(id))).toBe(true);
+      expect(entry).not.toHaveProperty("path");
+      expect(entry).not.toHaveProperty("expected");
+    }
+  });
+
   it("provides valid linked JSON Schema 2020-12 documents", async () => {
     const [scenarioSource, observationSource] = await Promise.all([
       readFile(

--- a/tests/differential-documentation.test.ts
+++ b/tests/differential-documentation.test.ts
@@ -40,6 +40,11 @@ describe("differential harness documentation", () => {
       "Exit `2`",
       "no runnable scenario",
       "retained prefix",
+      "post-normalization",
+      "absent",
+      "unreadable",
+      "invalid",
+      "self-test-normalized-state",
     ]) {
       expect(text.guide).toContain(required);
     }

--- a/tests/differential-documentation.test.ts
+++ b/tests/differential-documentation.test.ts
@@ -1,0 +1,94 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+const root = join(import.meta.dirname, "..");
+const files = {
+  readme: "README.md",
+  fixtures: "fixtures/README.md",
+  schemas: "schemas/README.md",
+  guide: "docs/compatibility/differential-harness.md",
+  parity: "docs/compatibility/parity-inventory.md",
+  contracts: "docs/compatibility/contract-versioning.md",
+  toolchain: "docs/development/toolchain.md",
+  workflow: ".github/workflows/ci.yml",
+} as const;
+
+let text: Record<keyof typeof files, string>;
+
+beforeAll(async () => {
+  text = Object.fromEntries(
+    await Promise.all(
+      Object.entries(files).map(async ([name, path]) => [
+        name,
+        await readFile(join(root, path), "utf8"),
+      ]),
+    ),
+  ) as Record<keyof typeof files, string>;
+});
+
+describe("differential harness documentation", () => {
+  it("publishes the public and authorized commands with exit semantics", () => {
+    for (const required of [
+      "npm run differential:check",
+      "--class live",
+      "--oracle",
+      "--candidate",
+      "Exit `0`",
+      "Exit `1`",
+      "Exit `2`",
+    ]) {
+      expect(text.guide).toContain(required);
+    }
+    expect(text.readme).toContain("Go-to-TypeScript differential harness");
+    expect(text.readme).toContain("Public self-test available");
+    expect(text.toolchain).toContain("npm run differential:check");
+  });
+
+  it("documents isolation, redaction, and current live mismatch honestly", () => {
+    for (const required of [
+      "external temporary",
+      "shell",
+      "digest-only",
+      "known mismatch",
+      "live-version",
+      "live-help",
+    ]) {
+      expect(text.guide).toContain(required);
+    }
+    expect(text.guide).toMatch(/does\s+not modify the source checkout/u);
+    expect(text.parity).toContain("0 / 400 (0.00%)");
+    expect(text.parity).toContain("differential harness");
+  });
+
+  it("keeps every PRD case planned and migration-only", () => {
+    for (const required of [
+      "sufficient context",
+      "insufficient context",
+      "needs_input",
+      "blocking",
+      "deferred",
+      "5 Whys",
+      "5W2H",
+      "probable root cause",
+      "invalid structured output",
+      "lineage",
+      "revision",
+      "content-bound approval",
+    ]) {
+      expect(text.guide).toContain(required);
+    }
+    expect(text.contracts).toContain("`migration-only`");
+    expect(text.contracts).toContain("12 planned PRD");
+  });
+
+  it("links schemas and fixtures and runs only the public self-test in CI", () => {
+    expect(text.schemas).toContain("differential-scenario.v1.schema.json");
+    expect(text.schemas).toContain("differential-observation.v1.schema.json");
+    expect(text.fixtures).toContain("differential/v1");
+    expect(text.workflow).toContain("npm run differential:check");
+    expect(text.workflow).not.toContain(".betaup/bin/yoda");
+    expect(text.workflow).not.toContain("secrets.");
+  });
+});

--- a/tests/differential-documentation.test.ts
+++ b/tests/differential-documentation.test.ts
@@ -38,6 +38,8 @@ describe("differential harness documentation", () => {
       "Exit `0`",
       "Exit `1`",
       "Exit `2`",
+      "no runnable scenario",
+      "retained prefix",
     ]) {
       expect(text.guide).toContain(required);
     }
@@ -57,6 +59,7 @@ describe("differential harness documentation", () => {
     ]) {
       expect(text.guide).toContain(required);
     }
+    expect(text.guide).toMatch(/opaque|single digest/u);
     expect(text.guide).toMatch(/does\s+not modify the source checkout/u);
     expect(text.parity).toContain("0 / 400 (0.00%)");
     expect(text.parity).toContain("differential harness");

--- a/tests/differential-runner.test.ts
+++ b/tests/differential-runner.test.ts
@@ -6,6 +6,7 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -28,6 +29,24 @@ async function root(): Promise<string> {
   const value = await mkdtemp(join(tmpdir(), "yoda-differential-runner-test-"));
   roots.push(value);
   return value;
+}
+
+/**
+ * Digest the tracked state of the real repository so a harness run can be
+ * proven not to touch the developer checkout.
+ */
+async function snapshotSourceCheckout(): Promise<string> {
+  const repository = join(import.meta.dirname, "..");
+  const status = execFileSync("git", ["status", "--porcelain"], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+  const tree = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+  const driver = await readFile(fixtureDriver, "utf8");
+  return `${tree}${status}${driver}`;
 }
 
 async function scenario(mode: string): Promise<DifferentialScenario> {
@@ -171,6 +190,62 @@ describe("isolated differential runner", () => {
     expect(await readdir(temporaryParent)).toEqual([]);
   });
 
+  it("survives a child that never drains a large stdin", async () => {
+    const temporaryParent = await root();
+    const fixture = await scenario("ignore-stdin");
+    // Larger than the operating-system pipe buffer, so the unread write fails
+    // with EPIPE once the child exits.
+    fixture.invocation.stdin = "x".repeat(400_000);
+
+    const result = await runScenarioSide({
+      side: "candidate",
+      executable: process.execPath,
+      scenario: fixture,
+      temporaryParent,
+    });
+
+    expect(result.observation.process).toMatchObject({
+      outcome: "exit",
+      exitCode: 0,
+      stdout: { content: "ignored\n" },
+    });
+    expect(await readdir(temporaryParent)).toEqual([]);
+  });
+
+  it("records a created Git repository even when Git capture is disabled", async () => {
+    const temporaryParent = await root();
+    const fixture = await scenario("git-create");
+    expect(fixture.capture.git).toBe(false);
+
+    const result = await runScenarioSide({
+      side: "candidate",
+      executable: process.execPath,
+      scenario: fixture,
+      temporaryParent,
+    });
+
+    // A side that creates a repository must never be byte-identical to a side
+    // that does nothing.
+    expect(result.observation.filesystem.mutations).toContainEqual({
+      path: ".git",
+      kind: "added",
+    });
+    expect(await readdir(temporaryParent)).toEqual([]);
+  });
+
+  it("leaves the source checkout byte-identical", async () => {
+    const temporaryParent = await root();
+    const before = await snapshotSourceCheckout();
+    await runScenario(
+      await scenario("unexpected-file"),
+      process.execPath,
+      process.execPath,
+      temporaryParent,
+    );
+    expect(await snapshotSourceCheckout()).toEqual(before);
+    expect(await readdir(temporaryParent)).toEqual([]);
+  });
+
   it("uses isolated environment roots and drops unrelated secrets", async () => {
     process.env.YODA_TEST_SECRET = "must-not-leak";
     const temporaryParent = await root();
@@ -180,7 +255,9 @@ describe("isolated differential runner", () => {
       scenario: await scenario("state"),
       temporaryParent,
     });
-    const value = result.observation.structured[0]?.value;
+    const artifact = result.observation.structured[0];
+    expect(artifact?.state).toBe("valid");
+    const value = artifact?.state === "valid" ? artifact.value : undefined;
     expect(value).toMatchObject({ leakedSecret: null });
     expect(value).toHaveProperty("home");
     expect(value).toHaveProperty("temporary");

--- a/tests/differential-runner.test.ts
+++ b/tests/differential-runner.test.ts
@@ -1,0 +1,196 @@
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runScenario,
+  runScenarioSide,
+  type DifferentialScenario,
+} from "@mestre-yoda/differential";
+import { afterEach, describe, expect, it } from "vitest";
+
+const fixtureDriver = join(
+  import.meta.dirname,
+  "fixtures/differential/driver.mjs",
+);
+const emptyDigest =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const roots: string[] = [];
+
+async function root(): Promise<string> {
+  const value = await mkdtemp(join(tmpdir(), "yoda-differential-runner-test-"));
+  roots.push(value);
+  return value;
+}
+
+async function scenario(mode: string): Promise<DifferentialScenario> {
+  const driver = await readFile(fixtureDriver, "utf8");
+  return {
+    schemaVersion: 1,
+    id: `runner-${mode}`,
+    parityContractIds: ["CLI-VERSION"],
+    workspace: {
+      entries: [
+        {
+          type: "file",
+          path: "driver.mjs",
+          content: driver,
+          executable: false,
+        },
+      ],
+    },
+    invocation: {
+      args: ["driver.mjs", mode],
+      stdin: "",
+      environment: {},
+      timeoutMs: mode === "timeout" ? 75 : 2_000,
+      maxStdoutBytes: 1_048_576,
+      maxStderrBytes: 1_048_576,
+    },
+    capture: {
+      structured:
+        mode === "state" ? [{ id: "state", path: ".brain/state.json" }] : [],
+      git: false,
+    },
+    normalization: [],
+    disclosure: {
+      stdout: "content",
+      stderr: "content",
+      artifacts: "digest",
+    },
+    expected: {
+      process: {
+        outcome: "exit",
+        exitCode: 0,
+        signal: null,
+        stdout: { bytes: 0, sha256: emptyDigest },
+        stderr: { bytes: 0, sha256: emptyDigest },
+      },
+      filesystem: { before: [], after: [], mutations: [] },
+      structured: [],
+      git: null,
+    },
+  };
+}
+
+afterEach(async () => {
+  delete process.env.YODA_TEST_SECRET;
+  await Promise.all(
+    roots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("isolated differential runner", () => {
+  it("runs independent equal sides and removes both temporary roots", async () => {
+    const temporaryParent = await root();
+    const fixture = await scenario("equal");
+    const seed = await runScenarioSide({
+      side: "oracle",
+      executable: process.execPath,
+      scenario: fixture,
+      temporaryParent,
+    });
+    fixture.expected = seed.observation;
+
+    const report = await runScenario(
+      fixture,
+      process.execPath,
+      process.execPath,
+      temporaryParent,
+    );
+    expect(report.equal).toBe(true);
+    expect(report.mismatches).toEqual([]);
+    expect(await readdir(temporaryParent)).toEqual([]);
+  });
+
+  it.each([
+    ["unexpected-file", "added", "exit"],
+    ["partial-mutation", "added", "exit"],
+    ["timeout", "added", "timeout"],
+  ] as const)("retains %s mutations", async (mode, mutation, outcome) => {
+    const temporaryParent = await root();
+    const result = await runScenarioSide({
+      side: "candidate",
+      executable: process.execPath,
+      scenario: await scenario(mode),
+      temporaryParent,
+    });
+    expect(result.observation.process.outcome).toBe(outcome);
+    expect(result.observation.filesystem.mutations).toContainEqual({
+      path: mode === "unexpected-file" ? "unexpected.txt" : "partial.txt",
+      kind: mutation,
+    });
+    expect(await readdir(temporaryParent)).toEqual([]);
+  });
+
+  it("classifies a signal crash and still cleans the workspace", async () => {
+    const temporaryParent = await root();
+    const result = await runScenarioSide({
+      side: "candidate",
+      executable: process.execPath,
+      scenario: await scenario("crash"),
+      temporaryParent,
+    });
+    expect(result.observation.process).toMatchObject({
+      outcome: "signal",
+      exitCode: null,
+      signal: "SIGABRT",
+    });
+    expect(await readdir(temporaryParent)).toEqual([]);
+  });
+
+  it("uses isolated environment roots and drops unrelated secrets", async () => {
+    process.env.YODA_TEST_SECRET = "must-not-leak";
+    const temporaryParent = await root();
+    const result = await runScenarioSide({
+      side: "candidate",
+      executable: process.execPath,
+      scenario: await scenario("state"),
+      temporaryParent,
+    });
+    const value = result.observation.structured[0]?.value;
+    expect(value).toMatchObject({ leakedSecret: null });
+    expect(value).toHaveProperty("home");
+    expect(value).toHaveProperty("temporary");
+    expect(JSON.stringify(value)).not.toContain("must-not-leak");
+    expect(JSON.stringify(value)).not.toContain(process.cwd());
+  });
+
+  it("accepts a distinct executable and reports a field-level mismatch", async () => {
+    const temporaryParent = await root();
+    const fixture = await scenario("equal");
+    const seed = await runScenarioSide({
+      side: "oracle",
+      executable: process.execPath,
+      scenario: fixture,
+      temporaryParent,
+    });
+    fixture.expected = seed.observation;
+    const candidate = join(temporaryParent, "candidate.mjs");
+    await writeFile(
+      candidate,
+      "#!/usr/bin/env node\nawait import('node:fs/promises').then(({writeFile}) => writeFile('unexpected.txt', 'x'));\n",
+      "utf8",
+    );
+    await chmod(candidate, 0o755);
+
+    const report = await runScenario(
+      fixture,
+      process.execPath,
+      candidate,
+      temporaryParent,
+    );
+    expect(report.equal).toBe(false);
+    expect(
+      report.mismatches.some(({ pointer }) => pointer.includes("filesystem")),
+    ).toBe(true);
+    expect(await readdir(temporaryParent)).toEqual(["candidate.mjs"]);
+  });
+});

--- a/tests/differential-runner.test.ts
+++ b/tests/differential-runner.test.ts
@@ -146,6 +146,31 @@ describe("isolated differential runner", () => {
     expect(await readdir(temporaryParent)).toEqual([]);
   });
 
+  it("bounds captured output, hashes the retained prefix, and terminates promptly", async () => {
+    const temporaryParent = await root();
+    const fixture = await scenario("output-limit");
+    fixture.invocation.timeoutMs = 2_000;
+    fixture.invocation.maxStdoutBytes = 10;
+    const result = await runScenarioSide({
+      side: "candidate",
+      executable: process.execPath,
+      scenario: fixture,
+      temporaryParent,
+    });
+
+    expect(result.observation.process).toMatchObject({
+      outcome: "output_limit",
+      stdout: {
+        bytes: 10,
+        content: "abcdefghij",
+        sha256:
+          "72399361da6a7754fec986dca5b7cbaf1c810a28ded4abaf56b2106d06cb78b0",
+      },
+    });
+    expect(result.durationMs).toBeLessThan(1_000);
+    expect(await readdir(temporaryParent)).toEqual([]);
+  });
+
   it("uses isolated environment roots and drops unrelated secrets", async () => {
     process.env.YODA_TEST_SECRET = "must-not-leak";
     const temporaryParent = await root();

--- a/tests/fixtures/differential/driver.mjs
+++ b/tests/fixtures/differential/driver.mjs
@@ -19,6 +19,11 @@ if (mode === "equal") {
 } else if (mode === "partial-mutation") {
   await writeFile("partial.txt", "before failure\n", "utf8");
   process.exitCode = 1;
+} else if (mode === "ignore-stdin") {
+  process.stdout.write("ignored\n");
+} else if (mode === "git-create") {
+  await mkdir(".git", { recursive: true });
+  await writeFile(".git/HEAD", "ref: refs/heads/main\n", "utf8");
 } else if (mode === "state") {
   await mkdir(".brain", { recursive: true });
   await writeFile(

--- a/tests/fixtures/differential/driver.mjs
+++ b/tests/fixtures/differential/driver.mjs
@@ -11,6 +11,9 @@ if (mode === "equal") {
 } else if (mode === "timeout") {
   await writeFile("partial.txt", "before timeout\n", "utf8");
   globalThis.setInterval(() => {}, 1_000);
+} else if (mode === "output-limit") {
+  process.stdout.write("abcdefghijklmnopqrstuvwxyz");
+  globalThis.setInterval(() => {}, 1_000);
 } else if (mode === "crash") {
   process.kill(process.pid, "SIGABRT");
 } else if (mode === "partial-mutation") {

--- a/tests/fixtures/differential/driver.mjs
+++ b/tests/fixtures/differential/driver.mjs
@@ -1,0 +1,33 @@
+import { mkdir, writeFile } from "node:fs/promises";
+
+const mode = process.argv[2] ?? "equal";
+
+if (mode === "equal") {
+  process.stdout.write("equal\n");
+} else if (mode === "normalize") {
+  process.stdout.write(`${process.cwd()}\r\n`);
+} else if (mode === "unexpected-file") {
+  await writeFile("unexpected.txt", "unexpected\n", "utf8");
+} else if (mode === "timeout") {
+  await writeFile("partial.txt", "before timeout\n", "utf8");
+  globalThis.setInterval(() => {}, 1_000);
+} else if (mode === "crash") {
+  process.kill(process.pid, "SIGABRT");
+} else if (mode === "partial-mutation") {
+  await writeFile("partial.txt", "before failure\n", "utf8");
+  process.exitCode = 1;
+} else if (mode === "state") {
+  await mkdir(".brain", { recursive: true });
+  await writeFile(
+    ".brain/state.json",
+    `${JSON.stringify({
+      home: process.env.HOME,
+      temporary: process.env.TMPDIR,
+      leakedSecret: process.env.YODA_TEST_SECRET ?? null,
+    })}\n`,
+    "utf8",
+  );
+} else {
+  process.stderr.write("unknown synthetic mode\n");
+  process.exitCode = 2;
+}

--- a/tests/readme-honesty.test.ts
+++ b/tests/readme-honesty.test.ts
@@ -51,6 +51,7 @@ describe("README honesty", () => {
       "npm ci",
       "npm run spellcheck",
       "npm run verify",
+      "npm run differential:check",
       "npm run build",
       "npm run package:verify",
     ];
@@ -67,10 +68,11 @@ describe("README honesty", () => {
         'cspell --gitignore-root . --no-progress --show-suggestions "**/*.md"',
       "parity:check": "node scripts/check-parity-inventory.mjs",
       "result:check": "node scripts/check-result-contract.mjs",
+      "differential:check": "node scripts/run-differential.mjs",
       build: "node scripts/build.mjs",
       "package:verify": "node scripts/verify-package.mjs",
       verify:
-        "npm run format:check && npm run spellcheck && npm run lint && npm run typecheck && npm test && npm run test:coverage && npm run oracle:verify && npm run parity:check && npm run result:check && npm run contracts:check && npm run build && npm run package:verify",
+        "npm run format:check && npm run spellcheck && npm run lint && npm run typecheck && npm test && npm run test:coverage && npm run oracle:verify && npm run parity:check && npm run result:check && npm run contracts:check && npm run differential:check && npm run build && npm run package:verify",
     });
     expect(commands.indexOf("npm run build")).toBeLessThan(
       commands.indexOf("npm run package:verify"),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "allowJs": false,
     "checkJs": false,
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
Closes #13. Part of epic #8. Builds on #9, #10, #11, and #12.

## What this adds

A versioned, isolated, fail-closed differential harness that runs identical golden scenarios against the frozen Go v3 oracle and the TypeScript candidate, then reports normalized field-level differences.

- `packages/differential/` — closed scenario/observation contracts and loader, deterministic workspace materialization, filesystem/Git/structured-JSON capture, closed field-scoped normalization, comparison, and bounded process execution.
- `schemas/compatibility/differential-{scenario,observation}.v1.schema.json` — recursively closed JSON Schema 2020-12 contracts.
- `compatibility/fixtures/differential/v1/` — two executable public self-test scenarios, two authorized live scenarios, and twelve planned PRD entries.
- `scripts/run-differential.mjs` — the `npm run differential:check` CLI, wired into `npm run verify` and CI.
- `docs/compatibility/differential-harness.md` — operation, exit, isolation, and disclosure contracts.

## Design choices

**Every scenario is an equality claim.** There is no "expected difference means success" mode. Both sides are compared against the same golden observation and against each other; any mismatch exits nonzero and grants no parity credit. A corpus that selects no runnable scenario exits `2` rather than reporting a vacuous pass.

**Normalization is closed and field-scoped.** The only operations are CRLF-to-LF conversion, workspace-token replacement, explicit JSON value tokens, keyed array sorting, and justified single-field removal — no wildcards, no regular-expression rewriting. Normalization cannot target process outcome/exit, the result contract's `status`, `exitCode`, or `reasonCode`, filesystem mutations, unexpected files, or Git effects, because rewriting any of those would normalize away a real behavioral difference.

**Disclosure is deny-by-default.** Reports summarize streams and captured artifacts as byte counts and SHA-256 digests. When `disclosure.artifacts` is `digest`, each structured value is compared as a single opaque digest rather than field by field, so neither private key names nor private scalar values can reach a report. `content` mode is the explicit opt-in and is reserved for original public fixtures.

**Every artifact is observable.** A selected artifact carries one of four states — `absent`, `unreadable`, `invalid` (byte count and digest), or `valid`. "The candidate produced no artifact" is the single most important PRD comparison, so it must be a field-level mismatch rather than an opaque harness error. Only a path resolving outside the workspace is refused outright, and it is never read. An unborn `HEAD` is captured as `head: null`, and a missing `git` binary is a harness failure rather than a silent "not a repository" that both sides would agree on vacuously.

**The golden observation is post-normalization.** A scenario's `expected` block is never normalized, so it must be written as a complete observation as it appears *after* normalization has run. Each side is compared to the golden by total recursive equality over the union of keys, so equality with the golden already implies the two sides equal each other, and a golden that omits a field fails closed rather than skipping it. This is why the plan's separate oracle-versus-candidate comparison was deliberately not added — it would emit only redundant mismatches. The invariant it depends on is now documented rather than implicit.

**Isolation is mandatory.** Each side gets a separately materialized fixture copy below an external temporary root, with isolated `HOME`, `TMPDIR`, and Git configuration. Executables spawn directly with a literal argument vector and `shell: false`; `NODE_OPTIONS`, credentials, and proxy configuration are not inherited. Temporary roots are removed in `finally`. The developer checkout is never mutated.

**Bounded execution.** Wall time and per-stream bytes are bounded. Overflow retains the prefix that fits and classifies the run `output_limit`; reported bytes, digest, and any disclosed content always describe that same retained prefix. Timeout or overflow sends SIGTERM to the process group and escalates to SIGKILL 250 ms later — measured from that signal, so an overflowing run does not wait out the full scenario timeout. Capture still runs after a nonzero exit, signal, timeout, crash, or partial mutation.

## Compatibility impact

None to shipped behavior; this adds test infrastructure only.

Parity remains honestly reported at **0 / 400 (0.00%)**. No row has yet earned all four required evidence classes (unit, differential, integration, E2E), so the harness existing does not by itself grant parity credit. The PRD `prd-output.schema.json` stays `migration-only` at its frozen digest until every required PRD differential case passes; all twelve PRD cases are recorded as `planned` corpus entries with real matrix contract IDs and explicit observable requirements, and carry no invented golden output.

The two live scenarios (`live-version`, `live-help`) currently report stdout byte-count and digest differences against the oracle. That is expected and honest: the candidate is not parity-complete, so authorized live comparison exits `1`.

## Verification

```bash
npm test -- tests/differential-contract.test.ts tests/differential-comparator.test.ts \
  tests/differential-capture.test.ts tests/differential-runner.test.ts \
  tests/differential-cli.test.ts tests/differential-documentation.test.ts \
  tests/readme-honesty.test.ts tests/parity-inventory-matrix.test.ts
npm run differential:check
npm run verify
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml .github/workflows/docs.yml
npx markdownlint-cli2 "**/*.md" "#node_modules" "#.worktrees"
rg --files -g '*.md' -g '!node_modules/**' -g '!.worktrees/**' -0 | xargs -0 lychee --config .lychee.toml
git diff --check main...HEAD
```

All green locally: `verify` passes end to end, markdownlint reports 0 issues across 49 files, lychee reports 205/205 links OK, and actionlint is clean.

## Failure evidence

The acceptance criterion "a seeded behavioral difference produces an actionable diff and nonzero exit" was verified by seeding a wrong golden exit code into a copy of the public self-test scenario, outside the repository:

```text
Differential corpus self-test: FAIL (1 scenario; 0 planned)
FAIL self-test-equality
  value /candidate/process/exitCode
  value /oracle/process/exitCode
EXIT=1
```

The report names the mismatch kind and JSON Pointer for each side and discloses no path, secret, or stream content. `git status` remained clean in both the worktree and the primary checkout after the run, confirming the harness does not modify the developer repository.

Harness self-tests additionally cover equality, expected normalization, unexpected files, timeout, crash, partial mutation, output overflow, spawn provenance failure, unsafe paths, and report redaction — 277 tests across 29 files.

The public corpus gained `self-test-normalized-state`, which is not a tautology: the driver writes its array members in the opposite order and emits CRLF, so the scenario only matches its golden because sorting, token replacement, and line-ending normalization actually ran. Both self-test sides still run the same executable, so the public corpus cannot itself observe a Go-vs-TypeScript divergence; divergence handling is proven by the harness self-tests, and the documentation now says so plainly instead of overclaiming.

## Review

Two independent review rounds ran against `main...HEAD`.

The first found a vacuous pass on an empty selection, a disclosure leak through structured values, an unprotected result `exitCode`, and a bounded-output capture that retained nothing.

The second found one Critical and eight Important issues, all fixed:

- **Critical** — an unhandled stdin `EPIPE` killed the harness before cleanup, leaking the sandbox, printing a stack trace, and exiting `1`, the documented *mismatch* code, for what was actually a harness crash. It triggers whenever stdin exceeds the pipe buffer and the child does not drain it, which the planned PRD scenarios will do.
- Capture converted three real behavioral differences — a missing artifact, an unborn `HEAD`, and a created repository — into harness errors or silent equality. The `.git` case was a confirmed vacuous pass: a side that created a repository was byte-identical to a side that did nothing.
- Normalization protected decision fields but not their parents, so a rule could remove `/process` or `/structured/N/value` and take the protected field with it.
- Reports named no paths, so a diff said only that "an object appeared" — short of the issue's actionable-diff criterion.
- The source-checkout immutability assertion the plan required was never written; it was backed only by a keyword grep over the documentation. It now runs a real digest comparison around a full `runScenario`.

One Minor finding is deferred and called out rather than quietly dropped: `packages/differential/src` is not yet under the repository's 100% coverage gate. Including it would require exhaustive error-path tests well beyond this issue's scope, and weakening the existing gate to accommodate it seemed worse than leaving the gap visible.
