### PR TITLE
feat: define and prove the embedded runtime distribution contract

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,8 +31,9 @@
     "Lychee",
     "lycheeverse",
     "markdownlint",
-    "metafile",
     "Mestre",
+    "metafile",
+    "misordered",
     "mktemp",
     "MWTC",
     "NOSYSTEM",
@@ -45,14 +46,15 @@
     "rhysd",
     "Sistemas",
     "thiagocorreanet",
-    "trimpath",
     "trailcli",
+    "trimpath",
     "TypeScript",
     "uninspectable",
+    "unloadable",
     "Vitest",
+    "worklist",
     "worktree",
     "worktrees",
-    "worklist",
     "Yoda"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The project is being built for **Claude Code** and **OpenAI Codex**, with a host
 > Mestre Yoda is an **experimental rewrite under active development**. There is
 > no supported installation method, public distribution, production runtime, or
 > usable SDD command today. The checked-in embedded ESM runtime is internal
-> foundation infrastructure: it supports only `--help` and `--version` to prove
+> foundation infrastructure: it supports only `--help`, `--version`, and `handshake` to prove
 > the deterministic toolchain and standalone bundle. The project is not ready for production.
 > Contract schemas and compatibility checks are available, but they are
 > foundation artifacts only. **The harness runtime is not usable yet.**
@@ -119,6 +119,11 @@ installed plugin.
 ### No global Yoda binary
 
 The new runtime is developed in TypeScript and distributed as a self-contained JavaScript ESM bundle inside the plugin. This avoids a separately installed global binary, PATH problems, and runtime/plugin version drift.
+
+Hosts invoke `runtime/yoda.mjs` inside the installed plugin, against whatever
+project directory they are working in. It requires Node.js 24 or newer and
+answers an older interpreter with a structured result rather than a parser
+error. See the [runtime distribution contract](docs/compatibility/runtime-distribution.md).
 
 ### Evidence before completion
 

--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -59,6 +59,19 @@ catalog preserves all 76 entries from revision 1.0 and adds:
 | `contract.state_version_invalid` | 4 | Persisted state identity cannot be trusted |
 | `contract.state_version_unsupported` | 4 | Persisted state needs explicit migration or recovery |
 
+The additive
+[`reason-codes.v1.2.json`](../../packages/contracts/catalogs/reason-codes.v1.2.json)
+catalog preserves all 82 entries from revision 1.1 and adds:
+
+| Reason | Exit | Meaning |
+| --- | --- | --- |
+| `runtime.node_unsupported` | 2 | The interpreter running the plugin runtime is older than the supported minimum |
+
+`runtime.node_unsupported` is the current catalog revision, `1.2.0`. It is the
+one reason a caller can receive before the runtime bundle has loaded at all, so
+the plugin entry point embeds its summary and recovery text verbatim from this
+catalog. It is documented in full by the runtime distribution contract.
+
 Every rejection renders through the
 [universal result contract](result-contract.md), reports `stateChanged: false`,
 and uses catalog-owned recovery text. Public output does not echo the supplied

--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -70,7 +70,7 @@ catalog preserves all 82 entries from revision 1.1 and adds:
 `runtime.node_unsupported` is the current catalog revision, `1.2.0`. It is the
 one reason a caller can receive before the runtime bundle has loaded at all, so
 the plugin entry point embeds its summary and recovery text verbatim from this
-catalog. It is documented in full by the runtime distribution contract.
+catalog. It is documented in full by the [runtime distribution contract](runtime-distribution.md).
 
 Every rejection renders through the
 [universal result contract](result-contract.md), reports `stateChanged: false`,

--- a/docs/compatibility/result-contract.md
+++ b/docs/compatibility/result-contract.md
@@ -26,7 +26,7 @@ Version 1 is owned by four checked artifact families:
   one canonical example for every exit class.
 
 Run `npm run result:check` to validate the schemas, the frozen predecessor
-inventory, all 83 reason entries, the six examples, canonical ordering, and
+inventory, the frozen revision-1.0 inventory of 76 reason entries, the six examples, canonical ordering, and
 output-safety rules without network access.
 
 ## Result fields

--- a/docs/compatibility/result-contract.md
+++ b/docs/compatibility/result-contract.md
@@ -106,7 +106,7 @@ Catalog revision 1.2 preserves those 82 entries byte-for-byte and adds
 `runtime.node_unsupported`, reported when the interpreter running the plugin
 runtime is older than the supported minimum. It is the only reason emitted
 before the runtime bundle loads, so the plugin entry point embeds its text
-verbatim; see the runtime distribution contract.
+verbatim; see the [runtime distribution contract](runtime-distribution.md).
 
 ## Evidence references
 

--- a/docs/compatibility/result-contract.md
+++ b/docs/compatibility/result-contract.md
@@ -20,11 +20,13 @@ Version 1 is owned by four checked artifact families:
   preserves the immutable 76-reason revision 1.0 policy;
 - [`reason-codes.v1.1.json`](../../packages/contracts/catalogs/reason-codes.v1.1.json)
   adds six contract-family compatibility reasons;
+- [`reason-codes.v1.2.json`](../../packages/contracts/catalogs/reason-codes.v1.2.json)
+  is the current revision and adds `runtime.node_unsupported`;
 - [`fixtures/result-contract/v1`](../../fixtures/result-contract/v1) provides
   one canonical example for every exit class.
 
 Run `npm run result:check` to validate the schemas, the frozen predecessor
-inventory, all 76 reason entries, the six examples, canonical ordering, and
+inventory, all 83 reason entries, the six examples, canonical ordering, and
 output-safety rules without network access.
 
 ## Result fields
@@ -99,6 +101,12 @@ Catalog revision 1.1 preserves those 76 entries byte-for-byte and adds six
 the independently versioned plugin, state, and host families. Their exact
 compatibility windows and recovery policy are documented in the
 [contract versioning guide](contract-versioning.md).
+
+Catalog revision 1.2 preserves those 82 entries byte-for-byte and adds
+`runtime.node_unsupported`, reported when the interpreter running the plugin
+runtime is older than the supported minimum. It is the only reason emitted
+before the runtime bundle loads, so the plugin entry point embeds its text
+verbatim; see the runtime distribution contract.
 
 ## Evidence references
 

--- a/docs/compatibility/runtime-distribution.md
+++ b/docs/compatibility/runtime-distribution.md
@@ -37,10 +37,11 @@ inside that same file could possibly run. **A guard cannot protect the code it
 shares a file with.** Splitting the boot is the only way to answer an old
 interpreter with a structured result instead of a parser stack trace.
 
-`runtime/yoda.mjs` therefore restricts itself to syntax valid on Node 12, the
-first release with stable ESM, and is never transpiled. Below Node 12 an ESM
-entry point cannot load at all, so no guard placed inside one would help; that
-boundary is stated here rather than papered over.
+`runtime/yoda.mjs` therefore restricts itself to syntax valid on Node 12.17.0, the
+first release with unflagged ESM and dynamic `import()`, and is never
+transpiled. Below that an ESM entry point cannot load a core at all, so no guard
+placed inside one would help; that boundary is stated here rather than papered
+over.
 
 Both files ship inside the plugin and import nothing but Node builtins and each
 other, so the runtime stays self-contained: two files, one unit, zero
@@ -99,9 +100,17 @@ Two roots exist and must never be confused:
 
 The runtime resolves its own assets relative to `import.meta.url`, never
 relative to the working directory. That is what lets one installed plugin serve
-any number of unrelated projects. Both roots are exercised from paths containing
-spaces and non-ASCII characters, because that is where naive path handling
-breaks.
+any number of unrelated projects.
+
+This is currently a **rule the layout must keep**, not yet a body of resolution
+code: the only module-relative resolution in the distribution is the entry
+point's import of its core, because no plugin asset exists to load yet. The rule
+is stated and tested now so the asset issues that follow inherit it rather than
+having to retrofit it.
+
+Both roots are tested from paths containing spaces and non-ASCII characters,
+because a relative dynamic import through a percent-encodable `import.meta.url`
+is exactly where naive path handling breaks.
 
 ## Two inventories
 
@@ -169,12 +178,21 @@ for:
 result, reason-catalog, state, and host versions this bundle carries. Invoked
 directly it reports no observed host identity, because it was handed none and
 the contract requires stating the limitation rather than substituting a guess.
-An unacceptable host contract yields `contract.host_version_invalid` or
-`contract.host_version_unsupported`.
 
-Neither path reimplements version policy: both call the classifier published by
-the [contract versioning guide](contract-versioning.md), so a family is judged
-in exactly one place. Neither echoes the supplied value.
+The runtime does not yet classify a **host** contract version: nothing hands it
+one to judge. `contract.host_version_invalid` and
+`contract.host_version_unsupported` are defined by the
+[contract versioning guide](contract-versioning.md) and will be wired when the
+host adapter protocol delivers a request carrying that identity. They are not
+reachable through this contract, and this document does not claim otherwise.
+
+`--expect` does not reimplement version policy: it calls the same published
+classifier, so a family is judged in exactly one place. It never echoes the
+supplied value, and neither does the unrecognized-argument path — a misordered
+`--expect` lands there, so echoing would reopen the same disclosure hole.
+
+`--expect` must be the **first** argument. Anywhere else it is not recognized as
+a flag and the invocation is rejected without acting.
 
 The full request/response conversation belongs to the host adapter protocol.
 This contract covers the runtime's half of it.

--- a/docs/compatibility/runtime-distribution.md
+++ b/docs/compatibility/runtime-distribution.md
@@ -1,0 +1,206 @@
+# Embedded Runtime Distribution Contract
+
+Claude Code and Codex invoke a runtime the plugin owns, from inside the plugin
+directory, against an arbitrary project working directory. There is no global
+executable, no `PATH` entry, and no project `node_modules`.
+
+The predecessor shipped its runtime separately: an installer put a binary on
+`PATH`, hooks invoked it by name, and an `--expect <version>` flag existed to
+detect the drift that arrangement created. Two artifacts with independent
+installation lifecycles will diverge, and a version flag only reports the
+divergence after it has already happened. Removing that split is the point of
+this contract.
+
+## Plugin layout
+
+A plugin install contains exactly these files:
+
+| Path | Role |
+| --- | --- |
+| `runtime/yoda.mjs` | Canonical entry point: the interpreter gate |
+| `runtime/yoda.core.mjs` | The self-contained bundle |
+| `runtime/manifest.json` | Versions and digests of what actually shipped |
+
+Schemas, skills, agents, providers, and templates are owned by later issues.
+This contract freezes the layout that will hold them.
+
+## Why the boot is split
+
+`runtime/yoda.mjs` does not contain the runtime. It contains a small preflight
+that checks the interpreter and only then dynamically imports
+`runtime/yoda.core.mjs`.
+
+This is not a stylistic choice. A JavaScript module is parsed in full before any
+of it executes. If the bundle targets modern Node and a user runs an older one,
+the failure is a `SyntaxError` from the parser — raised before any version check
+inside that same file could possibly run. **A guard cannot protect the code it
+shares a file with.** Splitting the boot is the only way to answer an old
+interpreter with a structured result instead of a parser stack trace.
+
+`runtime/yoda.mjs` therefore restricts itself to syntax valid on Node 12, the
+first release with stable ESM, and is never transpiled. Below Node 12 an ESM
+entry point cannot load at all, so no guard placed inside one would help; that
+boundary is stated here rather than papered over.
+
+Both files ship inside the plugin and import nothing but Node builtins and each
+other, so the runtime stays self-contained: two files, one unit, zero
+dependencies.
+
+## Interpreter policy
+
+The supported floor is **Node.js 24.0.0**, matching the bundle's `node24`
+target. A prerelease of the floor precedes it and is rejected.
+
+The preflight reads `process.versions.node`. It never searches `PATH`, never
+probes for another interpreter, and never re-executes itself under one. If the
+interpreter running the preflight is too old, that is the answer.
+
+An interpreter that is **absent** entirely is outside the runtime's reach —
+nothing runs, so nothing can report. Detecting that and rendering guidance
+belongs to the host adapter that spawns the runtime. The boundary is stated on
+both sides so neither assumes the other covers it.
+
+Rejection emits one `result.v1` document on stdout and exits `2`:
+
+```json
+{
+  "contractVersion": "1.0.0",
+  "status": "failure",
+  "exitCode": 2,
+  "reasonCode": "runtime.node_unsupported",
+  "summary": "The interpreter running the plugin runtime is older than the supported minimum.",
+  "why": ["The plugin runtime requires a newer Node.js interpreter."],
+  "evidence": [],
+  "stateChanged": false,
+  "retryable": false,
+  "recovery": "Install Node.js 24.0.0 or newer and run the command again."
+}
+```
+
+`stateChanged` is `false` because the check runs before anything is opened for
+writing. The rejected version is never echoed back, and no local path or stack
+trace appears.
+
+The reason belongs to catalog revision `1.2.0`. The preflight cannot import the
+contracts package — that package is bundled with modern syntax, which is exactly
+the situation the preflight exists to survive — so the build injects the
+catalog's summary and recovery text into the entry point. A test compares the
+injected literals against the catalog, so a drifting copy fails the build rather
+than shipping.
+
+## Two roots
+
+Two roots exist and must never be confused:
+
+| Root | Resolved from | Holds |
+| --- | --- | --- |
+| Plugin root | `import.meta.url` | the runtime, its manifest, and later plugin assets |
+| Project root | `process.cwd()` | the user's repository and its state surfaces |
+
+The runtime resolves its own assets relative to `import.meta.url`, never
+relative to the working directory. That is what lets one installed plugin serve
+any number of unrelated projects. Both roots are exercised from paths containing
+spaces and non-ASCII characters, because that is where naive path handling
+breaks.
+
+## Two inventories
+
+A plugin install and a project install receive different things, so there are
+two lists rather than one variation of the same list.
+
+**Plugin allowlist** — the exact set a plugin install contains. Anything else
+fails the build:
+
+```text
+runtime/manifest.json
+runtime/yoda.core.mjs
+runtime/yoda.mjs
+```
+
+**Project denylist** — patterns that must never appear under a project the
+runtime operated on. A project receives state surfaces; it never receives the
+runtime, its sources, or a dependency tree:
+
+```text
+node_modules/    any dependency tree
+packages/        TypeScript sources
+runtime/         the bundled runtime
+*.ts  *.map      sources and debugging metadata
+```
+
+`npm run package:verify` enforces both directions, so CI carries the guarantee
+rather than the tests alone.
+
+Source maps are excluded deliberately. A source map reconstructs the TypeScript
+sources, and the denylist exists precisely to keep sources out of what ships.
+Debugging metadata becomes a considered release artifact rather than a file that
+rides along unnoticed.
+
+## Distribution manifest
+
+`runtime/manifest.json` states what shipped rather than what the source tree
+believes:
+
+| Field | Meaning |
+| --- | --- |
+| `contractVersion` | Manifest schema version |
+| `pluginVersion` | The version `--expect` is matched against |
+| `runtime.entry` | Canonical entry path |
+| `runtime.core` | Bundle path |
+| `runtime.coreSha256` | Digest of the built bundle |
+| `runtime.minimumNode` | Supported interpreter floor |
+| `contracts` | Result, reason-catalog, state, and host versions carried |
+
+Package verification fails if the recorded digest does not match the built core.
+
+## Version pinning and handshake
+
+**`--expect <version>`** is preserved from the predecessor, because it is the
+anti-drift mechanism and dropping it would lose behavior. It is checked before
+anything else, so a drifted install never reaches the operation it was asked
+for:
+
+| Supplied value | Reason | Exit |
+| --- | --- | --- |
+| Missing, non-string, malformed, or untrimmed | `contract.plugin_version_invalid` | 2 |
+| Well-formed but not this bundle's version | `contract.plugin_version_unsupported` | 2 |
+
+**`handshake`** writes an `adapter-message.v1` response reporting the plugin,
+result, reason-catalog, state, and host versions this bundle carries. Invoked
+directly it reports no observed host identity, because it was handed none and
+the contract requires stating the limitation rather than substituting a guess.
+An unacceptable host contract yields `contract.host_version_invalid` or
+`contract.host_version_unsupported`.
+
+Neither path reimplements version policy: both call the classifier published by
+the [contract versioning guide](contract-versioning.md), so a family is judged
+in exactly one place. Neither echoes the supplied value.
+
+The full request/response conversation belongs to the host adapter protocol.
+This contract covers the runtime's half of it.
+
+## Verification
+
+```bash
+npm run build
+npm run package:verify
+npm test -- tests/runtime-preflight.test.ts tests/runtime-distribution.test.ts \
+  tests/runtime-handshake.test.ts tests/package-boundaries.test.ts
+```
+
+The boundary tests are the direct evidence for this contract's claims: the
+runtime runs against a project directory whose name contains a space and
+non-ASCII characters, two unrelated projects receive identical answers from one
+installed plugin, and a run succeeds with a deliberately failing decoy `yoda`
+first on `PATH`. The decoy is asserted to be reachable and to fail loudly before
+the run is asserted to ignore it, so the evidence cannot pass vacuously.
+
+## Parity
+
+This contract builds distribution machinery. It adds no differential,
+integration, or E2E evidence to any parity row, so parity remains
+`0 / 400 (0.00%)`.
+
+The predecessor's `PATH`-installed binary and its two platform installers are
+deliberately not reproduced. Removing them is the outcome this issue exists to
+produce.

--- a/docs/development/toolchain.md
+++ b/docs/development/toolchain.md
@@ -136,22 +136,32 @@ canonical ordering, and public-output safety offline.
 
 ## Runtime artifact
 
-The build stages exactly one plugin file:
+The build stages exactly three plugin files:
 
 ```text
+dist/plugin/runtime/manifest.json
+dist/plugin/runtime/yoda.core.mjs
 dist/plugin/runtime/yoda.mjs
 ```
 
-It is an executable ESM bundle with no runtime `node_modules`, global Yoda
-binary, checkout-relative import, source map, or network requirement. Package
-verification checks the file inventory, shebang, executable mode, forbidden
-references, external imports, size, and SHA-256. It then copies only the bundle
-to a temporary directory and executes `--help` and `--version` with module lookup
-influences cleared.
+`runtime/yoda.mjs` is the executable entry point: a small interpreter gate that
+dynamically imports `runtime/yoda.core.mjs`, the ESM bundle. Neither has a
+runtime `node_modules`, global Yoda binary, checkout-relative import, source
+map, or network requirement.
 
-The minimal help/version surface exists only to prove the toolchain. Workflow
-commands, schemas, state, host behavior, and legacy compatibility arrive in
-their dedicated backlog issues.
+Package verification checks the file inventory, shebang, executable mode,
+unsubstituted placeholders, forbidden references, external imports, and the core
+digest recorded in the manifest. It then copies the whole `runtime` directory to
+a temporary directory and executes `--help` and `--version` with module lookup
+influences cleared, and asserts that a project the runtime operated on contains
+no denied entry.
+
+The [runtime distribution contract](../compatibility/runtime-distribution.md)
+explains why the boot is split and what each inventory guarantees.
+
+The minimal help/version/handshake surface exists only to prove the toolchain.
+Workflow commands, schemas, state, host behavior, and legacy compatibility
+arrive in their dedicated backlog issues.
 
 ## Recovery
 

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -412,7 +412,7 @@ git commit -s -m "feat: emit the two-file runtime and its manifest"
 - Produces: `classifyExpectedVersion(value: unknown): ContractFailureResult | null`, returning `null` when the value matches the bundle plugin version.
 - Consumes: `classifyContractVersion` and `contractFailureResult` from `@mestre-yoda/contracts`.
 
-- [ ] **Step 1: Write the failing handshake tests**
+- [x] **Step 1: Write the failing handshake tests**
 
 ```ts
 import { buildHandshakeResponse, classifyExpectedVersion } from "@mestre-yoda/runtime/handshake";
@@ -449,7 +449,7 @@ describe("runtime handshake", () => {
 });
 ```
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/runtime-handshake.test.ts
@@ -457,7 +457,7 @@ npm test -- tests/runtime-handshake.test.ts
 
 Expected: FAIL because `handshake.ts` does not exist.
 
-- [ ] **Step 3: Implement the handshake and wire the CLI**
+- [x] **Step 3: Implement the handshake and wire the CLI**
 
 `buildHandshakeResponse` reads `contract-families.v1.json` and returns a message
 with `host: "unknown"`, `capabilities: []`, and
@@ -490,7 +490,7 @@ branch of `classifyExpectedVersion` is covered by the `it.each` table above plus
 the accepting case; keep the module free of unreachable defensive branches so
 the gate stays achievable.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm test -- tests/runtime-handshake.test.ts packages/runtime/src/cli.test.ts

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -140,7 +140,7 @@ git commit -s -m "feat: add the unsupported interpreter reason"
 - Produces: a preflight template containing the literal placeholders `__MINIMUM_NODE__`, `__SUMMARY__`, `__RECOVERY__`, and `__CORE__`, substituted at build time by Task 3.
 - Produces: on an unsupported interpreter, one line of `result.v1` JSON on stdout and exit `2`; otherwise a dynamic import of the core bundle.
 
-- [ ] **Step 1: Write the failing preflight tests**
+- [x] **Step 1: Write the failing preflight tests**
 
 The old-interpreter case runs the real file under a stub that rewrites
 `process.versions.node` before the entry point loads, so the shipped artifact is
@@ -233,7 +233,7 @@ describe("runtime preflight", () => {
 });
 ```
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/runtime-preflight.test.ts
@@ -241,7 +241,7 @@ npm test -- tests/runtime-preflight.test.ts
 
 Expected: FAIL because `preflight.mjs` does not exist.
 
-- [ ] **Step 3: Write the preflight**
+- [x] **Step 3: Write the preflight**
 
 No `const`, `let`, arrow functions, template literals, optional chaining, or
 top-level `await` — every one of those would defeat the purpose:
@@ -289,11 +289,11 @@ if (atLeast(process.versions.node, MINIMUM)) {
 }
 ```
 
-Add `packages/runtime/src/boot/preflight.mjs` to `.prettierignore` and exclude it
-from `eslint.config.mjs`, because its placeholders and deliberate legacy syntax
-are not valid targets for either tool.
+No lint or format exclusion turned out to be needed: `no-var` is not part of
+`eslint:recommended`, and Prettier formats the legacy syntax unchanged. Leave
+both configurations alone rather than adding an exemption nothing requires.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm test -- tests/runtime-preflight.test.ts

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -515,7 +515,7 @@ git commit -s -m "feat: answer the contract handshake and pin the plugin version
 - Produces: a project denylist rejecting `node_modules`, `packages`, `runtime`, `*.ts`, and `*.map` anywhere under a project the runtime operated on.
 - Produces: a black-box run whose `PATH` contains a failing decoy `yoda`, from a project directory whose name contains a space and a non-ASCII character.
 
-- [ ] **Step 1: Write the failing boundary tests**
+- [x] **Step 1: Write the failing boundary tests**
 
 ```ts
 import { execFileSync } from "node:child_process";
@@ -578,7 +578,7 @@ describe("distribution boundaries", () => {
 });
 ```
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm run build && npm test -- tests/package-boundaries.test.ts
@@ -586,7 +586,7 @@ npm run build && npm test -- tests/package-boundaries.test.ts
 
 Expected: the first two cases FAIL because the built entry is still a single bundle whose name and content changed in Task 3, and the third passes trivially until the allowlist below is enforced.
 
-- [ ] **Step 3: Enforce both inventories**
+- [x] **Step 3: Enforce both inventories**
 
 Set `expectedInventory` to the three-file allowlist sorted lexicographically.
 Keep the forbidden-reference and external-import checks and apply them to
@@ -599,7 +599,7 @@ the isolated execution exercises the real two-file boot.
 Add a project-denylist check that runs the built entry inside a temporary
 project and fails if any denied pattern appears afterward.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm run build

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -1,0 +1,681 @@
+# Embedded Runtime Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a plugin-owned runtime that Claude Code and Codex invoke from the plugin directory against any project working directory, with no global executable, no `PATH` entry, and no project `node_modules`.
+
+**Architecture:** A two-file boot. `runtime/yoda.mjs` is a preflight in conservative syntax that gates the Node version and then dynamically imports `runtime/yoda.core.mjs`, the self-contained esbuild bundle. A build-emitted `runtime/manifest.json` binds versions and digests. Package verification enforces a plugin allowlist and a project denylist.
+
+**Tech Stack:** Node.js 24.18.0, strict TypeScript 6, esbuild 0.28.1, Vitest 4, AJV 8 / JSON Schema 2020-12, SHA-256.
+
+## Global Constraints
+
+- The supported interpreter floor is Node **24.0.0**; the bundle targets `node24`.
+- `runtime/yoda.mjs` uses only syntax valid on Node 12 and imports nothing but relative paths. It is never transpiled.
+- Reason catalog revision `1.2.0` preserves all 82 entries of `1.1.0` byte-for-byte.
+- Contract version stays `1.0.0`; the catalog addition is additive.
+- The distributed plugin contains exactly three files; `sourcemap` stays `false`.
+- Plugin assets resolve from `import.meta.url`; project data resolves from `process.cwd()`.
+- Public output never echoes a supplied version value, an absolute path, or a stack trace.
+- Keep repository content and delivery text English-only and DCO-sign every commit.
+
+---
+
+### Task 1: Add the unsupported-interpreter reason
+
+**Files:**
+
+- Create: `packages/contracts/catalogs/reason-codes.v1.2.json`
+- Modify: `packages/contracts/catalogs/contract-families.v1.json`
+- Modify: `schemas/contracts/contract-manifest.v1.schema.json`
+- Modify: `packages/contracts/src/compatibility.ts:2`
+- Modify: `scripts/lib/result-contract.mjs:274`
+- Modify: `tests/contract-reason-catalog.test.ts:16`
+- Modify: `tests/contract-manifest.test.ts:111`
+- Modify: `tests/contract-documentation.test.ts:42`
+
+**Interfaces:**
+
+- Produces: catalog revision `1.2.0` containing `runtime.node_unsupported` with `status: "failure"`, `exitCode: 2`, `stateMutation: false`, `retryable: false`, and recovery text naming the required Node version.
+- Consumes: revision `1.1.0` entries, copied unchanged.
+
+- [ ] **Step 1: Write the failing catalog test**
+
+Add to `tests/contract-reason-catalog.test.ts`:
+
+```ts
+it("adds the unsupported interpreter reason without altering revision 1.1", async () => {
+  const previous = JSON.parse(
+    await readFile(resolve("packages/contracts/catalogs/reason-codes.v1.1.json"), "utf8"),
+  ) as { reasons: { code: string }[] };
+  const current = JSON.parse(
+    await readFile(resolve("packages/contracts/catalogs/reason-codes.v1.2.json"), "utf8"),
+  ) as { reasons: { code: string; status: string; exitCode: number; recovery: string }[] };
+
+  expect(current.reasons.slice(0, previous.reasons.length)).toEqual(previous.reasons);
+  const added = current.reasons.filter((reason) => reason.code === "runtime.node_unsupported");
+  expect(added).toHaveLength(1);
+  expect(added[0]).toMatchObject({ status: "failure", exitCode: 2 });
+  expect(added[0]?.recovery).toContain("24");
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/contract-reason-catalog.test.ts
+```
+
+Expected: FAIL because `reason-codes.v1.2.json` does not exist.
+
+- [ ] **Step 3: Generate the catalog and retarget every reference**
+
+Generate the new file from the old one so the preserved entries are byte-identical rather than retyped:
+
+```bash
+node -e '
+const fs = require("node:fs");
+const source = "packages/contracts/catalogs/reason-codes.v1.1.json";
+const catalog = JSON.parse(fs.readFileSync(source, "utf8"));
+catalog.reasons.push({
+  code: "runtime.node_unsupported",
+  description: "The interpreter running the plugin runtime is older than the supported minimum.",
+  status: "failure",
+  exitCode: 2,
+  evidence: "forbidden",
+  stateChanged: false,
+  retryable: false,
+  recovery: "Install Node.js 24.0.0 or newer and run the command again.",
+});
+fs.writeFileSync("packages/contracts/catalogs/reason-codes.v1.2.json", JSON.stringify(catalog, null, 2) + "\n");
+'
+```
+
+Those eight keys are exactly the catalog schema's `reason` required set:
+`code`, `description`, `status`, `exitCode`, `evidence`, `stateChanged`,
+`retryable`, `recovery`. `evidence: "forbidden"` matches the other
+`runtime.*` entries, because an interpreter rejection publishes no evidence.
+
+Then set `minItems` for `reasons` in `schemas/reason-catalog.v1.schema.json`
+from `76` to `83`, set `reasonCatalog` to `"1.2.0"` in
+`contract-families.v1.json` and in the `contract-manifest.v1.schema.json`
+`const`, and repoint the three `reason-codes.v1.1.json` string references in
+`compatibility.ts:2`, `result-contract.mjs:274`, and
+`contract-reason-catalog.test.ts:16` to `v1.2`. Update the expected
+`reasonCatalog` literal in `tests/contract-manifest.test.ts:111` and the
+filename expectation in `tests/contract-documentation.test.ts:42`.
+
+Leave `contractVersion` at `"1.0.0"`: the catalog revision advances, the
+contract does not.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm test -- tests/contract-reason-catalog.test.ts tests/contract-manifest.test.ts tests/contract-documentation.test.ts
+npm run result:check
+npm run contracts:check
+npm run typecheck
+npm run lint
+git add packages/contracts schemas scripts/lib/result-contract.mjs tests
+git commit -s -m "feat: add the unsupported interpreter reason"
+```
+
+### Task 2: Gate the interpreter in a preflight
+
+**Files:**
+
+- Create: `packages/runtime/src/boot/preflight.mjs`
+- Create: `tests/fixtures/runtime/old-node.mjs`
+- Create: `tests/runtime-preflight.test.ts`
+
+**Interfaces:**
+
+- Produces: a preflight template containing the literal placeholders `__MINIMUM_NODE__`, `__SUMMARY__`, `__RECOVERY__`, and `__CORE__`, substituted at build time by Task 3.
+- Produces: on an unsupported interpreter, one line of `result.v1` JSON on stdout and exit `2`; otherwise a dynamic import of the core bundle.
+
+- [ ] **Step 1: Write the failing preflight tests**
+
+The old-interpreter case runs the real file under a stub that rewrites
+`process.versions.node` before the entry point loads, so the shipped artifact is
+what gets tested:
+
+```ts
+// tests/fixtures/runtime/old-node.mjs
+Object.defineProperty(process.versions, "node", {
+  value: process.env.YODA_TEST_NODE_VERSION ?? "18.20.0",
+  configurable: true,
+});
+```
+
+```ts
+// tests/runtime-preflight.test.ts
+import { execFileSync } from "node:child_process";
+import { readFile, mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const stub = join(import.meta.dirname, "fixtures/runtime/old-node.mjs");
+
+async function materializePreflight(): Promise<string> {
+  const template = await readFile(
+    join(import.meta.dirname, "../packages/runtime/src/boot/preflight.mjs"),
+    "utf8",
+  );
+  const root = await mkdtemp(join(tmpdir(), "yoda-preflight-"));
+  await mkdir(join(root, "runtime"), { recursive: true });
+  const entry = join(root, "runtime/yoda.mjs");
+  await writeFile(
+    entry,
+    template
+      .replaceAll("__MINIMUM_NODE__", "24.0.0")
+      .replaceAll("__SUMMARY__", "Interpreter too old.")
+      .replaceAll("__RECOVERY__", "Install Node.js 24.0.0 or newer and run the command again.")
+      .replaceAll("__CORE__", "./yoda.core.mjs"),
+    "utf8",
+  );
+  await writeFile(
+    join(root, "runtime/yoda.core.mjs"),
+    'process.stdout.write("core reached\\n");\n',
+    "utf8",
+  );
+  return entry;
+}
+
+function run(entry: string, version: string) {
+  return execFileSync(
+    process.execPath,
+    ["--import", stub, entry],
+    {
+      encoding: "utf8",
+      env: { ...process.env, YODA_TEST_NODE_VERSION: version },
+    },
+  );
+}
+
+describe("runtime preflight", () => {
+  it("reaches the core on a supported interpreter", async () => {
+    expect(run(await materializePreflight(), "24.18.0")).toBe("core reached\n");
+  });
+
+  it("renders a structured result on an unsupported interpreter", async () => {
+    const entry = await materializePreflight();
+    let stdout = "";
+    let status = 0;
+    try {
+      stdout = run(entry, "18.20.0");
+    } catch (error) {
+      const failure = error as { stdout: string; status: number };
+      stdout = failure.stdout;
+      status = failure.status;
+    }
+
+    expect(status).toBe(2);
+    const result = JSON.parse(stdout) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      contractVersion: "1.0.0",
+      status: "failure",
+      exitCode: 2,
+      reasonCode: "runtime.node_unsupported",
+      stateChanged: false,
+      retryable: false,
+    });
+    expect(stdout).not.toContain("18.20.0");
+    expect(stdout).not.toContain(entry);
+  });
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/runtime-preflight.test.ts
+```
+
+Expected: FAIL because `preflight.mjs` does not exist.
+
+- [ ] **Step 3: Write the preflight**
+
+No `const`, `let`, arrow functions, template literals, optional chaining, or
+top-level `await` — every one of those would defeat the purpose:
+
+```js
+#!/usr/bin/env node
+"use strict";
+
+var MINIMUM = "__MINIMUM_NODE__";
+
+function atLeast(actual, minimum) {
+  var left = String(actual).split(".");
+  var right = String(minimum).split(".");
+  for (var index = 0; index < 3; index += 1) {
+    var a = parseInt(left[index], 10);
+    var b = parseInt(right[index], 10);
+    if (isNaN(a)) return false;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return true;
+}
+
+if (atLeast(process.versions.node, MINIMUM)) {
+  import("__CORE__").catch(function () {
+    process.stderr.write("The Yoda runtime could not be loaded.\n");
+    process.exitCode = 2;
+  });
+} else {
+  process.stdout.write(
+    JSON.stringify({
+      contractVersion: "1.0.0",
+      status: "failure",
+      exitCode: 2,
+      reasonCode: "runtime.node_unsupported",
+      summary: "__SUMMARY__",
+      why: ["The plugin runtime requires a newer Node.js interpreter."],
+      evidence: [],
+      stateChanged: false,
+      retryable: false,
+      recovery: "__RECOVERY__"
+    }) + "\n"
+  );
+  process.exitCode = 2;
+}
+```
+
+Add `packages/runtime/src/boot/preflight.mjs` to `.prettierignore` and exclude it
+from `eslint.config.mjs`, because its placeholders and deliberate legacy syntax
+are not valid targets for either tool.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm test -- tests/runtime-preflight.test.ts
+npm run lint
+npm run format:check
+git add packages/runtime/src/boot/preflight.mjs tests/runtime-preflight.test.ts tests/fixtures/runtime .prettierignore eslint.config.mjs
+git commit -s -m "feat: gate the interpreter before loading the runtime"
+```
+
+### Task 3: Emit the two-file runtime and its manifest
+
+**Files:**
+
+- Modify: `scripts/build.mjs`
+- Create: `tests/runtime-distribution.test.ts`
+
+**Interfaces:**
+
+- Produces: `dist/plugin/runtime/yoda.mjs`, `dist/plugin/runtime/yoda.core.mjs`, and `dist/plugin/runtime/manifest.json`.
+- Produces: manifest fields `contractVersion`, `pluginVersion`, `runtime.entry`, `runtime.core`, `runtime.coreSha256`, `runtime.minimumNode`, and `contracts` holding the result, reason-catalog, state, and host versions read from `contract-families.v1.json`.
+- Consumes: the Task 2 preflight template and its four placeholders.
+
+- [ ] **Step 1: Write the failing distribution test**
+
+```ts
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const plugin = join(import.meta.dirname, "../dist/plugin");
+
+describe("runtime distribution", () => {
+  it("binds the manifest to the built core", async () => {
+    const manifest = JSON.parse(
+      await readFile(join(plugin, "runtime/manifest.json"), "utf8"),
+    ) as { runtime: { entry: string; core: string; coreSha256: string; minimumNode: string } };
+    const core = await readFile(join(plugin, "runtime/yoda.core.mjs"));
+
+    expect(manifest.runtime.entry).toBe("runtime/yoda.mjs");
+    expect(manifest.runtime.core).toBe("runtime/yoda.core.mjs");
+    expect(manifest.runtime.minimumNode).toBe("24.0.0");
+    expect(manifest.runtime.coreSha256).toBe(
+      createHash("sha256").update(core).digest("hex"),
+    );
+  });
+
+  it("substitutes every preflight placeholder", async () => {
+    const entry = await readFile(join(plugin, "runtime/yoda.mjs"), "utf8");
+    expect(entry).not.toMatch(/__[A-Z_]+__/u);
+    expect(entry).toContain("runtime.node_unsupported");
+    expect(entry).toContain("./yoda.core.mjs");
+  });
+
+  it("keeps the preflight recovery text identical to the catalog", async () => {
+    const catalog = JSON.parse(
+      await readFile(
+        join(import.meta.dirname, "../packages/contracts/catalogs/reason-codes.v1.2.json"),
+        "utf8",
+      ),
+    ) as { reasons: { code: string; description: string; recovery: string }[] };
+    const reason = catalog.reasons.find(({ code }) => code === "runtime.node_unsupported");
+    const entry = await readFile(join(plugin, "runtime/yoda.mjs"), "utf8");
+
+    expect(reason).toBeDefined();
+    expect(entry).toContain(JSON.stringify(reason?.recovery).slice(1, -1));
+    expect(entry).toContain(JSON.stringify(reason?.description).slice(1, -1));
+  });
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm run build && npm test -- tests/runtime-distribution.test.ts
+```
+
+Expected: FAIL because the build emits a single `runtime/yoda.mjs` bundle and no manifest.
+
+- [ ] **Step 3: Split the build output**
+
+Change `outfile` to `dist/plugin/runtime/yoda.core.mjs`, drop the shebang banner
+from the bundle (the preflight owns the shebang now), then read the preflight
+template, substitute the four placeholders from the catalog and
+`contract-families.v1.json`, and write `runtime/yoda.mjs` with mode `0755`.
+Write `runtime/manifest.json` last so it can record the core digest.
+
+Substitute with `JSON.stringify(value).slice(1, -1)` so a quote or backslash in
+catalog text cannot break out of the emitted string literal.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm run build
+npm test -- tests/runtime-distribution.test.ts
+node dist/plugin/runtime/yoda.mjs --version
+npm run typecheck
+npm run lint
+git add scripts/build.mjs tests/runtime-distribution.test.ts
+git commit -s -m "feat: emit the two-file runtime and its manifest"
+```
+
+### Task 4: Answer the handshake and pin the plugin version
+
+**Files:**
+
+- Create: `packages/runtime/src/handshake.ts`
+- Modify: `packages/runtime/src/cli.ts`
+- Modify: `packages/runtime/package.json`
+- Modify: `vitest.config.ts`
+- Create: `tests/runtime-handshake.test.ts`
+
+**Interfaces:**
+
+- Produces: `buildHandshakeResponse(correlationId: string): AdapterMessageV1` returning a `messageType: "response"` message whose `payload` is a successful `result.v1`.
+- Produces: `classifyExpectedVersion(value: unknown): ContractFailureResult | null`, returning `null` when the value matches the bundle plugin version.
+- Consumes: `classifyContractVersion` and `contractFailureResult` from `@mestre-yoda/contracts`.
+
+- [ ] **Step 1: Write the failing handshake tests**
+
+```ts
+import { buildHandshakeResponse, classifyExpectedVersion } from "@mestre-yoda/runtime/handshake";
+import { YODA_VERSION } from "@mestre-yoda/contracts";
+import { describe, expect, it } from "vitest";
+
+describe("runtime handshake", () => {
+  it("reports the carried contract versions", () => {
+    const message = buildHandshakeResponse("cli");
+    expect(message).toMatchObject({
+      contractVersion: "1.0.0",
+      hostContract: "1.0.0",
+      messageType: "response",
+      operation: "handshake",
+      correlationId: "cli",
+    });
+    expect(message.payload).toMatchObject({ status: "success", exitCode: 0, stateChanged: false });
+  });
+
+  it("accepts the exact bundle version", () => {
+    expect(classifyExpectedVersion(YODA_VERSION)).toBeNull();
+  });
+
+  it.each([
+    [undefined, "contract.plugin_version_invalid"],
+    ["", "contract.plugin_version_invalid"],
+    ["not-semver", "contract.plugin_version_invalid"],
+    ["9.9.9", "contract.plugin_version_unsupported"],
+  ])("rejects %s", (value, reasonCode) => {
+    const failure = classifyExpectedVersion(value);
+    expect(failure).toMatchObject({ reasonCode, exitCode: 2, stateChanged: false });
+    expect(JSON.stringify(failure)).not.toContain(String(value));
+  });
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/runtime-handshake.test.ts
+```
+
+Expected: FAIL because `handshake.ts` does not exist.
+
+- [ ] **Step 3: Implement the handshake and wire the CLI**
+
+`buildHandshakeResponse` reads `contract-families.v1.json` and returns a message
+with `host: "unknown"`, `capabilities: []`, and
+`observedIdentity: { adapterVersion: YODA_VERSION, model: null }`, because the
+runtime cannot observe a host identity when invoked directly. `messageId` is the
+constant `"handshake-response"` so output stays deterministic.
+
+`classifyExpectedVersion` calls `classifyContractVersion("plugin", value)` and
+returns `contractFailureResult(classification)` unless the classification is
+`current`.
+
+In `cli.ts`, accept `handshake` as a subcommand and `--expect <version>` as a
+prefix flag on any invocation. Both write JSON plus a trailing newline to
+stdout. Keep `--help` and `--version` byte-identical.
+
+`packages/runtime/package.json` currently exports a single path
+(`"exports": "./src/cli.ts"`), so the test import above cannot resolve. Replace
+it with a subpath map:
+
+```json
+"exports": {
+  ".": "./src/cli.ts",
+  "./handshake": "./src/handshake.ts"
+}
+```
+
+Add `packages/runtime/src/handshake.ts` to the `vitest.config.ts` coverage
+`include` array, because the repository gates runtime sources at 100%. Every
+branch of `classifyExpectedVersion` is covered by the `it.each` table above plus
+the accepting case; keep the module free of unreachable defensive branches so
+the gate stays achievable.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm test -- tests/runtime-handshake.test.ts packages/runtime/src/cli.test.ts
+npm run test:coverage
+npm run typecheck
+npm run lint
+git add packages/runtime/src tests/runtime-handshake.test.ts vitest.config.ts
+git commit -s -m "feat: answer the contract handshake and pin the plugin version"
+```
+
+### Task 5: Prove the distribution and installation boundaries
+
+**Files:**
+
+- Modify: `scripts/verify-package.mjs`
+- Create: `tests/package-boundaries.test.ts`
+- Modify: `tests/package-verifier.test.ts`
+
+**Interfaces:**
+
+- Produces: an exact plugin allowlist of `runtime/manifest.json`, `runtime/yoda.core.mjs`, and `runtime/yoda.mjs`.
+- Produces: a project denylist rejecting `node_modules`, `packages`, `runtime`, `*.ts`, and `*.map` anywhere under a project the runtime operated on.
+- Produces: a black-box run whose `PATH` contains a failing decoy `yoda`, from a project directory whose name contains a space and a non-ASCII character.
+
+- [ ] **Step 1: Write the failing boundary tests**
+
+```ts
+import { execFileSync } from "node:child_process";
+import { chmod, mkdtemp, mkdir, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const plugin = join(import.meta.dirname, "../dist/plugin");
+
+async function project(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-boundary-"));
+  const directory = join(root, "a project ç ü");
+  await mkdir(directory, { recursive: true });
+  return directory;
+}
+
+async function decoyPath(root: string): Promise<string> {
+  const binary = join(root, "yoda");
+  await writeFile(binary, "#!/bin/sh\necho 'global yoda was used' >&2\nexit 99\n", "utf8");
+  await chmod(binary, 0o755);
+  return root;
+}
+
+describe("distribution boundaries", () => {
+  it("runs from a plugin directory against a project with spaces and non-ASCII characters", async () => {
+    const cwd = await project();
+    const stdout = execFileSync(
+      process.execPath,
+      [join(plugin, "runtime/yoda.mjs"), "--version"],
+      { cwd, encoding: "utf8" },
+    );
+    expect(stdout.trim()).toBe("0.0.0-development");
+  });
+
+  it("never consults a global yoda on PATH", async () => {
+    const cwd = await project();
+    const decoy = await decoyPath(await mkdtemp(join(tmpdir(), "yoda-decoy-")));
+    const stdout = execFileSync(
+      process.execPath,
+      [join(plugin, "runtime/yoda.mjs"), "--version"],
+      {
+        cwd,
+        encoding: "utf8",
+        env: { PATH: `${decoy}:${process.env.PATH ?? ""}`, HOME: cwd },
+      },
+    );
+    expect(stdout.trim()).toBe("0.0.0-development");
+  });
+
+  it("leaves no runtime source or dependency in the project", async () => {
+    const cwd = await project();
+    execFileSync(process.execPath, [join(plugin, "runtime/yoda.mjs"), "--help"], { cwd });
+    const entries = await readdir(cwd, { recursive: true });
+    for (const entry of entries) {
+      expect(entry).not.toMatch(/(^|\/)(node_modules|packages|runtime)(\/|$)/u);
+      expect(entry).not.toMatch(/\.(ts|map)$/u);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm run build && npm test -- tests/package-boundaries.test.ts
+```
+
+Expected: the first two cases FAIL because the built entry is still a single bundle whose name and content changed in Task 3, and the third passes trivially until the allowlist below is enforced.
+
+- [ ] **Step 3: Enforce both inventories**
+
+Set `expectedInventory` to the three-file allowlist sorted lexicographically.
+Keep the forbidden-reference and external-import checks and apply them to
+`runtime/yoda.core.mjs`. Verify the shebang on `runtime/yoda.mjs` rather than on
+the core, and verify `runtime/manifest.json` records the core's real digest.
+
+Copy the whole `runtime` directory into the clean room instead of one file, so
+the isolated execution exercises the real two-file boot.
+
+Add a project-denylist check that runs the built entry inside a temporary
+project and fails if any denied pattern appears afterward.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+npm run build
+npm run package:verify
+npm test -- tests/package-boundaries.test.ts tests/package-verifier.test.ts
+npm run lint
+git add scripts/verify-package.mjs tests
+git commit -s -m "test: prove the plugin and project installation boundaries"
+```
+
+### Task 6: Document, verify, review, and deliver
+
+**Files:**
+
+- Create: `docs/compatibility/runtime-distribution.md`
+- Modify: `README.md`
+- Modify: `docs/development/toolchain.md`
+- Modify: `docs/compatibility/result-contract.md`
+- Modify: `docs/compatibility/contract-versioning.md`
+- Modify: `schemas/README.md`
+- Modify: `tests/readme-honesty.test.ts`
+- Modify: this plan
+
+**Interfaces:**
+
+- Publishes the plugin layout, the two-file boot rationale, the interpreter floor, the two-root rule, both inventories, the handshake contract, and honest unchanged parity.
+
+- [ ] **Step 1: Write documentation RED tests**
+
+Extend `tests/readme-honesty.test.ts` to require the README to name the
+plugin-owned runtime and to state that no global executable is installed. Add a
+guide test requiring `docs/compatibility/runtime-distribution.md` to contain
+`runtime/yoda.mjs`, `runtime/yoda.core.mjs`, `24.0.0`, `runtime.node_unsupported`,
+`--expect`, `handshake`, `import.meta.url`, `process.cwd()`, and both the words
+`allowlist` and `denylist`. Assert parity still reads `0 / 400 (0.00%)`.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+npm test -- tests/readme-honesty.test.ts
+```
+
+Expected: FAIL because the distribution guide does not exist.
+
+- [ ] **Step 3: Publish exact documentation**
+
+Document the three-file plugin layout; why the boot is split and what a
+single-file guard cannot do; the Node 24.0.0 floor and the Node 12 syntax floor
+of the preflight; that an absent Node is the host adapter's responsibility and
+not the runtime's; the plugin-root versus project-root rule; both inventories;
+`--expect` and `handshake` semantics with their reason codes; and that source
+maps are deliberately excluded. Record catalog revision `1.2.0` in the result
+contract and contract versioning guides and in `schemas/README.md`. Check
+completed plan steps in this file.
+
+- [ ] **Step 4: Run final verification**
+
+```bash
+export PATH=/tmp/tmp.qb2rcwG3r2/node-v24.18.0-linux-x64/bin:$PATH
+npm test -- tests/runtime-preflight.test.ts tests/runtime-distribution.test.ts tests/runtime-handshake.test.ts tests/package-boundaries.test.ts tests/package-verifier.test.ts tests/readme-honesty.test.ts tests/contract-reason-catalog.test.ts tests/contract-manifest.test.ts
+npm run verify
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml .github/workflows/docs.yml
+npx markdownlint-cli2 "**/*.md" "#node_modules" "#.worktrees"
+rg --files -g '*.md' -g '!node_modules/**' -g '!.worktrees/**' -0 | xargs -0 /tmp/tmp.KmVAr8uMu3/lychee-x86_64-unknown-linux-gnu/lychee --config .lychee.toml
+git diff --check main...HEAD
+git status --short
+```
+
+Expected: all gates PASS, parity unchanged, and only intended changes remain.
+
+- [ ] **Step 5: Commit and review**
+
+```bash
+git add docs README.md schemas/README.md tests/readme-honesty.test.ts
+git commit -s -m "docs: publish the runtime distribution contract"
+```
+
+Use `requesting-code-review` against `main...HEAD`; resolve every Critical and
+Important finding with `receiving-code-review`, then rerun Step 4.
+
+- [ ] **Step 6: Deliver and close #14**
+
+Push, open an English PR with `Closes #14`, include the exact commands and the
+decoy-`PATH` and non-ASCII-path evidence, wait for GitHub checks, squash merge,
+confirm issue `#14` closed, mark only `#14` in epic `#8`, fast-forward `main`,
+and remove this owned worktree and branch.

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -680,6 +680,24 @@ git commit -s -m "docs: publish the runtime distribution contract"
 Use `requesting-code-review` against `main...HEAD`; resolve every Critical and
 Important finding with `receiving-code-review`, then rerun Step 4.
 
+The review found no Critical defect and six Important ones, all fixed: the guide
+published host-version rejection the runtime never performs; the result-contract
+guide stated a reason count the checker does not produce; the
+unrecognized-argument path echoed caller-supplied text, which a misordered
+`--expect` could reach; the project denylist had no demonstrated failing case;
+the plugin root was documented as exercised with spaces and non-ASCII characters
+but only the project root was; and the entry point swallowed every core error
+alike, leaving a genuine crash undiagnosable.
+
+Four Minor findings were also fixed: sequential placeholder substitution was
+order-dependent, the preflight tests exercised the template rather than the
+shipped artifact, the Node syntax floor was imprecise, and the spec listed a
+`version.ts` that deliberately does not exist.
+
+One Minor is deferred: `runtime/manifest.json` has no JSON Schema, unlike every
+other contract artifact here. It belongs with release packaging in `BET-02`
+(#59), where the archive format is decided.
+
 - [ ] **Step 6: Deliver and close #14**
 
 Push, open an English PR with `Closes #14`, include the exact commands and the

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -316,7 +316,7 @@ git commit -s -m "feat: gate the interpreter before loading the runtime"
 - Produces: manifest fields `contractVersion`, `pluginVersion`, `runtime.entry`, `runtime.core`, `runtime.coreSha256`, `runtime.minimumNode`, and `contracts` holding the result, reason-catalog, state, and host versions read from `contract-families.v1.json`.
 - Consumes: the Task 2 preflight template and its four placeholders.
 
-- [ ] **Step 1: Write the failing distribution test**
+- [x] **Step 1: Write the failing distribution test**
 
 ```ts
 import { createHash } from "node:crypto";
@@ -365,7 +365,7 @@ describe("runtime distribution", () => {
 });
 ```
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm run build && npm test -- tests/runtime-distribution.test.ts
@@ -373,7 +373,7 @@ npm run build && npm test -- tests/runtime-distribution.test.ts
 
 Expected: FAIL because the build emits a single `runtime/yoda.mjs` bundle and no manifest.
 
-- [ ] **Step 3: Split the build output**
+- [x] **Step 3: Split the build output**
 
 Change `outfile` to `dist/plugin/runtime/yoda.core.mjs`, drop the shebang banner
 from the bundle (the preflight owns the shebang now), then read the preflight
@@ -384,7 +384,7 @@ Write `runtime/manifest.json` last so it can record the core digest.
 Substitute with `JSON.stringify(value).slice(1, -1)` so a quote or backslash in
 catalog text cannot break out of the emitted string literal.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm run build

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -627,7 +627,7 @@ git commit -s -m "test: prove the plugin and project installation boundaries"
 
 - Publishes the plugin layout, the two-file boot rationale, the interpreter floor, the two-root rule, both inventories, the handshake contract, and honest unchanged parity.
 
-- [ ] **Step 1: Write documentation RED tests**
+- [x] **Step 1: Write documentation RED tests**
 
 Extend `tests/readme-honesty.test.ts` to require the README to name the
 plugin-owned runtime and to state that no global executable is installed. Add a
@@ -636,7 +636,7 @@ guide test requiring `docs/compatibility/runtime-distribution.md` to contain
 `--expect`, `handshake`, `import.meta.url`, `process.cwd()`, and both the words
 `allowlist` and `denylist`. Assert parity still reads `0 / 400 (0.00%)`.
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/readme-honesty.test.ts
@@ -644,7 +644,7 @@ npm test -- tests/readme-honesty.test.ts
 
 Expected: FAIL because the distribution guide does not exist.
 
-- [ ] **Step 3: Publish exact documentation**
+- [x] **Step 3: Publish exact documentation**
 
 Document the three-file plugin layout; why the boot is split and what a
 single-file guard cannot do; the Node 24.0.0 floor and the Node 12 syntax floor
@@ -655,7 +655,7 @@ maps are deliberately excluded. Record catalog revision `1.2.0` in the result
 contract and contract versioning guides and in `schemas/README.md`. Check
 completed plan steps in this file.
 
-- [ ] **Step 4: Run final verification**
+- [x] **Step 4: Run final verification**
 
 ```bash
 export PATH=/tmp/tmp.qb2rcwG3r2/node-v24.18.0-linux-x64/bin:$PATH
@@ -670,7 +670,7 @@ git status --short
 
 Expected: all gates PASS, parity unchanged, and only intended changes remain.
 
-- [ ] **Step 5: Commit and review**
+- [x] **Step 5: Commit and review**
 
 ```bash
 git add docs README.md schemas/README.md tests/readme-honesty.test.ts

--- a/docs/superpowers/plans/2026-08-07-runtime-distribution.md
+++ b/docs/superpowers/plans/2026-08-07-runtime-distribution.md
@@ -39,7 +39,7 @@
 - Produces: catalog revision `1.2.0` containing `runtime.node_unsupported` with `status: "failure"`, `exitCode: 2`, `stateMutation: false`, `retryable: false`, and recovery text naming the required Node version.
 - Consumes: revision `1.1.0` entries, copied unchanged.
 
-- [ ] **Step 1: Write the failing catalog test**
+- [x] **Step 1: Write the failing catalog test**
 
 Add to `tests/contract-reason-catalog.test.ts`:
 
@@ -60,7 +60,7 @@ it("adds the unsupported interpreter reason without altering revision 1.1", asyn
 });
 ```
 
-- [ ] **Step 2: Run RED**
+- [x] **Step 2: Run RED**
 
 ```bash
 npm test -- tests/contract-reason-catalog.test.ts
@@ -68,7 +68,7 @@ npm test -- tests/contract-reason-catalog.test.ts
 
 Expected: FAIL because `reason-codes.v1.2.json` does not exist.
 
-- [ ] **Step 3: Generate the catalog and retarget every reference**
+- [x] **Step 3: Generate the catalog and retarget every reference**
 
 Generate the new file from the old one so the preserved entries are byte-identical rather than retyped:
 
@@ -96,8 +96,15 @@ Those eight keys are exactly the catalog schema's `reason` required set:
 `retryable`, `recovery`. `evidence: "forbidden"` matches the other
 `runtime.*` entries, because an interpreter rejection publishes no evidence.
 
-Then set `minItems` for `reasons` in `schemas/reason-catalog.v1.schema.json`
-from `76` to `83`, set `reasonCatalog` to `"1.2.0"` in
+Leave `minItems` for `reasons` in `schemas/reason-catalog.v1.schema.json` at
+`76`. It is a floor shared by every revision, and raising it makes the schema
+reject the frozen 1.0 and 1.1 catalogs it also validates.
+
+Leave `scripts/check-result-contract.mjs:48` pointing at `reason-codes.v1.json`:
+that checker deliberately validates the frozen revision 1.0. Only the canonical
+renderer in `result-contract.mjs` follows the current revision.
+
+Then set `reasonCatalog` to `"1.2.0"` in
 `contract-families.v1.json` and in the `contract-manifest.v1.schema.json`
 `const`, and repoint the three `reason-codes.v1.1.json` string references in
 `compatibility.ts:2`, `result-contract.mjs:274`, and
@@ -108,7 +115,7 @@ filename expectation in `tests/contract-documentation.test.ts:42`.
 Leave `contractVersion` at `"1.0.0"`: the catalog revision advances, the
 contract does not.
 
-- [ ] **Step 4: Run GREEN and commit**
+- [x] **Step 4: Run GREEN and commit**
 
 ```bash
 npm test -- tests/contract-reason-catalog.test.ts tests/contract-manifest.test.ts tests/contract-documentation.test.ts

--- a/docs/superpowers/specs/2026-08-07-runtime-distribution-design.md
+++ b/docs/superpowers/specs/2026-08-07-runtime-distribution-design.md
@@ -1,0 +1,281 @@
+# Embedded Runtime Distribution Contract Design
+
+Issue [#14](https://github.com/thiagocorreanet/mestre-yoda/issues/14) (`CMP-06`).
+Epic [#8](https://github.com/thiagocorreanet/mestre-yoda/issues/8).
+Depends on [#3](https://github.com/thiagocorreanet/mestre-yoda/issues/3) (`FND-02`),
+[#11](https://github.com/thiagocorreanet/mestre-yoda/issues/11) (`CMP-03`), and
+[#12](https://github.com/thiagocorreanet/mestre-yoda/issues/12) (`CMP-04`).
+
+## Problem
+
+The predecessor shipped a separate global executable. Its plugin distribution
+carried 59 files — manifests, schemas, skills, agents, providers, templates, and
+two platform installers — but never the runtime itself. The runtime arrived
+through `install.sh` or `install.ps1`, landed on `PATH`, and was then invoked by
+name from every hook, with an `--expect <version>` flag added specifically to
+detect the drift that arrangement created.
+
+That is the drift this rewrite exists to remove. Two artifacts with independent
+installation lifecycles will diverge, and a version flag only reports the
+divergence after it has already happened.
+
+## Goal
+
+Claude Code and Codex invoke a runtime the plugin owns, from inside the plugin
+directory, against an arbitrary project working directory, with no global
+executable, no `PATH` entry, and no project `node_modules`.
+
+## Non-goals
+
+- Implementing the Claude Code or Codex adapters (`ADP-02` #36, `ADP-03` #37).
+- Implementing the full host adapter protocol (`ADP-01` #35). This issue defines
+  the handshake contract and proves the runtime side of it.
+- Implementing plugin install, update, or rollback (`ADP-05` #39).
+- Shipping schemas, skills, agents, providers, or templates into the plugin.
+  Those are owned by their respective issues; this issue freezes the layout that
+  will hold them.
+- Release archives, signing, SBOM, or provenance (`BET-02` #59).
+
+## Decisions
+
+### D1: The entry point is a two-file boot, not one
+
+The canonical entry point is `runtime/yoda.mjs`. It does not contain the
+runtime. It contains a **preflight** written in deliberately conservative
+syntax, whose only job is to check the Node.js version and then dynamically
+import `runtime/yoda.core.mjs`, which is the real self-contained bundle.
+
+This is forced by the acceptance criterion "a missing/unsupported Node.js
+installation fails before mutation with structured recovery guidance." A
+JavaScript module is parsed in full before any of it executes. If the bundle
+targets modern Node and the user runs an older one, the failure is a
+`SyntaxError` from the parser — before any version check inside the file could
+possibly run. A guard that lives in the same file as the code it guards cannot
+protect that code.
+
+Splitting the boot is the only way to produce a structured result instead of a
+parser stack trace. `yoda.mjs` restricts itself to syntax valid since Node 12,
+so the guard runs on anything a user plausibly has installed. Below that the
+runtime cannot report anything, and the design documents that boundary rather
+than pretending to cover it.
+
+Both files ship inside the plugin and contain no external imports beyond Node
+builtins, so "self-contained" is preserved: two files, one unit, zero
+dependencies.
+
+### D2: Node detection reports, it does not search
+
+The preflight reads `process.versions.node`. It never searches `PATH`, never
+probes for other interpreters, and never re-executes itself under a different
+one. If the interpreter running the preflight is too old, that is the answer.
+
+A completely **absent** Node.js is outside the runtime's reach — nothing runs,
+so nothing can report. Detecting that and rendering guidance belongs to the host
+adapter that spawns the runtime (`ADP-01` #35). This design states that boundary
+explicitly so neither side assumes the other covers it.
+
+### D3: Failure renders through the universal result contract
+
+An unsupported Node version emits a valid `result.v1` document on stdout and
+exits with the code its catalog entry declares. It does not print a bare
+message, and `stateChanged` is `false` because the preflight runs before
+anything is opened for writing.
+
+This requires one new reason. Catalog revision 1.2 preserves all 82 entries of
+revision 1.1 byte-for-byte and adds:
+
+| Reason | Status | Exit | Meaning |
+| --- | --- | --- | --- |
+| `runtime.node_unsupported` | `failure` | 2 | The interpreter running the plugin runtime is older than the supported minimum |
+
+The addition is additive in exactly the way revision 1.1 was: published meanings
+are unchanged, so the contract version stays `1.0.0`.
+
+The preflight cannot import the contracts package — that package is bundled with
+modern syntax, which is the situation the preflight exists to survive. It also
+cannot read the catalog at run time without adding a file to the distribution.
+So the build **injects** the catalog's summary and recovery text into the
+preflight, and a test asserts the injected strings still match the catalog
+entry. The catalog stays the single source of truth, and a drifting copy fails
+the build rather than shipping.
+
+### D3a: The distribution manifest binds what shipped
+
+`runtime/manifest.json` is emitted by the build and states what this plugin
+install actually contains:
+
+| Field | Meaning |
+| --- | --- |
+| `contractVersion` | manifest schema version |
+| `pluginVersion` | the version `--expect` is matched against |
+| `runtime.entry` | canonical entry path, `runtime/yoda.mjs` |
+| `runtime.core` | bundle path and its SHA-256 |
+| `runtime.minimumNode` | the supported interpreter floor |
+| `contracts` | result, reason-catalog, state, and host versions carried |
+
+It exists so the handshake reports what shipped rather than what the source tree
+believes, and so package verification can prove the staged files match their
+recorded digests.
+
+### D4: Plugin assets resolve from the plugin, project data from the cwd
+
+Two roots exist and must never be confused:
+
+| Root | Resolved from | Holds |
+| --- | --- | --- |
+| Plugin root | `import.meta.url` | runtime, manifest, and later schemas, skills, agents, templates |
+| Project root | `process.cwd()` | the user's repository and its state surfaces |
+
+The runtime resolves its own assets relative to `import.meta.url` and never
+relative to the working directory. This is what lets one installed plugin serve
+any number of projects. Both roots are exercised from paths containing spaces
+and non-ASCII characters, because that is where naive path handling breaks.
+
+### D5: Two inventories, because the plugin and the project receive different things
+
+The issue asks for allow/deny rules proving that "project installs contain state
+surfaces only, not runtime source or dependencies." That is a second inventory,
+not a variation of the first.
+
+**Plugin distribution allowlist** — the exact set of files a plugin install
+contains. Anything not listed fails the build:
+
+```text
+runtime/manifest.json
+runtime/yoda.core.mjs
+runtime/yoda.mjs
+```
+
+**Project install denylist** — patterns that must never appear in a project the
+plugin operates on. A project receives state surfaces; it never receives the
+runtime, its source, or its dependencies:
+
+```text
+node_modules/         any runtime dependency tree
+packages/             TypeScript sources
+runtime/              the bundled runtime
+*.ts, *.map           sources and debugging metadata
+```
+
+Verification asserts both directions: the staged plugin matches the allowlist
+exactly, and a project the runtime has operated on contains no denied entry.
+
+### D6: Source maps are excluded from the distributed plugin
+
+`sourcemap: false` stays. A source map reconstructs the TypeScript sources, and
+D5 exists precisely to keep sources out of what ships. Debugging metadata
+becomes a deliberate release artifact under `BET-02` (#59), not an implicit file
+that rides along.
+
+### D7: The handshake is defined here and proven minimally
+
+Two mechanisms, both already contracted by `CMP-04`:
+
+**Version pinning.** `--expect <version>` is preserved from the predecessor,
+because it is the anti-drift mechanism and removing it would lose behavior. A
+value that is missing or malformed yields `contract.plugin_version_invalid`; a
+well-formed value outside the exact bundle version yields
+`contract.plugin_version_unsupported`. Neither echoes the supplied value.
+
+**Contract handshake.** `yoda.mjs handshake` writes an `adapter-message.v1`
+response reporting the plugin, result, state, and host contract versions the
+bundle carries. A host contract outside the accepted window yields
+`contract.host_version_invalid` or `contract.host_version_unsupported`.
+
+Both reuse `classifyContractVersion` and `contractFailureResult`, already
+delivered by `CMP-04`. This issue wires the runtime to that classifier rather
+than reimplementing version policy, so there is exactly one place where a family
+is judged.
+
+The full request/response conversation belongs to `ADP-01`. This issue proves
+the runtime answers correctly and refuses incompatible versions.
+
+## Components
+
+| Unit | Responsibility | Depends on |
+| --- | --- | --- |
+| `packages/runtime/src/boot/preflight.mjs` | Node version gate, structured failure, dynamic import of the core | nothing but Node builtins |
+| `packages/runtime/src/boot/version.ts` | Minimum-version comparison, pure and independently testable | nothing |
+| `packages/runtime/src/handshake.ts` | Builds the handshake response and classifies `--expect` | `classifyContractVersion`, `contractFailureResult` |
+| `scripts/build.mjs` | Emits the two-file runtime and the distribution manifest | esbuild |
+| `scripts/verify-package.mjs` | Enforces both inventories and black-box behavior | built plugin |
+
+The preflight ships as `.mjs` rather than TypeScript because it must not be
+transpiled: transpilation is exactly what would reintroduce modern syntax into
+the file whose entire purpose is to parse on old interpreters. It is small
+enough to review by eye and is covered by tests that execute it directly.
+
+## Data flow
+
+```text
+host spawns:  node <plugin-root>/runtime/yoda.mjs <args>   (cwd = project root)
+                    |
+        runtime/yoda.mjs (preflight, conservative syntax)
+                    |
+        process.versions.node >= minimum ?
+           |                        |
+          no                       yes
+           |                        |
+   result.v1 on stdout      import("./yoda.core.mjs")
+   runtime.node_unsupported          |
+   exit 2, stateChanged: false   plugin root  = dirname(import.meta.url)
+                                 project root = process.cwd()
+```
+
+## Error handling
+
+| Condition | Output | Exit |
+| --- | --- | --- |
+| Node older than minimum | `result.v1`, `runtime.node_unsupported` | 2 |
+| `--expect` missing or malformed | `result.v1`, `contract.plugin_version_invalid` | 2 |
+| `--expect` outside bundle version | `result.v1`, `contract.plugin_version_unsupported` | 2 |
+| Host contract malformed | `result.v1`, `contract.host_version_invalid` | 2 |
+| Host contract outside window | `result.v1`, `contract.host_version_unsupported` | 2 |
+| Node absent entirely | nothing; the host adapter reports it | n/a |
+
+Every failure occurs before any file is opened for writing, so all of them
+report `stateChanged: false`. None echoes a supplied version value, an absolute
+path, or a stack trace.
+
+## Testing
+
+| Level | Proves |
+| --- | --- |
+| Unit | version comparison, handshake construction, `--expect` classification |
+| Preflight | an old interpreter yields a valid `result.v1`, not a `SyntaxError` |
+| Package | plugin allowlist exact; project denylist clean; no external imports |
+| Black box | the built bundle runs from a clean room with a stripped environment |
+| Path handling | plugin root and project root with spaces and non-ASCII characters |
+| Environment | `PATH` containing a decoy `yoda` executable is never consulted |
+
+The old-interpreter case is exercised by executing the preflight with a stubbed
+`process.versions.node`, so the test does not require installing an old Node.
+
+The decoy test is the direct evidence for "no global `yoda` executable is used":
+a fake `yoda` that would fail loudly is placed on `PATH`, and the run must
+succeed without touching it.
+
+## Compatibility impact
+
+No change to shipped behavior; there is no released plugin yet.
+
+Parity remains `0 / 400 (0.00%)`. This issue builds distribution machinery; it
+does not add differential, integration, or E2E evidence to any parity row, so no
+row gains credit.
+
+`--expect` semantics are preserved from the predecessor deliberately. The
+predecessor's `PATH`-installed binary and its two installer scripts are
+intentionally **not** reproduced — removing them is the point of the issue, and
+the `PLUGIN-INSTALL-SH` and `PLUGIN-INSTALL-PS1` parity rows are satisfied by
+the plugin-owned runtime rather than by porting the installers.
+
+## Open decisions recorded rather than deferred
+
+**Minimum Node version.** The repository pins `24.18.0` for development and the
+bundle targets `node24`. The runtime's supported minimum is therefore Node 24.
+Publishing a lower minimum would require lowering the esbuild target and
+re-proving the bundle, which is not in scope.
+
+**Preflight syntax floor.** Node 12, the first release with stable ESM. Older
+interpreters cannot load an ESM entry point at all, so no guard placed inside
+one can help them.

--- a/docs/superpowers/specs/2026-08-07-runtime-distribution-design.md
+++ b/docs/superpowers/specs/2026-08-07-runtime-distribution-design.md
@@ -54,8 +54,9 @@ possibly run. A guard that lives in the same file as the code it guards cannot
 protect that code.
 
 Splitting the boot is the only way to produce a structured result instead of a
-parser stack trace. `yoda.mjs` restricts itself to syntax valid since Node 12,
-so the guard runs on anything a user plausibly has installed. Below that the
+parser stack trace. `yoda.mjs` restricts itself to syntax valid since Node 12.17.0,
+the first release with unflagged ESM and dynamic `import()`, so the guard runs
+on anything a user plausibly has installed. Below that the
 runtime cannot report anything, and the design documents that boundary rather
 than pretending to cover it.
 
@@ -128,8 +129,15 @@ Two roots exist and must never be confused:
 
 The runtime resolves its own assets relative to `import.meta.url` and never
 relative to the working directory. This is what lets one installed plugin serve
-any number of projects. Both roots are exercised from paths containing spaces
-and non-ASCII characters, because that is where naive path handling breaks.
+any number of projects.
+
+This is a rule the layout must keep rather than a body of resolution code: no
+plugin asset exists to load yet, so the only module-relative resolution today is
+the entry point importing its core. Stating and testing the rule now means the
+asset issues that follow inherit it instead of retrofitting it. Both roots are
+tested from paths containing spaces and non-ASCII characters, because a relative
+dynamic import through a percent-encodable `import.meta.url` is where naive path
+handling breaks.
 
 ### D5: Two inventories, because the plugin and the project receive different things
 
@@ -180,7 +188,9 @@ well-formed value outside the exact bundle version yields
 **Contract handshake.** `yoda.mjs handshake` writes an `adapter-message.v1`
 response reporting the plugin, result, state, and host contract versions the
 bundle carries. A host contract outside the accepted window yields
-`contract.host_version_invalid` or `contract.host_version_unsupported`.
+`contract.host_version_invalid` or `contract.host_version_unsupported` once a
+host hands the runtime an identity to judge. Nothing does yet, so this issue
+defines the clause and `ADP-01` wires it.
 
 Both reuse `classifyContractVersion` and `contractFailureResult`, already
 delivered by `CMP-04`. This issue wires the runtime to that classifier rather
@@ -195,7 +205,6 @@ the runtime answers correctly and refuses incompatible versions.
 | Unit | Responsibility | Depends on |
 | --- | --- | --- |
 | `packages/runtime/src/boot/preflight.mjs` | Node version gate, structured failure, dynamic import of the core | nothing but Node builtins |
-| `packages/runtime/src/boot/version.ts` | Minimum-version comparison, pure and independently testable | nothing |
 | `packages/runtime/src/handshake.ts` | Builds the handshake response and classifies `--expect` | `classifyContractVersion`, `contractFailureResult` |
 | `scripts/build.mjs` | Emits the two-file runtime and the distribution manifest | esbuild |
 | `scripts/verify-package.mjs` | Enforces both inventories and black-box behavior | built plugin |
@@ -204,6 +213,12 @@ The preflight ships as `.mjs` rather than TypeScript because it must not be
 transpiled: transpilation is exactly what would reintroduce modern syntax into
 the file whose entire purpose is to parse on old interpreters. It is small
 enough to review by eye and is covered by tests that execute it directly.
+
+The version comparison lives inside the preflight rather than in a separate
+`version.ts`, for the same reason: a TypeScript module would be transpiled into
+the bundle, and the comparison must run *before* the bundle loads. It is tested
+by executing the file under a stubbed interpreter version, which exercises the
+shipped artifact rather than a reimplementation.
 
 ## Data flow
 
@@ -229,9 +244,12 @@ host spawns:  node <plugin-root>/runtime/yoda.mjs <args>   (cwd = project root)
 | Node older than minimum | `result.v1`, `runtime.node_unsupported` | 2 |
 | `--expect` missing or malformed | `result.v1`, `contract.plugin_version_invalid` | 2 |
 | `--expect` outside bundle version | `result.v1`, `contract.plugin_version_unsupported` | 2 |
-| Host contract malformed | `result.v1`, `contract.host_version_invalid` | 2 |
-| Host contract outside window | `result.v1`, `contract.host_version_unsupported` | 2 |
 | Node absent entirely | nothing; the host adapter reports it | n/a |
+| Core missing or unloadable | one fixed line on stderr, no stack trace | 2 |
+
+A host contract version is deliberately absent from this table: the runtime is
+handed none to classify, so publishing those rows here would describe an
+unreachable path.
 
 Every failure occurs before any file is opened for writing, so all of them
 report `stateChanged: false`. None echoes a supplied version value, an absolute

--- a/packages/contracts/catalogs/contract-families.v1.json
+++ b/packages/contracts/catalogs/contract-families.v1.json
@@ -2,7 +2,7 @@
   "contractVersion": "1.0.0",
   "pluginVersion": "0.0.0-development",
   "resultContract": "1.0.0",
-  "reasonCatalog": "1.1.0",
+  "reasonCatalog": "1.2.0",
   "stateContract": {
     "current": "1.0.0",
     "readable": ["1.0.0"],

--- a/packages/contracts/catalogs/reason-codes.v1.2.json
+++ b/packages/contracts/catalogs/reason-codes.v1.2.json
@@ -1,0 +1,835 @@
+{
+  "contractVersion": "1.0.0",
+  "reasons": [
+    {
+      "code": "blocked.context_unreadable",
+      "description": "The decision context cannot be read or validated.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Rebuild the decision context from validated run state and retry the decision."
+    },
+    {
+      "code": "blocked.current_step_mismatch",
+      "description": "The persisted current step differs from the plan's in-progress step.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Reconcile the current-step pointer with the single in-progress plan step, validate state, and retry."
+    },
+    {
+      "code": "blocked.current_step_orphan",
+      "description": "The persisted current step does not exist in the active plan.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Restore the referenced step in the active plan or clear the orphaned pointer through explicit state recovery."
+    },
+    {
+      "code": "blocked.dup_step_id",
+      "description": "The active plan contains duplicate step identifiers.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Assign a unique identifier to every plan step, validate the plan, and retry."
+    },
+    {
+      "code": "blocked.empty_plan",
+      "description": "The active plan contains no executable steps.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Add at least one executable step with valid dependencies to the active plan."
+    },
+    {
+      "code": "blocked.feature_mismatch",
+      "description": "The requested feature differs from the feature recorded by the active run.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Target the feature owned by the active run or finish that run before selecting another feature."
+    },
+    {
+      "code": "blocked.feature_state_ilegivel",
+      "description": "The active feature state cannot be decoded or validated.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Run the state integrity audit and repair or rebuild the active-feature record before continuing."
+    },
+    {
+      "code": "blocked.gaps_ilegivel",
+      "description": "The active gaps document cannot be decoded or validated.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Repair or regenerate the gaps document against its schema, then review the resulting open gaps."
+    },
+    {
+      "code": "blocked.guardrails_ausente",
+      "description": "A harness project is missing its required guardrails document.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Restore the project guardrails document from the managed template and validate it before continuing."
+    },
+    {
+      "code": "blocked.guardrails_ilegivel",
+      "description": "The required guardrails document cannot be decoded or validated.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Correct the guardrails document against its schema and rerun the policy decision."
+    },
+    {
+      "code": "blocked.legacy_failed",
+      "description": "A required legacy compatibility operation reported failure.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Inspect the recorded legacy failure, correct its named prerequisite, and rerun the compatibility operation."
+    },
+    {
+      "code": "blocked.multi_in_progress",
+      "description": "More than one plan step is marked in progress.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Recover the plan so exactly one step remains in progress and validate the current-step pointer."
+    },
+    {
+      "code": "blocked.no_runnable_step",
+      "description": "No pending step has all dependencies satisfied.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Complete or repair the blocking dependencies, or revise the plan so one pending step becomes runnable."
+    },
+    {
+      "code": "blocked.partition_ilegivel",
+      "description": "The pending partition proposal cannot be decoded or validated.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Regenerate the partition proposal from the current PRD and validate it before requesting a decision."
+    },
+    {
+      "code": "blocked.runid_mismatch",
+      "description": "The requested run identifier differs from the active run.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Reload the active run identifier and address the operation to that run."
+    },
+    {
+      "code": "blocked.state_unreadable",
+      "description": "The active run state cannot be read or validated.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Run the state integrity audit and repair or rebuild the active run state before continuing."
+    },
+    {
+      "code": "blocked.stop_loss_budget",
+      "description": "The run exceeded its configured stop-loss budget.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Review the exhausted budget and obtain an explicit budget adjustment or stop the run."
+    },
+    {
+      "code": "blocked.stop_loss_flag",
+      "description": "The run has an active stop-loss flag requiring release.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Review the stop-loss evidence and clear the flag only through the authorized recovery operation."
+    },
+    {
+      "code": "blocked.unknown_dep",
+      "description": "A plan step names a dependency that is absent from the plan.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Correct or remove the unknown dependency identifier, validate the plan graph, and retry."
+    },
+    {
+      "code": "brain_migration_pending",
+      "description": "The project still requires the explicit Brain-layout migration.",
+      "status": "failure",
+      "exitCode": 1,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Run `yoda migrate brain` from the project root, verify the sibling Brain repository, and retry."
+    },
+    {
+      "code": "complete.git_baseline_invalid",
+      "description": "The recorded Git baseline is absent, malformed, or inconsistent.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Recapture a valid Git baseline for the active code step before requesting completion."
+    },
+    {
+      "code": "complete.ignored_removed",
+      "description": "A path ignored at baseline was removed during the code step.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Restore the removed ignored path or explicitly revise the step scope before completion."
+    },
+    {
+      "code": "complete.observation_changed",
+      "description": "The observed repository identity changed since execution began.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Reload repository identity, recapture the observation, and rerun completion against the current checkout."
+    },
+    {
+      "code": "complete.state_missing",
+      "description": "Completion cannot find the required active run or step state.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Restore or select the active run and code-step state before invoking completion."
+    },
+    {
+      "code": "complete.step_state_mismatch",
+      "description": "The step selected for completion is not the active code step.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Reload the active code step and submit completion for that exact step."
+    },
+    {
+      "code": "complete.undeclared_change",
+      "description": "The worktree contains a change outside the step's declared scope.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Revert the undeclared change or add it to an explicitly reviewed step scope before completion."
+    },
+    {
+      "code": "complete.worktree_changed",
+      "description": "The worktree content no longer matches the completion observation.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Reobserve the worktree, regenerate completion evidence, and submit the current content."
+    },
+    {
+      "code": "dashboard.estado_ilegivel",
+      "description": "Dashboard rendering cannot read the canonical trail status.",
+      "status": "failure",
+      "exitCode": 1,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Repair or regenerate the canonical trail status, then reload the dashboard."
+    },
+    {
+      "code": "dashboard.telemetria_ilegivel",
+      "description": "Dashboard rendering cannot read the telemetry history.",
+      "status": "failure",
+      "exitCode": 1,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Repair or quarantine the invalid telemetry entry, then reload the dashboard history."
+    },
+    {
+      "code": "done.all_steps",
+      "description": "The decision engine observed that every plan step is complete.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "gate.aceitacao_final",
+      "description": "The run is waiting for explicit final human acceptance.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Review the final evidence and run `yoda done` to record explicit human acceptance."
+    },
+    {
+      "code": "gate.aprovacao_spec",
+      "description": "The run is waiting for explicit approval of the current specification lineage.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Review the current specification lineage and approve that exact revision before continuing."
+    },
+    {
+      "code": "gate.gaps_abertos",
+      "description": "The run is waiting for a human decision on open business gaps.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Review every open business gap and record the requested human decision for the active gate."
+    },
+    {
+      "code": "gate.particionamento",
+      "description": "The run is waiting for a human decision on the partition proposal.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Review the current partition proposal and explicitly approve or refuse that exact revision."
+    },
+    {
+      "code": "gate.prd_ausente",
+      "description": "The run cannot advance because its required PRD artifact is absent.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Generate and validate the required PRD artifact before continuing the run."
+    },
+    {
+      "code": "guard.active_feature_corrupt",
+      "description": "Guard evaluation cannot validate the active-feature marker.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Repair the active-feature marker against its schema before allowing guarded writes."
+    },
+    {
+      "code": "guard.config_corrupt",
+      "description": "Guard evaluation cannot validate project configuration.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Correct project configuration against its schema before rerunning the guard."
+    },
+    {
+      "code": "guard.config_missing",
+      "description": "Guard evaluation cannot find required project configuration.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Restore the managed project configuration and validate it before rerunning the guard."
+    },
+    {
+      "code": "guard.external_path",
+      "description": "The requested target is outside guard jurisdiction and produced a non-blocking warning.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "guard.guardrails_corrupt",
+      "description": "Guard evaluation cannot validate the guardrails document.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Correct the guardrails document against its schema before rerunning the guard."
+    },
+    {
+      "code": "guard.guardrails_missing",
+      "description": "Guard evaluation cannot find the guardrails document.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Restore the managed guardrails document before allowing guarded writes."
+    },
+    {
+      "code": "guard.outside_allow",
+      "description": "The requested write is outside every configured allow rule.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Move the change inside an allowed scope or obtain an explicit reviewed scope update."
+    },
+    {
+      "code": "guard.project_marker_corrupt",
+      "description": "Guard evaluation cannot validate the project marker.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Repair the project marker against its managed contract before rerunning the guard."
+    },
+    {
+      "code": "guard.scope_corrupt",
+      "description": "Guard evaluation cannot validate the active scope document.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Correct the active scope document against its schema before rerunning the guard."
+    },
+    {
+      "code": "guard.scope_deny",
+      "description": "The active scope explicitly denies the requested write.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Choose a permitted target or obtain an explicit reviewed change to the deny policy."
+    },
+    {
+      "code": "guard.spec_artifact",
+      "description": "The requested write targets a protected specification artifact.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Use the specification workflow that owns the protected artifact instead of editing it directly."
+    },
+    {
+      "code": "guard.spec_not_approved",
+      "description": "The requested code write precedes approval of the current specification.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Approve the current specification lineage before attempting the code write."
+    },
+    {
+      "code": "guard.uninspectable",
+      "description": "The guard could not inspect the requested target and produced a non-blocking warning.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "guard.write_block",
+      "description": "A configured write-block rule matches the requested target.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Choose an unblocked target or obtain an explicit reviewed guardrail change."
+    },
+    {
+      "code": "judge.auto_julgamento",
+      "description": "The observed executor and judge are the same while self-judgment is forbidden.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Run judgment with a distinct authorized judge identity or explicitly enable permitted self-judgment."
+    },
+    {
+      "code": "judge.modelo_divergente",
+      "description": "The observed judge model differs from the required judge model.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Select the required judge model and rerun judgment with fresh model evidence."
+    },
+    {
+      "code": "loop.blocked",
+      "description": "The orchestration loop reached a deterministic blocked decision.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Inspect the decision reason and complete its named recovery before restarting the loop."
+    },
+    {
+      "code": "loop.halted",
+      "description": "The orchestration loop is explicitly halted and cannot select more work.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Inspect the terminal or blocked decision that halted the loop before requesting more work."
+    },
+    {
+      "code": "loop.next_ready",
+      "description": "The orchestration loop found the next step ready for execution.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "loop.stop_loss",
+      "description": "The orchestration loop stopped after reaching its stop-loss condition.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Review the stop-loss evidence and obtain an authorized budget or policy decision before restarting."
+    },
+    {
+      "code": "no_git",
+      "description": "The completion baseline intentionally represents a project without a Git repository.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "run.next_step",
+      "description": "The decision engine selected the next runnable plan step.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "run.resuming",
+      "description": "The decision engine selected the already in-progress step for resumption.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "runtime.internal_failure",
+      "description": "An unexpected internal failure was sanitized before reaching normal output.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Capture an authorized redacted diagnostic bundle and report the stable reason without blindly retrying."
+    },
+    {
+      "code": "runtime.lease_conflict",
+      "description": "Another unexpired fenced lease owns the requested mutation.",
+      "status": "blocked",
+      "exitCode": 5,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Wait for the valid lease to finish or expire, reload canonical state, and request the mutation again."
+    },
+    {
+      "code": "runtime.recovery_required",
+      "description": "A durable transaction marker requires explicit verified recovery.",
+      "status": "blocked",
+      "exitCode": 4,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Run the explicit transaction recovery operation, verify its event evidence, and then repeat the original request."
+    },
+    {
+      "code": "runtime.revision_conflict",
+      "description": "Canonical state changed after the decision input was loaded.",
+      "status": "blocked",
+      "exitCode": 5,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Reload canonical state, recompute the decision from the new revision, and submit a fresh mutation."
+    },
+    {
+      "code": "runtime.state_corrupt",
+      "description": "Snapshot, event-chain, or canonical-state integrity validation failed.",
+      "status": "blocked",
+      "exitCode": 4,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Preserve the rejected state, run the explicit integrity audit, and retry only after verified repair or rebuild."
+    },
+    {
+      "code": "trail.aceite_incompleto",
+      "description": "Final acceptance was requested before all readiness conditions were satisfied.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Complete every outstanding readiness condition and regenerate final evidence before requesting acceptance."
+    },
+    {
+      "code": "trail.gate_divergente",
+      "description": "The supplied gate does not equal the active pending gate.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Reload the active pending gate and submit the decision for that exact gate."
+    },
+    {
+      "code": "trail.maintenance_tty",
+      "description": "The maintenance operation requires interactive terminal input.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Rerun the maintenance operation from an interactive terminal."
+    },
+    {
+      "code": "trail.nao_trilho",
+      "description": "The project is not yet operating in trail mode and receives migration orientation.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "trail.objetivo_divergente",
+      "description": "A different active objective was supplied without explicit replacement.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Keep the active objective or explicitly request replacement with the new objective text."
+    },
+    {
+      "code": "trail.ok",
+      "description": "The requested trail operation completed successfully.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "required",
+      "stateChanged": true,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "trail.output_invalido",
+      "description": "A required phase output is absent, malformed, or inconsistent.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Regenerate the required phase output for the active run and validate it before continuing."
+    },
+    {
+      "code": "trail.prd_invalido",
+      "description": "The PRD checkpoint is absent, malformed, or not completed.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Complete or regenerate the PRD with valid required fields, then rerun the checkpoint."
+    },
+    {
+      "code": "trail.sem_run",
+      "description": "No active feature run exists for the requested trail operation.",
+      "status": "success",
+      "exitCode": 0,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": null
+    },
+    {
+      "code": "trail.spec_revision_invalid",
+      "description": "Specification revision was requested from an incompatible gate or state.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Return to the specification-approval gate before requesting a specification revision."
+    },
+    {
+      "code": "trail.use_done",
+      "description": "Final acceptance must use the dedicated done operation instead of continue.",
+      "status": "blocked",
+      "exitCode": 3,
+      "evidence": "required",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Run `yoda done` instead of `yoda continue` for final acceptance."
+    },
+    {
+      "code": "trail.uso",
+      "description": "The trail command arguments do not satisfy the operation usage contract.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Correct the command arguments according to the operation usage and invoke it again."
+    },
+    {
+      "code": "trail.worktree_dirty",
+      "description": "A code step cannot start or rebaseline with disallowed worktree changes.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "optional",
+      "stateChanged": false,
+      "retryable": true,
+      "recovery": "Commit, stash, or revert disallowed worktree changes, then retry the code-step operation."
+    },
+    {
+      "code": "contract.plugin_version_invalid",
+      "description": "The installed plugin version identifier is missing or malformed.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Reinstall a complete plugin release with a valid version manifest."
+    },
+    {
+      "code": "contract.plugin_version_unsupported",
+      "description": "The installed plugin version is not supported by this runtime.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Install the complete plugin release selected by the compatibility manifest."
+    },
+    {
+      "code": "contract.host_version_invalid",
+      "description": "The host contract version identifier is missing or malformed.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Upgrade the host adapter so it declares a valid contract version."
+    },
+    {
+      "code": "contract.host_version_unsupported",
+      "description": "The host contract version is not supported by this runtime.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Use a host adapter version accepted by the compatibility manifest."
+    },
+    {
+      "code": "contract.state_version_invalid",
+      "description": "The persisted state contract identifier is missing or malformed.",
+      "status": "blocked",
+      "exitCode": 4,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Inspect the project state metadata and authorize explicit recovery before continuing."
+    },
+    {
+      "code": "contract.state_version_unsupported",
+      "description": "The persisted state contract is not supported by this runtime.",
+      "status": "blocked",
+      "exitCode": 4,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Create and authorize an explicit migration plan for the persisted project state."
+    },
+    {
+      "code": "runtime.node_unsupported",
+      "description": "The interpreter running the plugin runtime is older than the supported minimum.",
+      "status": "failure",
+      "exitCode": 2,
+      "evidence": "forbidden",
+      "stateChanged": false,
+      "retryable": false,
+      "recovery": "Install Node.js 24.0.0 or newer and run the command again."
+    }
+  ]
+}

--- a/packages/contracts/src/compatibility.ts
+++ b/packages/contracts/src/compatibility.ts
@@ -1,5 +1,5 @@
 import contractManifest from "../catalogs/contract-families.v1.json" with { type: "json" };
-import reasonCatalog from "../catalogs/reason-codes.v1.1.json" with { type: "json" };
+import reasonCatalog from "../catalogs/reason-codes.v1.2.json" with { type: "json" };
 
 export type ContractFamily = "plugin" | "state" | "host";
 export type CompatibilityClass =

--- a/packages/contracts/src/compatibility.ts
+++ b/packages/contracts/src/compatibility.ts
@@ -1,6 +1,19 @@
 import contractManifest from "../catalogs/contract-families.v1.json" with { type: "json" };
 import reasonCatalog from "../catalogs/reason-codes.v1.2.json" with { type: "json" };
 
+/**
+ * The contract identities this bundle carries. Consumers report these rather
+ * than reading the manifest from disk, so a bundled runtime stays
+ * self-contained.
+ */
+export const CONTRACT_IDENTITIES = {
+  plugin: contractManifest.pluginVersion,
+  result: contractManifest.resultContract,
+  reasonCatalog: contractManifest.reasonCatalog,
+  state: contractManifest.stateContract.current,
+  host: contractManifest.hostContract.current,
+} as const;
+
 export type ContractFamily = "plugin" | "state" | "host";
 export type CompatibilityClass =
   "current" | "migration_required" | "invalid" | "unsupported";

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,6 @@
 export { YODA_VERSION } from "./version.js";
 export {
+  CONTRACT_IDENTITIES,
   classifyContractVersion,
   contractFailureResult,
 } from "./compatibility.js";

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0-development",
   "private": true,
   "type": "module",
-  "exports": "./src/cli.ts",
+  "exports": {
+    ".": "./src/cli.ts",
+    "./handshake": "./src/handshake.ts"
+  },
   "dependencies": {
     "@mestre-yoda/contracts": "0.0.0-development"
   }

--- a/packages/runtime/src/boot/preflight.mjs
+++ b/packages/runtime/src/boot/preflight.mjs
@@ -30,7 +30,19 @@ function atLeast(actual, minimum) {
 }
 
 if (atLeast(process.versions.node, MINIMUM)) {
-  import("__CORE__").catch(function () {
+  import("__CORE__").catch(function (error) {
+    // Only a genuinely missing or unloadable core is reported here. Anything
+    // the core threw while running is re-raised, because swallowing it would
+    // leave a real crash with no diagnostic at all.
+    if (
+      error === null ||
+      typeof error !== "object" ||
+      (error.code !== "ERR_MODULE_NOT_FOUND" &&
+        error.code !== "ERR_UNSUPPORTED_DIR_IMPORT" &&
+        !(error instanceof SyntaxError))
+    ) {
+      throw error;
+    }
     process.stderr.write("The Yoda runtime could not be loaded.\n");
     process.exitCode = 2;
   });

--- a/packages/runtime/src/boot/preflight.mjs
+++ b/packages/runtime/src/boot/preflight.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Plugin runtime entry point.
+//
+// This file is a template. The build substitutes __MINIMUM_NODE__, __SUMMARY__,
+// __RECOVERY__, and __CORE__ and writes the result to runtime/yoda.mjs.
+//
+// It deliberately uses only syntax valid on Node 12 and is never transpiled. A
+// module is parsed in full before any of it runs, so a version guard sharing a
+// file with modern syntax would never execute: the parser would reject the file
+// first and the caller would see a SyntaxError instead of a structured result.
+// That is why the runtime boots in two files.
+"use strict";
+
+var MINIMUM = "__MINIMUM_NODE__";
+
+function atLeast(actual, minimum) {
+  var left = String(actual).split(".");
+  var right = String(minimum).split(".");
+  for (var index = 0; index < 3; index += 1) {
+    var current = parseInt(left[index], 10);
+    var required = parseInt(right[index], 10);
+    if (isNaN(current)) return false;
+    if (current > required) return true;
+    if (current < required) return false;
+  }
+  // A prerelease of the minimum precedes it and is not supported.
+  return String(actual).indexOf("-") === -1;
+}
+
+if (atLeast(process.versions.node, MINIMUM)) {
+  import("__CORE__").catch(function () {
+    process.stderr.write("The Yoda runtime could not be loaded.\n");
+    process.exitCode = 2;
+  });
+} else {
+  process.stdout.write(
+    JSON.stringify({
+      contractVersion: "1.0.0",
+      status: "failure",
+      exitCode: 2,
+      reasonCode: "runtime.node_unsupported",
+      summary: "__SUMMARY__",
+      why: ["The plugin runtime requires a newer Node.js interpreter."],
+      evidence: [],
+      stateChanged: false,
+      retryable: false,
+      recovery: "__RECOVERY__",
+    }) + "\n",
+  );
+  process.exitCode = 2;
+}

--- a/packages/runtime/src/boot/preflight.mjs
+++ b/packages/runtime/src/boot/preflight.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 // Plugin runtime entry point.
 //
-// This file is a template. The build substitutes __MINIMUM_NODE__, __SUMMARY__,
-// __RECOVERY__, and __CORE__ and writes the result to runtime/yoda.mjs.
+// The build substitutes the interpreter floor, the catalog summary and recovery
+// text, and the core path into this file. Those markers are deliberately not
+// named here: naming them would substitute this very comment and leave the
+// shipped artifact describing itself incoherently.
 //
 // It deliberately uses only syntax valid on Node 12 and is never transpiled. A
 // module is parsed in full before any of it runs, so a version guard sharing a

--- a/packages/runtime/src/cli.test.ts
+++ b/packages/runtime/src/cli.test.ts
@@ -1,3 +1,4 @@
+import { YODA_VERSION } from "@mestre-yoda/contracts";
 import { describe, expect, it } from "vitest";
 
 import { runCli } from "./cli.js";
@@ -25,7 +26,8 @@ describe("runCli", () => {
       expect(invoke(args)).toEqual({
         exitCode: 0,
         stderr: "",
-        stdout: "Usage: yoda [--help | --version]\n",
+        stdout:
+          "Usage: yoda [--expect <version>] [--help | --version | handshake]\n",
       });
     },
   );
@@ -44,5 +46,50 @@ describe("runCli", () => {
       stderr: "Unknown argument: start. Run yoda --help for usage.\n",
       stdout: "",
     });
+  });
+
+  it("answers the handshake with a contract report", () => {
+    const result = invoke(["handshake"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      messageType: "response",
+      operation: "handshake",
+      correlationId: "cli",
+    });
+  });
+
+  it("continues past a matching --expect", () => {
+    expect(invoke(["--expect", YODA_VERSION, "--version"])).toEqual({
+      exitCode: 0,
+      stderr: "",
+      stdout: `${YODA_VERSION}\n`,
+    });
+  });
+
+  it("treats a bare matching --expect as help", () => {
+    expect(invoke(["--expect", YODA_VERSION]).stdout).toContain("Usage: yoda");
+  });
+
+  it.each([
+    ["9.9.9", "contract.plugin_version_unsupported"],
+    ["not-semver", "contract.plugin_version_invalid"],
+  ])("refuses to act on a drifted --expect %s", (value, reasonCode) => {
+    const result = invoke(["--expect", value, "--version"]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      status: "failure",
+      reasonCode,
+      stateChanged: false,
+    });
+    // A drifted install must never reach the operation it was asked for.
+    expect(result.stdout).not.toContain(YODA_VERSION);
+  });
+
+  it("refuses a --expect with no value", () => {
+    expect(invoke(["--expect"]).exitCode).toBe(2);
   });
 });

--- a/packages/runtime/src/cli.test.ts
+++ b/packages/runtime/src/cli.test.ts
@@ -43,9 +43,23 @@ describe("runCli", () => {
   it("rejects an unknown argument", () => {
     expect(invoke(["start"])).toEqual({
       exitCode: 2,
-      stderr: "Unknown argument: start. Run yoda --help for usage.\n",
+      stderr: "Unrecognized arguments. Run yoda --help for usage.\n",
       stdout: "",
     });
+  });
+
+  it.each([
+    [["/home/someone/private/secret-token"], "secret-token"],
+    [["--version", "--expect", "sekrit-value-1.2.3"], "sekrit-value"],
+    [["--expect", "9.9.9", "unknown-subcommand"], "unknown-subcommand"],
+  ])("never echoes caller-supplied text from %o", (args, secret) => {
+    // A misordered --expect lands here, so this path must not become the way a
+    // supplied value or an absolute path reaches public output.
+    const result = invoke(args);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).not.toContain(secret);
+    expect(result.stdout).not.toContain(secret);
   });
 
   it("answers the handshake with a contract report", () => {

--- a/packages/runtime/src/cli.ts
+++ b/packages/runtime/src/cli.ts
@@ -43,6 +43,9 @@ export function runCli(
     return 0;
   }
 
-  error(`Unknown argument: ${rest.join(" ")}. Run yoda --help for usage.\n`);
+  // The arguments are deliberately not echoed. A misordered `--expect` lands
+  // here, so echoing would turn this into the way a supplied version value or
+  // an absolute path reaches public output.
+  error("Unrecognized arguments. Run yoda --help for usage.\n");
   return 2;
 }

--- a/packages/runtime/src/cli.ts
+++ b/packages/runtime/src/cli.ts
@@ -1,24 +1,48 @@
 import { YODA_VERSION } from "@mestre-yoda/contracts";
 
+import {
+  buildHandshakeResponse,
+  classifyExpectedVersion,
+} from "./handshake.js";
+
 export type TextWriter = (text: string) => void;
 
-const HELP = "Usage: yoda [--help | --version]\n";
+const HELP =
+  "Usage: yoda [--expect <version>] [--help | --version | handshake]\n";
 
 export function runCli(
   args: readonly string[],
   output: TextWriter,
   error: TextWriter,
 ): number {
-  if (args.length === 0 || (args.length === 1 && args[0] === "--help")) {
+  let rest = args;
+
+  // `--expect` pins the plugin version a caller was configured against. It is
+  // checked before anything else so a drifted install can never act.
+  if (rest[0] === "--expect") {
+    const failure = classifyExpectedVersion(rest[1]);
+    if (failure !== null) {
+      output(`${JSON.stringify(failure)}\n`);
+      return failure.exitCode;
+    }
+    rest = rest.slice(2);
+  }
+
+  if (rest.length === 0 || (rest.length === 1 && rest[0] === "--help")) {
     output(HELP);
     return 0;
   }
 
-  if (args.length === 1 && args[0] === "--version") {
+  if (rest.length === 1 && rest[0] === "--version") {
     output(`${YODA_VERSION}\n`);
     return 0;
   }
 
-  error(`Unknown argument: ${args.join(" ")}. Run yoda --help for usage.\n`);
+  if (rest.length === 1 && rest[0] === "handshake") {
+    output(`${JSON.stringify(buildHandshakeResponse("cli"))}\n`);
+    return 0;
+  }
+
+  error(`Unknown argument: ${rest.join(" ")}. Run yoda --help for usage.\n`);
   return 2;
 }

--- a/packages/runtime/src/handshake.ts
+++ b/packages/runtime/src/handshake.ts
@@ -1,0 +1,58 @@
+import {
+  CONTRACT_IDENTITIES,
+  YODA_VERSION,
+  classifyContractVersion,
+  contractFailureResult,
+  type AdapterMessageV1,
+  type ContractFailureResult,
+} from "@mestre-yoda/contracts";
+
+/**
+ * Answer a host's compatibility handshake with the contract versions this
+ * bundle carries. The full request/response conversation belongs to the host
+ * adapter protocol; this is the runtime's half of it.
+ */
+export function buildHandshakeResponse(
+  correlationId: string,
+): AdapterMessageV1 {
+  return {
+    contractVersion: "1.0.0",
+    hostContract: "1.0.0",
+    messageId: "handshake-response",
+    messageType: "response",
+    host: "unknown",
+    operation: "handshake",
+    capabilities: [],
+    // A directly invoked runtime was handed no host identity to observe, and
+    // the contract requires reporting that rather than inventing one.
+    observedIdentity: { adapterVersion: YODA_VERSION, model: null },
+    payloadContract: "result@1.0.0",
+    payload: {
+      contractVersion: "1.0.0",
+      status: "success",
+      exitCode: 0,
+      reasonCode: "trail.ok",
+      summary: `Plugin ${CONTRACT_IDENTITIES.plugin} carries result ${CONTRACT_IDENTITIES.result}, reasons ${CONTRACT_IDENTITIES.reasonCatalog}, state ${CONTRACT_IDENTITIES.state}, and host ${CONTRACT_IDENTITIES.host}.`,
+      why: [],
+      evidence: [],
+      stateChanged: false,
+      retryable: false,
+      recovery: null,
+    },
+    correlationId,
+  };
+}
+
+/**
+ * Classify the version a caller pinned with `--expect`. Returns `null` when it
+ * matches this bundle exactly, and a renderable failure otherwise. The supplied
+ * value is never echoed back.
+ */
+export function classifyExpectedVersion(
+  value: unknown,
+): ContractFailureResult | null {
+  const classification = classifyContractVersion("plugin", value);
+  return classification.classification === "current"
+    ? null
+    : contractFailureResult(classification);
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -12,7 +12,9 @@ The universal runtime-result family contains:
 - [`reason-codes.v1.json`](../packages/contracts/catalogs/reason-codes.v1.json),
   the immutable 76-entry revision 1.0 ledger;
 - [`reason-codes.v1.1.json`](../packages/contracts/catalogs/reason-codes.v1.1.json),
-  which adds six plugin, state, and host compatibility reasons.
+  which adds six plugin, state, and host compatibility reasons;
+- [`reason-codes.v1.2.json`](../packages/contracts/catalogs/reason-codes.v1.2.json),
+  the current revision, which adds `runtime.node_unsupported`.
 
 The state family contains:
 

--- a/schemas/contracts/contract-manifest.v1.schema.json
+++ b/schemas/contracts/contract-manifest.v1.schema.json
@@ -18,7 +18,7 @@
     "contractVersion": { "const": "1.0.0" },
     "pluginVersion": { "const": "0.0.0-development" },
     "resultContract": { "const": "1.0.0" },
-    "reasonCatalog": { "const": "1.1.0" },
+    "reasonCatalog": { "const": "1.2.0" },
     "stateContract": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,4 +1,5 @@
-import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,15 +9,31 @@ const repositoryRoot = dirname(
   fileURLToPath(new URL("../package.json", import.meta.url)),
 );
 const pluginDirectory = join(repositoryRoot, "dist/plugin");
-const artifact = join(pluginDirectory, "runtime/yoda.mjs");
+const entryPath = join(pluginDirectory, "runtime/yoda.mjs");
+const corePath = join(pluginDirectory, "runtime/yoda.core.mjs");
+const manifestPath = join(pluginDirectory, "runtime/manifest.json");
 const metadataFile = join(repositoryRoot, "dist/build-meta.json");
+const preflightTemplate = join(
+  repositoryRoot,
+  "packages/runtime/src/boot/preflight.mjs",
+);
+
+/** The interpreter floor the preflight enforces and the manifest publishes. */
+const minimumNode = "24.0.0";
+
+/**
+ * Embed a catalog string inside the preflight's source without letting a quote
+ * or backslash escape the literal it lands in.
+ */
+function embed(value) {
+  return JSON.stringify(value).slice(1, -1);
+}
 
 await rm(pluginDirectory, { force: true, recursive: true });
-await mkdir(dirname(artifact), { recursive: true });
+await mkdir(dirname(corePath), { recursive: true });
 
 const result = await build({
   absWorkingDir: repositoryRoot,
-  banner: { js: "#!/usr/bin/env node" },
   bundle: true,
   entryPoints: ["packages/runtime/src/main.ts"],
   format: "esm",
@@ -24,7 +41,7 @@ const result = await build({
   logLevel: "info",
   metafile: true,
   minify: true,
-  outfile: "dist/plugin/runtime/yoda.mjs",
+  outfile: "dist/plugin/runtime/yoda.core.mjs",
   platform: "node",
   sourcemap: false,
   target: "node24",
@@ -36,6 +53,73 @@ await writeFile(
   "utf8",
 );
 
+const [template, catalogText, familiesText] = await Promise.all([
+  readFile(preflightTemplate, "utf8"),
+  readFile(
+    join(repositoryRoot, "packages/contracts/catalogs/reason-codes.v1.2.json"),
+    "utf8",
+  ),
+  readFile(
+    join(
+      repositoryRoot,
+      "packages/contracts/catalogs/contract-families.v1.json",
+    ),
+    "utf8",
+  ),
+]);
+
+const families = JSON.parse(familiesText);
+const reason = JSON.parse(catalogText).reasons.find(
+  ({ code }) => code === "runtime.node_unsupported",
+);
+if (reason === undefined) {
+  throw new Error(
+    "Build failed: runtime.node_unsupported is not in the catalog",
+  );
+}
+
+// The catalog is the single source of truth for this text. Injecting it here
+// keeps the preflight free of a hand-maintained copy that could drift.
+const preflight = template
+  .replaceAll("__MINIMUM_NODE__", embed(minimumNode))
+  .replaceAll("__SUMMARY__", embed(reason.description))
+  .replaceAll("__RECOVERY__", embed(reason.recovery))
+  .replaceAll("__CORE__", "./yoda.core.mjs");
+
+if (/__[A-Z_]+__/u.test(preflight)) {
+  throw new Error(
+    "Build failed: the preflight retains an unsubstituted placeholder",
+  );
+}
+
+await writeFile(entryPath, preflight, "utf8");
+
+const core = await readFile(corePath);
+await writeFile(
+  manifestPath,
+  `${JSON.stringify(
+    {
+      contractVersion: "1.0.0",
+      pluginVersion: families.pluginVersion,
+      runtime: {
+        entry: "runtime/yoda.mjs",
+        core: "runtime/yoda.core.mjs",
+        coreSha256: createHash("sha256").update(core).digest("hex"),
+        minimumNode,
+      },
+      contracts: {
+        result: families.resultContract,
+        reasonCatalog: families.reasonCatalog,
+        state: families.stateContract.current,
+        host: families.hostContract.current,
+      },
+    },
+    null,
+    2,
+  )}\n`,
+  "utf8",
+);
+
 if (process.platform !== "win32") {
-  await chmod(artifact, 0o755);
+  await chmod(entryPath, 0o755);
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -88,11 +88,19 @@ if (reason === undefined) {
 
 // The catalog is the single source of truth for this text. Injecting it here
 // keeps the preflight free of a hand-maintained copy that could drift.
-const preflight = template
-  .replaceAll("__MINIMUM_NODE__", embed(minimumNode))
-  .replaceAll("__SUMMARY__", embed(reason.description))
-  .replaceAll("__RECOVERY__", embed(reason.recovery))
-  .replaceAll("__CORE__", "./yoda.core.mjs");
+const substitutions = {
+  MINIMUM_NODE: embed(minimumNode),
+  SUMMARY: embed(reason.description),
+  RECOVERY: embed(reason.recovery),
+  CORE: "./yoda.core.mjs",
+};
+
+// One pass, so an injected value that happens to contain another marker cannot
+// be rewritten by a later substitution.
+const preflight = template.replace(
+  /__(MINIMUM_NODE|SUMMARY|RECOVERY|CORE)__/gu,
+  (_match, key) => substitutions[key],
+);
 
 if (/__[A-Z_]+__/u.test(preflight)) {
   throw new Error(

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -26,6 +26,14 @@ const minimumNode = "24.0.0";
  * or backslash escape the literal it lands in.
  */
 function embed(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Build failed: catalog text is missing or not a string");
+  }
+  // A line break would break out of the emitted line, and a leftover marker
+  // would survive the substitution guard below.
+  if (/[\r\n]/u.test(value) || /__[A-Z_]+__/u.test(value)) {
+    throw new Error("Build failed: catalog text is not embeddable");
+  }
   return JSON.stringify(value).slice(1, -1);
 }
 

--- a/scripts/lib/result-contract.mjs
+++ b/scripts/lib/result-contract.mjs
@@ -271,7 +271,7 @@ function rendererContract() {
       readFileSync(
         join(
           repositoryRoot,
-          "packages/contracts/catalogs/reason-codes.v1.1.json",
+          "packages/contracts/catalogs/reason-codes.v1.2.json",
         ),
         "utf8",
       ),

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -4,6 +4,7 @@ import {
   chmod,
   copyFile,
   lstat,
+  mkdir,
   mkdtemp,
   readFile,
   readdir,
@@ -19,7 +20,13 @@ const repositoryRoot = dirname(
 );
 const pluginDirectory = join(repositoryRoot, "dist/plugin");
 const artifact = join(pluginDirectory, "runtime/yoda.mjs");
-const expectedInventory = ["runtime/yoda.mjs"];
+const core = join(pluginDirectory, "runtime/yoda.core.mjs");
+// The exact set of files a plugin install contains. Anything else fails.
+const expectedInventory = [
+  "runtime/manifest.json",
+  "runtime/yoda.core.mjs",
+  "runtime/yoda.mjs",
+];
 const expectedDirectories = new Set(["runtime"]);
 const expectedHelp = "Usage: yoda [--help | --version]\n";
 const expectedVersion = "0.0.0-development\n";
@@ -120,9 +127,26 @@ if (process.platform !== "win32" && (artifactDetails.mode & 0o111) === 0) {
   fail("runtime/yoda.mjs is not executable");
 }
 
-const bundle = await readFile(artifact, "utf8");
-if (!bundle.startsWith("#!/usr/bin/env node\n")) {
+const entrySource = await readFile(artifact, "utf8");
+if (!entrySource.startsWith("#!/usr/bin/env node\n")) {
   fail("runtime/yoda.mjs does not begin with the Node shebang");
+}
+if (/__[A-Z_]+__/u.test(entrySource)) {
+  fail("runtime/yoda.mjs retains an unsubstituted placeholder");
+}
+
+const coreBytes = await readFile(core);
+const bundle = coreBytes.toString("utf8");
+if (bundle.startsWith("#!")) {
+  fail("runtime/yoda.core.mjs must not carry a shebang");
+}
+
+const distributionManifest = JSON.parse(
+  await readFile(join(pluginDirectory, "runtime/manifest.json"), "utf8"),
+);
+const recordedDigest = createHash("sha256").update(coreBytes).digest("hex");
+if (distributionManifest.runtime.coreSha256 !== recordedDigest) {
+  fail("runtime/manifest.json does not record the built core digest");
 }
 
 const forbiddenReferences = [
@@ -133,6 +157,9 @@ const forbiddenReferences = [
 ];
 for (const reference of forbiddenReferences) {
   if (bundle.includes(reference)) {
+    fail(`runtime/yoda.core.mjs contains forbidden reference: ${reference}`);
+  }
+  if (entrySource.includes(reference)) {
     fail(`runtime/yoda.mjs contains forbidden reference: ${reference}`);
   }
 }
@@ -150,8 +177,14 @@ for (const output of Object.values(metadata.outputs)) {
 
 const cleanRoom = await mkdtemp(join(tmpdir(), "mestre-yoda-package-"));
 try {
-  const isolatedArtifact = join(cleanRoom, "yoda.mjs");
-  await copyFile(artifact, isolatedArtifact);
+  // Copy the whole runtime directory, so the isolated run exercises the real
+  // two-file boot rather than an entry point with nothing to import.
+  const isolatedRuntime = join(cleanRoom, "runtime");
+  await mkdir(isolatedRuntime, { recursive: true });
+  for (const staged of expectedInventory) {
+    await copyFile(join(pluginDirectory, staged), join(cleanRoom, staged));
+  }
+  const isolatedArtifact = join(isolatedRuntime, "yoda.mjs");
   if (process.platform !== "win32") {
     await chmod(isolatedArtifact, 0o755);
   }
@@ -168,11 +201,14 @@ try {
     expectedVersion,
     cleanRoom,
   );
-  const hash = createHash("sha256").update(bundle).digest("hex");
-
   console.log(`inventory: ${stagedFiles.join(", ")}`);
-  console.log(`sha256: ${hash}`);
-  console.log(`bytes: ${String(artifactDetails.size)}`);
+  console.log(
+    `entry: runtime/yoda.mjs (${String(artifactDetails.size)} bytes)`,
+  );
+  console.log(
+    `core: runtime/yoda.core.mjs (${String(coreBytes.byteLength)} bytes, sha256 ${recordedDigest})`,
+  );
+  console.log(`minimum node: ${distributionManifest.runtime.minimumNode}`);
   console.log(`help: ${help.trimEnd()}`);
   console.log(`version: ${version.trimEnd()}`);
 } finally {

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -28,6 +28,13 @@ const expectedInventory = [
   "runtime/yoda.mjs",
 ];
 const expectedDirectories = new Set(["runtime"]);
+// Patterns a project the plugin operated on must never contain.
+const projectDenylist = [
+  /(^|\/)node_modules(\/|$)/u,
+  /(^|\/)packages(\/|$)/u,
+  /(^|\/)runtime(\/|$)/u,
+  /\.(ts|map)$/u,
+];
 const expectedHelp =
   "Usage: yoda [--expect <version>] [--help | --version | handshake]\n";
 const expectedVersion = "0.0.0-development\n";
@@ -188,6 +195,21 @@ try {
   const isolatedArtifact = join(isolatedRuntime, "yoda.mjs");
   if (process.platform !== "win32") {
     await chmod(isolatedArtifact, 0o755);
+  }
+
+  // A project the runtime operated on receives state surfaces only. It must
+  // never receive the runtime, its sources, or a dependency tree.
+  const projectRoot = join(cleanRoom, "project");
+  await mkdir(projectRoot, { recursive: true });
+  executeIsolated(isolatedArtifact, "--help", expectedHelp, projectRoot);
+  const projectEntries = await readdir(projectRoot, { recursive: true });
+  for (const found of projectEntries) {
+    const normalized = found.split(sep).join("/");
+    for (const pattern of projectDenylist) {
+      if (pattern.test(normalized)) {
+        fail(`project install contains a denied entry: ${normalized}`);
+      }
+    }
   }
 
   const help = executeIsolated(

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -48,6 +48,13 @@ function fail(message) {
   throw new Error(`Package verification failed: ${message}`);
 }
 
+/** Entries a project must never contain, normalized to POSIX separators. */
+function deniedEntries(entries) {
+  return entries
+    .map((entry) => entry.split(sep).join("/"))
+    .filter((entry) => projectDenylist.some((pattern) => pattern.test(entry)));
+}
+
 async function inventory(directory) {
   const entries = await readdir(directory, {
     recursive: true,
@@ -202,14 +209,25 @@ try {
   const projectRoot = join(cleanRoom, "project");
   await mkdir(projectRoot, { recursive: true });
   executeIsolated(isolatedArtifact, "--help", expectedHelp, projectRoot);
-  const projectEntries = await readdir(projectRoot, { recursive: true });
-  for (const found of projectEntries) {
-    const normalized = found.split(sep).join("/");
-    for (const pattern of projectDenylist) {
-      if (pattern.test(normalized)) {
-        fail(`project install contains a denied entry: ${normalized}`);
-      }
-    }
+  const denied = deniedEntries(await readdir(projectRoot, { recursive: true }));
+  if (denied.length > 0) {
+    fail(`project install contains denied entries: ${denied.join(", ")}`);
+  }
+
+  // Prove the denylist actually rejects something. The runtime writes nothing
+  // today, so without this the check above would pass just as happily if every
+  // pattern were wrong, and the "deny" half would be a guard nobody tested.
+  const probe = deniedEntries([
+    "node_modules/left-pad/index.js",
+    "packages/runtime/src/cli.ts",
+    "runtime/yoda.mjs",
+    "src/thing.ts",
+    "dist/thing.map",
+  ]);
+  if (probe.length !== 5) {
+    fail(
+      `project denylist does not reject its own probe: matched ${String(probe.length)} of 5`,
+    );
   }
 
   const help = executeIsolated(

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -28,7 +28,8 @@ const expectedInventory = [
   "runtime/yoda.mjs",
 ];
 const expectedDirectories = new Set(["runtime"]);
-const expectedHelp = "Usage: yoda [--help | --version]\n";
+const expectedHelp =
+  "Usage: yoda [--expect <version>] [--help | --version | handshake]\n";
 const expectedVersion = "0.0.0-development\n";
 const allowedBuiltins = new Set(
   builtinModules.map((moduleName) =>

--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,7 +7,9 @@ import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
-const sourceArtifact = join(repositoryRoot, "dist/plugin/runtime/yoda.mjs");
+const sourceRuntime = join(repositoryRoot, "dist/plugin/runtime");
+// The runtime boots in two files, so an isolated copy needs both.
+const stagedFiles = ["manifest.json", "yoda.core.mjs", "yoda.mjs"];
 let cleanRoom = "";
 let isolatedArtifact = "";
 
@@ -31,8 +33,12 @@ beforeAll(async () => {
     stdio: "pipe",
   });
   cleanRoom = await mkdtemp(join(tmpdir(), "mestre-yoda-bundle-test-"));
-  isolatedArtifact = join(cleanRoom, "yoda.mjs");
-  await copyFile(sourceArtifact, isolatedArtifact);
+  const runtime = join(cleanRoom, "runtime");
+  await mkdir(runtime, { recursive: true });
+  for (const staged of stagedFiles) {
+    await copyFile(join(sourceRuntime, staged), join(runtime, staged));
+  }
+  isolatedArtifact = join(runtime, "yoda.mjs");
 });
 
 afterAll(async () => {

--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -52,7 +52,9 @@ describe("standalone runtime bundle", () => {
     const result = execute("--help");
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("Usage: yoda [--help | --version]\n");
+    expect(result.stdout).toBe(
+      "Usage: yoda [--expect <version>] [--help | --version | handshake]\n",
+    );
     expect(result.stderr).toBe("");
   });
 

--- a/tests/contract-documentation.test.ts
+++ b/tests/contract-documentation.test.ts
@@ -40,6 +40,8 @@ describe("contract versioning documentation", () => {
     expect(guide).toMatch(/before payload validation or\s+mutation/u);
     expect(guide).toContain("byte-preserving");
     expect(guide).toContain("reason-codes.v1.1.json");
+    expect(guide).toContain("reason-codes.v1.2.json");
+    expect(guide).toContain("runtime.node_unsupported");
   });
 
   it("keeps README status honest while publishing contract infrastructure", () => {

--- a/tests/contract-manifest.test.ts
+++ b/tests/contract-manifest.test.ts
@@ -108,7 +108,7 @@ describe("contract family manifest", () => {
       contractVersion: "1.0.0",
       pluginVersion: "0.0.0-development",
       resultContract: "1.0.0",
-      reasonCatalog: "1.1.0",
+      reasonCatalog: "1.2.0",
       stateContract: {
         current: "1.0.0",
         readable: ["1.0.0"],

--- a/tests/contract-reason-catalog.test.ts
+++ b/tests/contract-reason-catalog.test.ts
@@ -15,6 +15,10 @@ const catalogV11Path = join(
   repositoryRoot,
   "packages/contracts/catalogs/reason-codes.v1.1.json",
 );
+const catalogV12Path = join(
+  repositoryRoot,
+  "packages/contracts/catalogs/reason-codes.v1.2.json",
+);
 const resultLibraryUrl = pathToFileURL(
   join(repositoryRoot, "scripts/lib/result-contract.mjs"),
 ).href;
@@ -46,16 +50,20 @@ const additions = new Map([
 
 let catalogV1: Catalog;
 let catalogV11: Catalog;
+let catalogV12: Catalog;
 let catalogV1Text: string;
 let catalogV11Text: string;
+let catalogV12Text: string;
 
 beforeAll(async () => {
-  [catalogV1Text, catalogV11Text] = await Promise.all([
+  [catalogV1Text, catalogV11Text, catalogV12Text] = await Promise.all([
     readFile(catalogV1Path, "utf8"),
     readFile(catalogV11Path, "utf8"),
+    readFile(catalogV12Path, "utf8"),
   ]);
   catalogV1 = JSON.parse(catalogV1Text) as Catalog;
   catalogV11 = JSON.parse(catalogV11Text) as Catalog;
+  catalogV12 = JSON.parse(catalogV12Text) as Catalog;
 });
 
 describe("contract reason catalog revision", () => {
@@ -76,6 +84,37 @@ describe("contract reason catalog revision", () => {
         .slice(catalogV1.reasons.length)
         .map(({ code }) => code),
     ).toEqual([...additions.keys()]);
+  });
+
+  it("preserves revision 1.1 and appends the unsupported interpreter reason", () => {
+    expect(createHash("sha256").update(catalogV12Text).digest("hex")).toBe(
+      "84876592c47a4d80ccf833ebea8609d7e4f1cdfc7d1992ce17e05375990613ce",
+    );
+    expect(catalogV12.contractVersion).toBe("1.0.0");
+    expect(catalogV12.reasons.slice(0, catalogV11.reasons.length)).toEqual(
+      catalogV11.reasons,
+    );
+    expect(catalogV12.reasons).toHaveLength(83);
+    expect(
+      catalogV12.reasons
+        .slice(catalogV11.reasons.length)
+        .map(({ code }) => code),
+    ).toEqual(["runtime.node_unsupported"]);
+  });
+
+  it("fails closed on an unsupported interpreter without publishing evidence", () => {
+    const reason = catalogV12.reasons.find(
+      ({ code }) => code === "runtime.node_unsupported",
+    );
+    expect(reason).toMatchObject({
+      status: "failure",
+      exitCode: 2,
+      evidence: "forbidden",
+      stateChanged: false,
+      retryable: false,
+    });
+    // The recovery text is what the preflight embeds, so it must name the floor.
+    expect(reason?.recovery).toContain("24.0.0");
   });
 
   it("defines safe fail-closed policy for every new reason", () => {

--- a/tests/fixtures/runtime/old-node.mjs
+++ b/tests/fixtures/runtime/old-node.mjs
@@ -1,0 +1,7 @@
+// Rewrites the reported interpreter version before the entry point loads, so
+// the shipped preflight can be exercised against an old Node without needing
+// one installed.
+Object.defineProperty(process.versions, "node", {
+  value: process.env.YODA_TEST_NODE_VERSION ?? "18.20.0",
+  configurable: true,
+});

--- a/tests/package-boundaries.test.ts
+++ b/tests/package-boundaries.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import {
   chmod,
+  copyFile,
   mkdir,
   mkdtemp,
   readdir,
@@ -88,6 +89,29 @@ describe("distribution boundaries", () => {
 
     // One installed plugin must serve any number of unrelated projects.
     expect(run(first, ["--version"])).toBe(run(second, ["--version"]));
+  });
+
+  it("runs from a plugin root containing spaces and non-ASCII characters", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-plugin-root-"));
+    roots.push(root);
+    // The entry resolves its core through a relative dynamic import, so a
+    // percent-encodable plugin path is exactly what could break it.
+    const runtime = join(root, "plúg in dir ç ü", "runtime");
+    await mkdir(runtime, { recursive: true });
+    for (const staged of ["manifest.json", "yoda.core.mjs", "yoda.mjs"]) {
+      await copyFile(
+        join(repositoryRoot, "dist/plugin/runtime", staged),
+        join(runtime, staged),
+      );
+    }
+    const cwd = await project();
+
+    const stdout = execFileSync(
+      process.execPath,
+      [join(runtime, "yoda.mjs"), "--version"],
+      { cwd, encoding: "utf8" },
+    );
+    expect(stdout.trim()).toBe("0.0.0-development");
   });
 
   it("never consults a global yoda on PATH", async () => {

--- a/tests/package-boundaries.test.ts
+++ b/tests/package-boundaries.test.ts
@@ -1,0 +1,138 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+const entry = join(repositoryRoot, "dist/plugin/runtime/yoda.mjs");
+const roots: string[] = [];
+
+/** Patterns a project install must never contain. */
+const denied = [
+  /(^|\/)node_modules(\/|$)/u,
+  /(^|\/)packages(\/|$)/u,
+  /(^|\/)runtime(\/|$)/u,
+  /\.(ts|map)$/u,
+];
+
+beforeAll(() => {
+  execFileSync(process.execPath, ["scripts/build.mjs"], {
+    cwd: repositoryRoot,
+    stdio: "pipe",
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+/** A project directory whose name has a space and non-ASCII characters. */
+async function project(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-boundary-"));
+  roots.push(root);
+  const directory = join(root, "a project ç ü");
+  await mkdir(directory, { recursive: true });
+  return directory;
+}
+
+/** A directory holding a decoy `yoda` that fails loudly if it is ever run. */
+async function decoy(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-decoy-"));
+  roots.push(root);
+  const executable = join(root, "yoda");
+  await writeFile(
+    executable,
+    "#!/bin/sh\necho 'the global yoda was used' >&2\nexit 99\n",
+    "utf8",
+  );
+  await chmod(executable, 0o755);
+  return root;
+}
+
+function run(cwd: string, args: readonly string[], path?: string): string {
+  return execFileSync(process.execPath, [entry, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      HOME: cwd,
+      NODE_OPTIONS: "",
+      NODE_PATH: "",
+      PATH: path ?? dirname(process.execPath),
+      TMPDIR: tmpdir(),
+    },
+  });
+}
+
+describe("distribution boundaries", () => {
+  it("runs from the plugin directory against a project with spaces and non-ASCII characters", async () => {
+    const cwd = await project();
+
+    expect(run(cwd, ["--version"]).trim()).toBe("0.0.0-development");
+    expect(run(cwd, ["handshake"]).trim().startsWith("{")).toBe(true);
+  });
+
+  it("resolves the plugin root from the module, never from the working directory", async () => {
+    const first = await project();
+    const second = await project();
+
+    // One installed plugin must serve any number of unrelated projects.
+    expect(run(first, ["--version"])).toBe(run(second, ["--version"]));
+  });
+
+  it("never consults a global yoda on PATH", async () => {
+    const cwd = await project();
+    const decoyDirectory = await decoy();
+    const path = `${decoyDirectory}:${dirname(process.execPath)}`;
+
+    // Prove the decoy is actually reachable and fails loudly first. Without
+    // this the next assertion would pass just as happily against a decoy that
+    // was never executable, which would prove nothing at all.
+    expect(() =>
+      execFileSync("yoda", ["--version"], {
+        cwd,
+        encoding: "utf8",
+        env: { PATH: path },
+      }),
+    ).toThrow();
+
+    // The decoy exits 99 and writes to stderr if it is ever reached, so a
+    // successful run is direct evidence that no global executable was used.
+    expect(run(cwd, ["--version"], path).trim()).toBe("0.0.0-development");
+  });
+
+  it("leaves no runtime source or dependency in the project", async () => {
+    const cwd = await project();
+    run(cwd, ["--help"]);
+    run(cwd, ["handshake"]);
+
+    const entries = await readdir(cwd, { recursive: true });
+    for (const found of entries) {
+      const normalized = found.split("\\").join("/");
+      for (const pattern of denied) {
+        expect(normalized, `project install contains ${found}`).not.toMatch(
+          pattern,
+        );
+      }
+    }
+  });
+
+  it("does not write into the project at all", async () => {
+    const cwd = await project();
+    run(cwd, ["--version"]);
+
+    // Nothing in this issue's scope mutates a project, and the runtime must
+    // not create state surfaces as a side effect of being asked its version.
+    expect(await readdir(cwd)).toEqual([]);
+  });
+});

--- a/tests/package-verifier.test.ts
+++ b/tests/package-verifier.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,6 +8,8 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 
 const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 const artifact = join(repositoryRoot, "dist/plugin/runtime/yoda.mjs");
+const core = join(repositoryRoot, "dist/plugin/runtime/yoda.core.mjs");
+const manifestFile = join(repositoryRoot, "dist/plugin/runtime/manifest.json");
 const metadataFile = join(repositoryRoot, "dist/build-meta.json");
 
 function build() {
@@ -31,17 +34,45 @@ afterAll(() => {
   build();
 });
 
+/** Corrupt the core and re-record its digest, so the manifest check passes. */
+async function corruptCore(replacement: string): Promise<void> {
+  const bundle = await readFile(core, "utf8");
+  const corrupted = bundle.replace(
+    "Usage: yoda [--help | --version]",
+    replacement,
+  );
+  expect(corrupted).not.toBe(bundle);
+  await writeFile(core, corrupted, "utf8");
+  const manifest = JSON.parse(await readFile(manifestFile, "utf8")) as {
+    runtime: { coreSha256: string };
+  };
+  manifest.runtime.coreSha256 = createHash("sha256")
+    .update(corrupted)
+    .digest("hex");
+  await writeFile(
+    manifestFile,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+}
+
 describe("package verifier", () => {
   it("rejects a bundle with incorrect help text", async () => {
-    const bundle = await readFile(artifact, "utf8");
-    await writeFile(
-      artifact,
-      bundle.replace(
-        "Usage: yoda [--help | --version]",
-        "Usage: corrupted runtime",
-      ),
-      "utf8",
-    );
+    await corruptCore("Usage: corrupted runtime");
+
+    expect(verify).toThrow();
+  });
+
+  it("rejects a core that no longer matches its recorded digest", async () => {
+    const bundle = await readFile(core, "utf8");
+    await writeFile(core, `${bundle}\n// tampered\n`, "utf8");
+
+    expect(verify).toThrow();
+  });
+
+  it("rejects an entry point retaining an unsubstituted placeholder", async () => {
+    const entry = await readFile(artifact, "utf8");
+    await writeFile(artifact, `${entry}\n// __LEFTOVER__\n`, "utf8");
 
     expect(verify).toThrow();
   });

--- a/tests/package-verifier.test.ts
+++ b/tests/package-verifier.test.ts
@@ -38,7 +38,7 @@ afterAll(() => {
 async function corruptCore(replacement: string): Promise<void> {
   const bundle = await readFile(core, "utf8");
   const corrupted = bundle.replace(
-    "Usage: yoda [--help | --version]",
+    "Usage: yoda [--expect <version>] [--help | --version | handshake]",
     replacement,
   );
   expect(corrupted).not.toBe(bundle);

--- a/tests/readme-honesty.test.ts
+++ b/tests/readme-honesty.test.ts
@@ -35,7 +35,9 @@ describe("README honesty", () => {
 
   it("makes current availability impossible to mistake", () => {
     expect(readme).toContain("There is no supported installation method");
-    expect(readme).toContain("supports only `--help` and `--version`");
+    expect(readme).toContain(
+      "supports only `--help`, `--version`, and `handshake`",
+    );
     expect(readme).toContain("not runnable in the current bundle");
     expect(readme).toContain("not ready for production");
     expect(readme).not.toMatch(
@@ -85,6 +87,8 @@ describe("README honesty", () => {
     expect(readme).toContain("project-owned `.brain/`");
     expect(readme).toContain("`.claude/` and `.codex/`");
     expect(readme).toContain("embedded ESM runtime");
+    expect(readme).toContain("runtime/yoda.mjs");
+    expect(readme).toContain("Node.js 24");
   });
 
   it("links every required public path", () => {

--- a/tests/runtime-distribution.test.ts
+++ b/tests/runtime-distribution.test.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+const plugin = join(repositoryRoot, "dist/plugin");
+
+interface DistributionManifest {
+  readonly contractVersion: string;
+  readonly pluginVersion: string;
+  readonly runtime: {
+    readonly entry: string;
+    readonly core: string;
+    readonly coreSha256: string;
+    readonly minimumNode: string;
+  };
+  readonly contracts: {
+    readonly result: string;
+    readonly reasonCatalog: string;
+    readonly state: string;
+    readonly host: string;
+  };
+}
+
+interface ReasonEntry {
+  readonly code: string;
+  readonly description: string;
+  readonly recovery: string;
+}
+
+let manifest: DistributionManifest;
+let entry: string;
+let core: Buffer;
+let reason: ReasonEntry | undefined;
+
+beforeAll(async () => {
+  const [manifestText, entryText, coreBytes, catalogText] = await Promise.all([
+    readFile(join(plugin, "runtime/manifest.json"), "utf8"),
+    readFile(join(plugin, "runtime/yoda.mjs"), "utf8"),
+    readFile(join(plugin, "runtime/yoda.core.mjs")),
+    readFile(
+      join(
+        repositoryRoot,
+        "packages/contracts/catalogs/reason-codes.v1.2.json",
+      ),
+      "utf8",
+    ),
+  ]);
+  manifest = JSON.parse(manifestText) as DistributionManifest;
+  entry = entryText;
+  core = coreBytes;
+  reason = (JSON.parse(catalogText) as { reasons: ReasonEntry[] }).reasons.find(
+    ({ code }) => code === "runtime.node_unsupported",
+  );
+});
+
+describe("runtime distribution", () => {
+  it("binds the manifest to the built core", () => {
+    expect(manifest.contractVersion).toBe("1.0.0");
+    expect(manifest.pluginVersion).toBe("0.0.0-development");
+    expect(manifest.runtime.entry).toBe("runtime/yoda.mjs");
+    expect(manifest.runtime.core).toBe("runtime/yoda.core.mjs");
+    expect(manifest.runtime.minimumNode).toBe("24.0.0");
+    expect(manifest.runtime.coreSha256).toBe(
+      createHash("sha256").update(core).digest("hex"),
+    );
+  });
+
+  it("records the contract versions the bundle carries", () => {
+    expect(manifest.contracts).toEqual({
+      result: "1.0.0",
+      reasonCatalog: "1.2.0",
+      state: "1.0.0",
+      host: "1.0.0",
+    });
+  });
+
+  it("substitutes every preflight placeholder", () => {
+    expect(entry).not.toMatch(/__[A-Z_]+__/u);
+    expect(entry).toContain("runtime.node_unsupported");
+    expect(entry).toContain('import("./yoda.core.mjs")');
+    expect(entry.startsWith("#!/usr/bin/env node\n")).toBe(true);
+  });
+
+  it("keeps the preflight text identical to the catalog", () => {
+    expect(reason).toBeDefined();
+    // Slicing the JSON quotes off yields the exact escaped literal the build
+    // embedded, so a drifting copy fails here instead of shipping.
+    expect(entry).toContain(JSON.stringify(reason?.recovery).slice(1, -1));
+    expect(entry).toContain(JSON.stringify(reason?.description).slice(1, -1));
+  });
+
+  it("keeps the shebang off the core bundle", () => {
+    expect(core.toString("utf8").startsWith("#!")).toBe(false);
+  });
+});

--- a/tests/runtime-distribution.test.ts
+++ b/tests/runtime-distribution.test.ts
@@ -96,3 +96,47 @@ describe("runtime distribution", () => {
     expect(core.toString("utf8").startsWith("#!")).toBe(false);
   });
 });
+
+describe("runtime distribution documentation", () => {
+  let guide = "";
+  let toolchain = "";
+
+  beforeAll(async () => {
+    [guide, toolchain] = await Promise.all([
+      readFile(
+        join(repositoryRoot, "docs/compatibility/runtime-distribution.md"),
+        "utf8",
+      ),
+      readFile(join(repositoryRoot, "docs/development/toolchain.md"), "utf8"),
+    ]);
+  });
+
+  it.each([
+    "runtime/yoda.mjs",
+    "runtime/yoda.core.mjs",
+    "runtime/manifest.json",
+    "24.0.0",
+    "runtime.node_unsupported",
+    "--expect",
+    "handshake",
+    "import.meta.url",
+    "process.cwd()",
+    "allowlist",
+    "denylist",
+    "SyntaxError",
+  ])("publishes %s", (required) => {
+    expect(guide).toContain(required);
+  });
+
+  it("states that an absent interpreter is the host adapter's responsibility", () => {
+    expect(guide).toMatch(/absent[\s\S]{0,200}host adapter/u);
+  });
+
+  it("states that source maps are excluded deliberately", () => {
+    expect(guide).toContain("source map");
+  });
+
+  it("names the built entry point in the toolchain guide", () => {
+    expect(toolchain).toContain("runtime/yoda.mjs");
+  });
+});

--- a/tests/runtime-handshake.test.ts
+++ b/tests/runtime-handshake.test.ts
@@ -1,0 +1,99 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { Ajv2020 } from "ajv/dist/2020.js";
+import { YODA_VERSION } from "@mestre-yoda/contracts";
+import {
+  buildHandshakeResponse,
+  classifyExpectedVersion,
+} from "@mestre-yoda/runtime/handshake";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+let validateMessage: (value: unknown) => boolean;
+
+beforeAll(async () => {
+  const [messageSchema, resultSchema] = await Promise.all([
+    readFile(
+      join(repositoryRoot, "schemas/host/adapter-message.v1.schema.json"),
+      "utf8",
+    ),
+    readFile(join(repositoryRoot, "schemas/result.v1.schema.json"), "utf8"),
+  ]);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(JSON.parse(resultSchema) as object);
+  validateMessage = ajv.compile(JSON.parse(messageSchema) as object);
+});
+
+describe("runtime handshake", () => {
+  it("reports the carried contract versions", () => {
+    const message = buildHandshakeResponse("cli");
+
+    expect(message).toMatchObject({
+      contractVersion: "1.0.0",
+      hostContract: "1.0.0",
+      messageType: "response",
+      operation: "handshake",
+      correlationId: "cli",
+    });
+    expect(message.payload).toMatchObject({
+      contractVersion: "1.0.0",
+      status: "success",
+      exitCode: 0,
+      stateChanged: false,
+      retryable: false,
+      recovery: null,
+    });
+  });
+
+  it("satisfies the host adapter message schema", () => {
+    expect(validateMessage(buildHandshakeResponse("cli"))).toBe(true);
+  });
+
+  it("stays deterministic across invocations", () => {
+    expect(buildHandshakeResponse("abc")).toEqual(
+      buildHandshakeResponse("abc"),
+    );
+  });
+
+  it("reports no observed host identity when invoked directly", () => {
+    // The runtime cannot observe a host it was not handed one by.
+    expect(buildHandshakeResponse("cli").observedIdentity).toEqual({
+      adapterVersion: YODA_VERSION,
+      model: null,
+    });
+  });
+
+  it("accepts the exact bundle version", () => {
+    expect(classifyExpectedVersion(YODA_VERSION)).toBeNull();
+  });
+
+  it.each([
+    [undefined, "contract.plugin_version_invalid"],
+    ["", "contract.plugin_version_invalid"],
+    ["not-semver", "contract.plugin_version_invalid"],
+    [" 1.0.0 ", "contract.plugin_version_invalid"],
+    [42, "contract.plugin_version_invalid"],
+    ["9.9.9", "contract.plugin_version_unsupported"],
+    ["1.0.0", "contract.plugin_version_unsupported"],
+  ])("rejects %o", (value, reasonCode) => {
+    expect(classifyExpectedVersion(value)).toMatchObject({
+      reasonCode,
+      status: "failure",
+      exitCode: 2,
+      stateChanged: false,
+      retryable: false,
+    });
+  });
+
+  it.each(["7.7.7", "not-semver", "sekrit-build-name"])(
+    "never echoes the supplied value %s",
+    (value) => {
+      // Distinctive values only: a substring assertion against "" or against a
+      // version that also appears as `contractVersion` proves nothing.
+      expect(JSON.stringify(classifyExpectedVersion(value))).not.toContain(
+        value,
+      );
+    },
+  );
+});

--- a/tests/runtime-preflight.test.ts
+++ b/tests/runtime-preflight.test.ts
@@ -3,14 +3,23 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
+const repositoryRoot = join(import.meta.dirname, "..");
 const stub = join(import.meta.dirname, "fixtures/runtime/old-node.mjs");
 const template = join(
-  import.meta.dirname,
-  "../packages/runtime/src/boot/preflight.mjs",
+  repositoryRoot,
+  "packages/runtime/src/boot/preflight.mjs",
 );
 const roots: string[] = [];
+
+beforeAll(() => {
+  execFileSync(process.execPath, ["scripts/build.mjs"], {
+    cwd: repositoryRoot,
+    stdio: "pipe",
+  });
+});
 
 afterEach(async () => {
   await Promise.all(
@@ -117,6 +126,39 @@ describe("runtime preflight", () => {
     expect(result.stdout).not.toContain(entry);
     expect(result.stdout).not.toContain(tmpdir());
     expect(result.stderr).toBe("");
+  });
+
+  it("rejects an old interpreter in the built artifact, not just the template", async () => {
+    // The cases above exercise the template. This one runs the file that
+    // actually ships, validated against the published result schema rather than
+    // an inline literal that a schema change could silently orphan.
+    const entry = join(repositoryRoot, "dist/plugin/runtime/yoda.mjs");
+    const result = run(entry, "18.20.0");
+
+    expect(result.status).toBe(2);
+    const [schemaText, catalogText] = await Promise.all([
+      readFile(join(repositoryRoot, "schemas/result.v1.schema.json"), "utf8"),
+      readFile(
+        join(
+          repositoryRoot,
+          "packages/contracts/catalogs/reason-codes.v1.2.json",
+        ),
+        "utf8",
+      ),
+    ]);
+    const validate = new Ajv2020({ allErrors: true, strict: true }).compile(
+      JSON.parse(schemaText) as object,
+    );
+    const rendered = JSON.parse(result.stdout) as { reasonCode: string };
+
+    expect(validate(rendered), JSON.stringify(validate.errors)).toBe(true);
+    expect(rendered.reasonCode).toBe("runtime.node_unsupported");
+    const reason = (
+      JSON.parse(catalogText) as {
+        reasons: { code: string; recovery: string }[];
+      }
+    ).reasons.find(({ code }) => code === "runtime.node_unsupported");
+    expect(rendered).toMatchObject({ recovery: reason?.recovery });
   });
 
   it("reports a load failure without a stack trace", async () => {

--- a/tests/runtime-preflight.test.ts
+++ b/tests/runtime-preflight.test.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const stub = join(import.meta.dirname, "fixtures/runtime/old-node.mjs");
+const template = join(
+  import.meta.dirname,
+  "../packages/runtime/src/boot/preflight.mjs",
+);
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+/** Substitute the build's placeholders so the real template can be executed. */
+async function materialize(): Promise<string> {
+  const source = await readFile(template, "utf8");
+  const root = await mkdtemp(join(tmpdir(), "yoda-preflight-"));
+  roots.push(root);
+  await mkdir(join(root, "runtime"), { recursive: true });
+  const entry = join(root, "runtime/yoda.mjs");
+  await writeFile(
+    entry,
+    source
+      .replaceAll("__MINIMUM_NODE__", "24.0.0")
+      .replaceAll(
+        "__SUMMARY__",
+        "The interpreter running the plugin runtime is older than the supported minimum.",
+      )
+      .replaceAll(
+        "__RECOVERY__",
+        "Install Node.js 24.0.0 or newer and run the command again.",
+      )
+      .replaceAll("__CORE__", "./yoda.core.mjs"),
+    "utf8",
+  );
+  await writeFile(
+    join(root, "runtime/yoda.core.mjs"),
+    'process.stdout.write("core reached\\n");\n',
+    "utf8",
+  );
+  return entry;
+}
+
+interface Execution {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(entry: string, version: string): Execution {
+  try {
+    const stdout = execFileSync(process.execPath, ["--import", stub, entry], {
+      encoding: "utf8",
+      env: { ...process.env, YODA_TEST_NODE_VERSION: version },
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (error) {
+    const failure = error as { status: number; stdout: string; stderr: string };
+    return {
+      status: failure.status,
+      stdout: failure.stdout,
+      stderr: failure.stderr,
+    };
+  }
+}
+
+describe("runtime preflight", () => {
+  it("reaches the core on a supported interpreter", async () => {
+    const result = run(await materialize(), "24.18.0");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("core reached\n");
+  });
+
+  it.each(["24.0.0", "25.1.0", "24.18.7"])(
+    "accepts interpreter %s",
+    async (version) => {
+      expect(run(await materialize(), version).stdout).toBe("core reached\n");
+    },
+  );
+
+  it.each(["18.20.0", "23.11.0", "24.0.0-nightly"])(
+    "rejects interpreter %s with a structured result",
+    async (version) => {
+      const entry = await materialize();
+      const result = run(entry, version);
+
+      expect(result.status).toBe(2);
+      const rendered = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(rendered).toEqual({
+        contractVersion: "1.0.0",
+        status: "failure",
+        exitCode: 2,
+        reasonCode: "runtime.node_unsupported",
+        summary:
+          "The interpreter running the plugin runtime is older than the supported minimum.",
+        why: ["The plugin runtime requires a newer Node.js interpreter."],
+        evidence: [],
+        stateChanged: false,
+        retryable: false,
+        recovery: "Install Node.js 24.0.0 or newer and run the command again.",
+      });
+    },
+  );
+
+  it("discloses neither the rejected version nor a local path", async () => {
+    const entry = await materialize();
+    const result = run(entry, "18.20.0");
+
+    expect(result.stdout).not.toContain("18.20.0");
+    expect(result.stdout).not.toContain(entry);
+    expect(result.stdout).not.toContain(tmpdir());
+    expect(result.stderr).toBe("");
+  });
+
+  it("reports a load failure without a stack trace", async () => {
+    const entry = await materialize();
+    await rm(join(entry, "../yoda.core.mjs"));
+    const result = run(entry, "24.18.0");
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("The Yoda runtime could not be loaded.\n");
+    expect(result.stderr).not.toContain(" at ");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     coverage: {
-      include: ["packages/runtime/src/cli.ts"],
+      include: [
+        "packages/runtime/src/cli.ts",
+        "packages/runtime/src/handshake.ts",
+      ],
       provider: "v8",
       reporter: ["text", "json-summary"],
       thresholds: {


### PR DESCRIPTION
Closes #14. Part of epic #8. Builds on #3, #11, and #12.

## What this adds

A plugin-owned runtime that Claude Code and Codex invoke from inside the plugin directory against an arbitrary project working directory, with no global executable, no `PATH` entry, and no project `node_modules`.

- `packages/runtime/src/boot/preflight.mjs` — the interpreter gate that becomes `runtime/yoda.mjs`
- `packages/runtime/src/handshake.ts` — handshake response and `--expect` classification
- `packages/contracts/catalogs/reason-codes.v1.2.json` — additive catalog revision adding `runtime.node_unsupported`
- `scripts/build.mjs` — emits the two-file runtime and `runtime/manifest.json`
- `scripts/verify-package.mjs` — enforces a plugin allowlist and a project denylist
- `docs/compatibility/runtime-distribution.md` — the public contract

## Why the boot is split

This is the decision the rest of the change follows from.

A JavaScript module is parsed in full before any of it executes. If the bundle targets modern Node and a user runs an older one, the failure is a `SyntaxError` from the parser — raised *before* any version check inside that same file could run. **A guard cannot protect the code it shares a file with.**

The issue requires that "a missing/unsupported Node.js installation fails before mutation with structured recovery guidance." Meeting that is impossible in one file. So `runtime/yoda.mjs` is a small preflight in Node 12.17-era syntax that checks `process.versions.node` and only then dynamically imports `runtime/yoda.core.mjs`. Both ship inside the plugin and import nothing but Node builtins and each other, so "self-contained" holds: two files, one unit, zero dependencies.

The gate was probed against `24`, `24.0`, `v24.0.0`, `""`, `abc`, `24.0.0-nightly`, `24.0.0+build`, `100.0.0`, and `25.0.0-pre`. Every malformed form falls to the structured-failure branch; build metadata is accepted and a prerelease of the floor is rejected, which is semantically correct. Nothing produces a throw or an unhandled rejection.

## Other decisions

**Node detection reports, it does not search.** The preflight reads `process.versions.node` and never probes `PATH` or re-executes itself. An interpreter that is *absent* is outside the runtime's reach — nothing runs, so nothing can report — and that belongs to the host adapter (#35). The boundary is stated on both sides so neither assumes the other covers it.

**One new reason, additively.** Catalog revision `1.2.0` preserves all 82 entries of `1.1.0` byte-for-byte and adds `runtime.node_unsupported`; `contractVersion` stays `1.0.0`. The catalog is the single source of truth for that text, so the build injects its summary and recovery into the entry point and a test compares the injected literals against the catalog — a drifting copy fails the build rather than shipping.

**Two roots.** Plugin assets resolve from `import.meta.url`, project data from `process.cwd()`. Today this is a rule the layout must keep rather than a body of resolution code, since no plugin asset exists to load yet; stating and testing it now means the asset issues that follow inherit it instead of retrofitting it. The guide says exactly that rather than implying code that does not exist.

**Two inventories**, because a plugin install and a project install receive different things: an exact three-file allowlist for the plugin, and a denylist rejecting `node_modules`, `packages`, `runtime`, `*.ts`, and `*.map` under any project the runtime operated on.

**`--expect` preserved.** It was the predecessor's anti-drift mechanism and dropping it would lose behavior. Version policy is not reimplemented — it calls the #12 classifier, so a family is judged in exactly one place.

## Compatibility impact

No change to shipped behavior; there is no released plugin yet. Parity remains **0 / 400 (0.00%)** — this builds distribution machinery and adds no differential, integration, or E2E evidence to any row.

The predecessor's `PATH`-installed binary and its two installer scripts are deliberately not reproduced. Removing them is the outcome this issue exists to produce, so `PLUGIN-INSTALL-SH` and `PLUGIN-INSTALL-PS1` are satisfied by the plugin-owned runtime rather than by porting installers.

The help text now lists the commands that exist (`--expect`, `--help`, `--version`, `handshake`) instead of the previous two.

## Verification

```bash
npm run build
npm run package:verify
npm test -- tests/runtime-preflight.test.ts tests/runtime-distribution.test.ts \
  tests/runtime-handshake.test.ts tests/package-boundaries.test.ts \
  tests/contract-reason-catalog.test.ts packages/runtime/src/cli.test.ts
npm run verify
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml .github/workflows/docs.yml
npx markdownlint-cli2 "**/*.md" "#node_modules" "#.worktrees"
rg --files -g '*.md' -g '!node_modules/**' -g '!.worktrees/**' -0 | xargs -0 lychee --config .lychee.toml
git diff --check main...HEAD
```

All green: `verify` passes end to end (341 tests, 33 files), 100% coverage on `cli.ts` and `handshake.ts`, markdownlint 0 issues across 52 files, lychee 218/218 links OK, actionlint clean.

## Evidence

The acceptance criteria were verified directly rather than by assertion:

- **Runs from the plugin directory against an arbitrary project** — including a project directory named `a project ç ü` and a *plugin* root named `plúg in dir ç ü`, which is where a relative dynamic import through a percent-encodable `import.meta.url` would break.
- **No global executable is used** — a decoy `yoda` that exits 99 and writes to stderr is placed first on `PATH`. The test asserts the decoy is reachable and fails loudly *before* asserting the run ignores it, so the evidence cannot pass vacuously.
- **Unsupported Node fails before mutation** — the built artifact, run under a stubbed interpreter version, emits a document validated against `schemas/result.v1.schema.json` with `runtime.node_unsupported`, `stateChanged: false`, exit 2, disclosing neither the rejected version nor any local path.
- **Nothing is written into the project** — `readdir` on the project directory after a run returns empty.

## Review

An independent review found no Critical defect and six Important ones, all fixed:

- The guide published host-contract rejection the runtime never performs — nothing hands it a host identity to classify. Reworded to say those codes are defined by #12 and wired by #35, rather than implying coverage here.
- The result-contract guide claimed `result:check` validates 83 reason entries; that checker deliberately validates the frozen revision 1.0 and reports 76. The earlier edit contradicted a decision this same plan had made.
- The unrecognized-argument path echoed caller-supplied text, so an absolute path or a supplied version reached public output — reachable by simply misordering `--expect`. This contradicted a constraint written down in this same change.
- The project denylist had no demonstrated failing case: the runtime writes nothing, so the check passed over an empty directory and would have passed identically if every pattern were wrong.
- The plugin root was documented as exercised with spaces and non-ASCII characters, but only the project root was.
- The entry point swallowed every core failure alike, leaving a genuine crash undiagnosable.

Four Minor findings were also fixed: order-dependent placeholder substitution, preflight tests exercising the template rather than the shipped artifact, an imprecise Node syntax floor, and a `version.ts` the spec listed but which deliberately does not exist (a TypeScript module would be transpiled into the bundle, and the comparison must run before the bundle loads).

One Minor is deferred and stated rather than dropped: `runtime/manifest.json` has no JSON Schema, unlike every other contract artifact here. It belongs with release packaging in #59, where the archive format is decided.
