### PR TITLE
feat: implement project discovery and configuration resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ The project-owned `.brain/` state lives inside the project. Host instructions li
 in `.claude/` and `.codex/`. The embedded ESM runtime remains owned by the
 installed plugin.
 
+The internal [project discovery contract](docs/architecture/project-discovery.md)
+now fixes root, worktree, migration, and configuration precedence. It adds no new runnable command
+to the current bundle.
+
 ### No global Yoda binary
 
 The new runtime is developed in TypeScript and distributed as a self-contained JavaScript ESM bundle inside the plugin. This avoids a separately installed global binary, PATH problems, and runtime/plugin version drift.

--- a/docs/architecture/project-discovery.md
+++ b/docs/architecture/project-discovery.md
@@ -30,6 +30,12 @@ Canonicalization, marker containment, and Git topology are observations made by
 the `Workspace` port. The pure resolver receives those observations and cannot
 read the filesystem, invoke Git, or mutate a project.
 
+A `.git` marker is not sufficient evidence by itself. If Git cannot validate
+its topology, or a separate metadata layout does not expose an unambiguous
+principal checkout, discovery refuses that marker. Unexpected filesystem errors
+propagate to the composition boundary as internal failures; only expected
+absence or a non-directory path is classified as unavailable.
+
 ## State locations and migration
 
 The supported location is the project-owned `.brain/` directory. A legacy

--- a/docs/architecture/project-discovery.md
+++ b/docs/architecture/project-discovery.md
@@ -1,0 +1,83 @@
+# Project Discovery and Configuration Resolution
+
+Project discovery is a read-only boundary between the process environment and
+the deterministic runtime. It identifies one canonical project root, observes
+the project-owned `.brain/`, and classifies configuration before any mutating
+runtime ports are created. It does not add a command to the shipped CLI.
+
+## Root selection
+
+An explicit `--root` is resolved relative to the process working directory,
+canonicalized, and inspected directly. Discovery never searches its ancestors.
+If the explicit directory is unavailable, or its nearest marker is unusable,
+the request is refused rather than silently redirected.
+
+Without an explicit root, discovery walks from the current directory toward
+the filesystem boundary. The nearest ancestor containing a usable `.brain/`
+wins. An unusable nearest marker stops the search so that an older parent state
+cannot unexpectedly take control.
+
+Git is fallback context, not a stronger marker. In an ordinary checkout, its
+top level may provide the root when no ancestor has state. In a linked Git worktree,
+the default order is:
+
+1. a local worktree `.brain/`;
+2. the principal checkout and its nearest ancestor marker;
+3. the local Git top level without initialized state.
+
+The principal checkout fallback can be disabled with the worktree-local mode.
+Canonicalization, marker containment, and Git topology are observations made by
+the `Workspace` port. The pure resolver receives those observations and cannot
+read the filesystem, invoke Git, or mutate a project.
+
+## State locations and migration
+
+The supported location is the project-owned `.brain/` directory. A legacy
+sibling Brain layout is migration-only: discovery can report that migration is
+required, but it never selects or reads sibling state as current project state.
+Migration itself belongs to the migration command and its transactional policy.
+
+Symlinks are accepted only when their canonical target remains inside the
+selected project. Escapes and unreadable markers are refusals, not absence.
+Discovery creates, changes, and removes nothing.
+
+## Configuration
+
+`.brain/config.json` is classified in this order:
+
+1. JSON syntax;
+2. `stateContract` identity and support;
+3. schema validation through `ConfigurationValidator`.
+
+`RUN-04` owns the schema registry and supplies that validator. Discovery does
+not duplicate schema interpretation while that contract is being implemented.
+Missing, corrupt, unsupported, migration-required, and schema-invalid inputs
+remain distinct typed outcomes.
+
+Effective values follow one explicit precedence:
+
+```text
+command flag > validated project configuration > runtime default
+```
+
+There is no environment-variable configuration layer. Each effective value
+retains a provenance reference: `null` for a runtime default,
+`.brain/config.json` for project configuration, or a fixed `--flag` name for a
+command override. These references are safe to render and never contain an
+absolute path, environment value, or raw configuration payload.
+
+## Composition and compatibility
+
+`discoverProject` composes the real environment and Node `Workspace` adapter.
+Only an initialized resolution may be passed to `createRuntimeAt`, which then
+roots mutation-capable ports at the selected canonical directory. Tests can
+replace either boundary explicitly; production does not select fakes through
+ambient state.
+
+The source workspace exposes the discovery contract at
+`@mestre-yoda/runtime/composition/discovery`. The standalone bundle still
+supports only `help`, `version`, and `handshake`, and its three-file inventory
+is unchanged. No discovery command is published by this issue.
+
+Parity remains `0 / 400 (0.00%)`. This work provides internal unit, property,
+and filesystem evidence, but no completed differential or end-to-end parity row.

--- a/docs/architecture/runtime-boundaries.md
+++ b/docs/architecture/runtime-boundaries.md
@@ -69,6 +69,12 @@ that imports it, which is what the layering exists to prevent.
 | `Locks` | acquire and release a fenced lease | concurrency timing |
 | `Environment` | environment variables and working directory | ambient process state |
 | `Output` | structured and human output | stream side effects |
+| `Workspace` | canonical paths, read-only project markers, and Git worktree topology | ambient discovery state |
+
+`Workspace` is deliberately separate from `RuntimePorts`. Project discovery
+uses it before a project root exists; only after discovery succeeds does
+`createRuntimeAt` construct mutation-capable ports at that root. See the
+[project discovery contract](project-discovery.md) for precedence and safety.
 
 `Git` and `Locks` ship deliberately thin implementations. `RUN-08` owns
 repository classification and approved scope deltas; `RUN-07` owns lease expiry,
@@ -170,8 +176,9 @@ boundary, and this issue does not claim to provide it.
 ## Scope
 
 This issue delivers the boundary; it defines no policy, no transition, and no
-command. The objective lifecycle, guardrails, event store, locks, project
-discovery, and host adapters fill it in through their own issues.
+command. The objective lifecycle, guardrails, event store, locks, and host
+adapters fill it in through their own issues. Read-only project discovery now
+uses the boundary without changing the shipped command surface.
 
 Parity remains `0 / 400 (0.00%)`. This is internal structure and adds no
 differential, integration, or E2E evidence to any row.

--- a/docs/superpowers/plans/2026-08-07-project-discovery.md
+++ b/docs/superpowers/plans/2026-08-07-project-discovery.md
@@ -1,0 +1,473 @@
+# Project Discovery and `.brain` Configuration Resolution Implementation Plan
+
+> **Issue:** [#18](https://github.com/thiagocorreanet/mestre-yoda/issues/18) (`RUN-03`)
+>
+> **Design:** `docs/superpowers/specs/2026-08-07-project-discovery-design.md`
+
+**Goal:** Resolve a safe project root, classify project-local `.brain` state,
+load configuration through a version-first validation seam, and preserve
+setting provenance without exposing mutation capabilities during discovery.
+
+**Architecture:** The Node and fake `Workspace` ports collect canonical,
+read-only observations. Pure domain functions select the root, classify the raw
+configuration, and layer validated settings. Composition performs bootstrap
+discovery first and creates rooted mutation ports only after a successful
+resolution. `RUN-04` owns schema interpretation; this issue defines and tests a
+pure `ConfigurationValidator` seam rather than duplicating a registry.
+
+**Toolchain:** TypeScript 6, Node 24, Vitest 4, existing contracts package,
+native `node:fs/promises`, `node:path`, and `git` process invocation.
+
+**Compatibility constraints:** Keep the frozen public inventory at `0 / 400`.
+Do not add commands, flags, reason codes, schemas, or configuration defaults.
+Treat the old sibling `<project>-brain/.brain` layout as migration input only.
+Never publish absolute paths or caller-provided root values.
+
+---
+
+## Task 1: Define the closed discovery vocabulary
+
+**Files:**
+
+- Create: `packages/runtime/src/domain/project/request.ts`
+- Create: `packages/runtime/src/domain/project/observation.ts`
+- Create: `packages/runtime/src/domain/project/validation.ts`
+- Create: `packages/runtime/src/domain/project/resolution.ts`
+- Create: `packages/runtime/src/domain/project/index.ts`
+- Modify: `packages/runtime/package.json`
+- Test: `tests/project-types.test.ts`
+
+### RED
+
+Write compile-time/runtime assertions for:
+
+- `DiscoveryRequest` with canonical working directory, optional explicit root,
+  and `principal | local` worktree mode;
+- nearest-first `DirectoryProbe` values with closed brain, Git, legacy, and
+  raw-configuration classifications;
+- `ConfigurationValidator` accepting unknown parsed data and returning either
+  a typed project configuration or a schema-invalid outcome;
+- discriminated `ProjectResolution` variants from the design;
+- a public `@mestre-yoda/runtime/domain/project` export.
+
+Run:
+
+```bash
+npx vitest run tests/project-types.test.ts
+npm run typecheck
+```
+
+Expected: FAIL because the project domain and export do not exist.
+
+### GREEN
+
+Add only the interfaces, discriminants, and barrel exports needed by the test.
+Keep every absolute path field explicitly internal-only in its documentation.
+Do not add behavior or defaults.
+
+Run the focused test and typecheck again. Commit with DCO:
+
+```bash
+git commit -s -m "feat: define the project discovery vocabulary"
+```
+
+## Task 2: Select roots with explicit precedence
+
+**Files:**
+
+- Create: `packages/runtime/src/domain/project/resolve-root.ts`
+- Modify: `packages/runtime/src/domain/project/index.ts`
+- Test: `tests/project-root-resolution.test.ts`
+
+### RED
+
+Table-test these policies with literal observations:
+
+1. an explicit canonical root is the only candidate and never walks upward;
+2. without an explicit root, the nearest usable `.brain` marker wins;
+3. an unusable or escaping nearest marker refuses rather than falling through;
+4. absent markers fall back to the discovered Git top level;
+5. a linked worktree falls back to its principal worktree unless local mode is
+   explicitly requested;
+6. a local `.brain` wins before principal fallback;
+7. no marker and no Git root returns `not-found`;
+8. a legacy sibling classifies `migration-pending` and never becomes storage;
+9. spaces, composed/decomposed Unicode, detached HEAD metadata, and repeated
+   identical input do not alter selection;
+10. every refusal contains a stable reason code and no input path in public
+    prose.
+
+Run:
+
+```bash
+npx vitest run tests/project-root-resolution.test.ts
+```
+
+Expected: FAIL because `resolveRoot` does not exist.
+
+### GREEN
+
+Implement a pure nearest-first selector. It may compare canonical paths but may
+not import Node builtins, call ports, parse Git output, or mutate observations.
+Map outcomes through one reason binding table so an oracle correction changes
+one place.
+
+Run the focused test, typecheck, lint, and commit:
+
+```bash
+git commit -s -m "feat: resolve project roots from workspace observations"
+```
+
+## Task 3: Classify configuration before schema validation
+
+**Files:**
+
+- Create: `packages/runtime/src/domain/project/configuration.ts`
+- Modify: `packages/runtime/src/domain/project/index.ts`
+- Test: `tests/project-configuration.test.ts`
+
+### RED
+
+Prove the exact failure order:
+
+- absent document -> `guard.config_missing`;
+- non-file document or invalid JSON -> `guard.config_corrupt` with no parser
+  message or source bytes;
+- missing, non-string, or untrimmed `stateContract` ->
+  `contract.state_version_invalid`;
+- unsupported or migration-only state contract -> the corresponding frozen
+  contract reason;
+- only a current contract invokes `ConfigurationValidator`;
+- a validator rejection -> `guard.config_corrupt`;
+- a validator success carries the typed configuration unchanged.
+
+Use a recording validator and assert zero calls for every pre-schema failure.
+Include quoted strings, absolute paths, credential-shaped text, duplicate JSON
+keys, and future fields to prove no raw value reaches diagnostics.
+
+Run:
+
+```bash
+npx vitest run tests/project-configuration.test.ts
+```
+
+Expected: FAIL because configuration classification is absent.
+
+### GREEN
+
+Implement JSON parsing behind a sanitized catch, call the existing state-family
+version classifier before the injected validator, and return data-only outcomes.
+Do not implement JSON Schema keywords and do not cast unknown data to
+`ProjectConfigV1` without validator success.
+
+Run focused tests, typecheck, lint, and commit:
+
+```bash
+git commit -s -m "feat: classify project configuration before validation"
+```
+
+## Task 4: Resolve layered values with attached provenance
+
+**Files:**
+
+- Create: `packages/runtime/src/domain/project/layers.ts`
+- Modify: `packages/runtime/src/domain/project/index.ts`
+- Test: `tests/project-configuration-layers.test.ts`
+
+### RED
+
+Table-test a generic closed-key layer resolver:
+
+- precedence is `default < project < flag`;
+- every output is `{ value, source, ref }`;
+- default refs are `null`, project refs are `.brain/config.json`, and flag refs
+  are declared flag names;
+- absent higher layers preserve both the lower value and its provenance;
+- unknown keys and undefined values fail closed;
+- input objects are not mutated;
+- output key order is deterministic;
+- no absolute path can be used as a provenance ref.
+
+Run:
+
+```bash
+npx vitest run tests/project-configuration-layers.test.ts
+```
+
+Expected: FAIL because the layer resolver does not exist.
+
+### GREEN
+
+Implement the smallest generic resolver satisfying the closed key list supplied
+by its caller. Do not choose shipped language, policy, or snapshot defaults.
+
+Run focused tests and commit:
+
+```bash
+git commit -s -m "feat: retain provenance across configuration layers"
+```
+
+## Task 5: Add the read-only Workspace port and deterministic fake
+
+**Files:**
+
+- Modify: `packages/runtime/src/ports/index.ts`
+- Modify: `packages/runtime/src/infra/fake/index.ts`
+- Create: `tests/support/workspace-contract.ts`
+- Create: `tests/fake-workspace.test.ts`
+- Modify: `tests/runtime-fakes.test.ts`
+
+### RED
+
+Define one shared contract that requires:
+
+- path canonicalization is idempotent;
+- ancestor probes are nearest-first and end at the filesystem root;
+- marker kinds distinguish absent, real directory, other, and escaping symlink;
+- configuration bytes are returned only for a real project-local marker;
+- a sibling legacy Brain is observed but never read as current state;
+- worktree location distinguishes ordinary/principal and linked roots;
+- traversal, NUL/control characters, empty segments, drive prefixes in the
+  wrong path dialect, and symlink escapes are refused;
+- every method is read-only.
+
+Run:
+
+```bash
+npx vitest run tests/fake-workspace.test.ts tests/runtime-fakes.test.ts
+```
+
+Expected: FAIL because `Workspace` and `memoryWorkspace` are absent.
+
+### GREEN
+
+Add `Workspace` as a bootstrap port, not to `RuntimePorts`. Implement a fake
+from an inert path tree with no mutation methods. Match the async rejection
+behavior of Node ports.
+
+Run focused tests, typecheck, lint, and commit:
+
+```bash
+git commit -s -m "feat: add the read-only workspace boundary"
+```
+
+## Task 6: Implement the Node workspace adapter
+
+**Files:**
+
+- Create: `packages/runtime/src/infra/node/workspace.ts`
+- Modify: `packages/runtime/src/infra/node/index.ts`
+- Test: `tests/node-workspace.test.ts`
+
+### RED
+
+Run the shared workspace contract against real temporary directories and Git
+repositories. Include:
+
+- ordinary repositories and nested directories;
+- non-repository directories;
+- detached HEAD and unborn repositories;
+- linked worktrees whose paths contain spaces and Unicode;
+- project-local `.brain`, marker-as-file, safe internal symlink target, and
+  escaping symlink target;
+- legacy sibling `<project>-brain/.brain`;
+- an explicit root that does not exist or is not a directory;
+- a real Git worktree fixture proving the synthetic topology is not vacuous.
+
+Run:
+
+```bash
+npx vitest run tests/node-workspace.test.ts
+```
+
+Expected: FAIL because `nodeWorkspace` does not exist.
+
+### GREEN
+
+Implement canonicalization with `realpath`, inspect marker entries without
+following an unsafe final symlink, walk parents with `dirname`, and query Git
+with fixed locale/environment arguments. Never change process cwd. Convert
+expected absence to data and allow unexpected I/O errors to reject for the
+sanitized composition boundary.
+
+Run the focused suite, typecheck, lint, and commit:
+
+```bash
+git commit -s -m "feat: observe projects through the node workspace adapter"
+```
+
+## Task 7: Compose bootstrap discovery before rooted runtime creation
+
+**Files:**
+
+- Create: `packages/runtime/src/composition/discovery.ts`
+- Modify: `packages/runtime/src/composition/index.ts`
+- Modify: `packages/runtime/package.json`
+- Test: `tests/project-discovery-composition.test.ts`
+- Modify: `tests/runtime-composition.test.ts`
+
+### RED
+
+Prove:
+
+- `observeProject` receives only `Workspace` and `Environment` bootstrap ports;
+- failure paths cannot access `FileSystem`, `Git`, `Locks`, `Ids`, or output;
+- explicit roots are resolved relative to the observed working directory and
+  process cwd never changes;
+- validated `initialized` and `root-only` resolutions can create a runtime
+  whose file/Git/lock adapters are rooted at the selected canonical root;
+- validation, serialization, or observation failure happens before runtime
+  creation;
+- repeated observations are byte/deep equal.
+
+Use recording factories and make a deliberately mutating bootstrap fixture fail
+the test, proving the non-mutation assertion is active.
+
+Run:
+
+```bash
+npx vitest run tests/project-discovery-composition.test.ts tests/runtime-composition.test.ts
+```
+
+Expected: FAIL because two-phase composition is absent.
+
+### GREEN
+
+Add a separate bootstrap composition type and an explicit
+`createRuntimeAt(root, overrides)` function. Preserve `createRuntime` for the
+existing public commands until a later command opts into project discovery.
+Do not silently change help/version/handshake behavior.
+
+Run focused tests, typecheck, lint, and commit:
+
+```bash
+git commit -s -m "feat: compose runtime creation after project discovery"
+```
+
+## Task 8: Prove normalization, traversal refusal, and determinism
+
+**Files:**
+
+- Create: `tests/project-discovery-properties.test.ts`
+- Create: `tests/project-discovery-integration.test.ts`
+
+### RED
+
+Add a seeded generator without a new dependency. Generate path segments with
+`.` / `..`, empty values, controls, separators, drive/UNC forms, spaces,
+combining Unicode, and ordinary names. Assert:
+
+- successful canonicalization is idempotent;
+- no accepted project marker escapes its selected root;
+- explicit traversal is never clamped into a valid project;
+- equivalent observations resolve identically;
+- local/principal worktree precedence is stable;
+- discovery creates, writes, deletes, and appends nothing.
+
+Print the seed on failure and include a deliberately weakened resolver fixture
+that proves the properties detect an escape.
+
+Run:
+
+```bash
+npx vitest run tests/project-discovery-properties.test.ts tests/project-discovery-integration.test.ts
+```
+
+Expected: FAIL until the property and integration boundaries expose every edge.
+
+### GREEN
+
+Fix only the production branches exposed by the tests. Do not add coverage
+ignores for reachable logic.
+
+Run focused tests and commit:
+
+```bash
+git commit -s -m "test: prove project discovery path safety"
+```
+
+## Task 9: Document the public internal contract and package it
+
+**Files:**
+
+- Create: `docs/architecture/project-discovery.md`
+- Modify: `docs/architecture/runtime-boundaries.md`
+- Modify: `README.md`
+- Modify: `scripts/verify-package.mjs`
+- Modify: `tests/bundle-smoke.test.ts`
+- Modify: `tests/readme-honesty.test.ts`
+- Modify: `tests/contract-documentation.test.ts`
+
+### RED
+
+Pin documentation and package assertions for:
+
+- project-owned `.brain` and migration-only sibling state;
+- explicit-root, ancestor, Git, and worktree precedence;
+- no environment-variable configuration layer;
+- provenance refs that are safe to render;
+- the schema-registry seam owned by `RUN-04`;
+- no change to the shipped command surface;
+- bundle import of the discovery API with no runtime asset outside the three
+  allowed plugin files.
+
+Run the focused documentation, bundle, and package tests. Expected: FAIL until
+the docs and bundle contract are updated.
+
+### GREEN
+
+Write concise public architecture documentation. Mention only public/redacted
+legacy evidence; never include local paths or private source excerpts. Update
+package verification only for actual bundled exports.
+
+Run focused tests, build, package verification, and commit:
+
+```bash
+git commit -s -m "docs: publish the project discovery contract"
+```
+
+## Task 10: Complete verification, independent review, and delivery
+
+### Local verification
+
+Run, in order:
+
+```bash
+npm run verify
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 \
+  .github/workflows/ci.yml .github/workflows/docs.yml
+```
+
+Require:
+
+- focused and full suites green;
+- 100% covered statements, branches, functions, and lines;
+- typecheck, lint, format, spelling, contracts, oracle, parity, differential,
+  build, and package verification green;
+- parity still exactly `0 / 400`;
+- `git diff --check` clean;
+- every issue commit contains a DCO sign-off.
+
+### Independent review
+
+Review `origin/main..HEAD` with an independent agent. Fix every Critical and
+Important finding using a new RED test before production changes. Repeat full
+verification after the final fix and obtain a merge verdict.
+
+### GitHub delivery
+
+Push `feat/issue-18-project-discovery`, open a ready PR linking and closing #18,
+list exact verification evidence, monitor both GitHub Actions workflows, fix
+any failure, and squash-merge only when all required checks pass. Ensure the
+squash commit has DCO sign-off.
+
+After merge:
+
+1. verify #18 is closed and mark every issue checklist item complete;
+2. mark #18 complete in epic #15;
+3. fast-forward local `main` without touching `.claude/` user worktrees;
+4. delete the remote feature branch;
+5. preserve the externally managed worktree registration rather than removing
+   it from the host;
+6. continue to the next open executable issue.
+

--- a/docs/superpowers/plans/2026-08-07-project-discovery.md
+++ b/docs/superpowers/plans/2026-08-07-project-discovery.md
@@ -408,8 +408,8 @@ Pin documentation and package assertions for:
 - provenance refs that are safe to render;
 - the schema-registry seam owned by `RUN-04`;
 - no change to the shipped command surface;
-- bundle import of the discovery API with no runtime asset outside the three
-  allowed plugin files.
+- workspace-package import of the discovery API, while the CLI bundle keeps
+  exactly the three allowed plugin files and exposes no new command.
 
 Run the focused documentation, bundle, and package tests. Expected: FAIL until
 the docs and bundle contract are updated.
@@ -470,4 +470,3 @@ After merge:
 5. preserve the externally managed worktree registration rather than removing
    it from the host;
 6. continue to the next open executable issue.
-

--- a/docs/superpowers/specs/2026-08-07-project-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-07-project-discovery-design.md
@@ -129,7 +129,8 @@ interface WorktreeLocation {
 }
 
 interface Workspace {
-  canonicalize(path: string): Promise<string | null>;
+  canonicalize(path: string, base: string): Promise<string | null>;
+  inspect(path: string): Promise<DirectoryProbe>;
   ancestors(start: string): Promise<readonly DirectoryProbe[]>;
   locateWorktree(start: string): Promise<WorktreeLocation | null>;
 }
@@ -429,9 +430,9 @@ decisions and claim no row.
 | `domain/project/config.ts` | Layered configuration and `Resolved<T>` |
 | `domain/project/validation.ts` | Pure validator seam consumed by discovery and implemented by `RUN-04` |
 | `domain/project/reasons.ts` | Resolution variant to reason-code mapping |
-| `ports/index.ts` | `Workspace` interface added to `RuntimePorts` |
+| `ports/index.ts` | Pre-root `Workspace` interface, separate from `RuntimePorts` |
 | `infra/node/workspace.ts` | Ancestor walk, canonicalization, worktree query |
-| `infra/fake/workspace.ts` | In-memory tree honouring the same contract |
+| `infra/fake/index.ts` | In-memory tree honouring the same contract |
 | `composition/discovery.ts` | `observeWorkspace` and the two-phase wiring |
 
 `domain/project/**` imports no Node builtin and calls no port, so the
@@ -445,6 +446,7 @@ architecture test already in place covers it without a new rule.
 | `--root` absent, unreadable, or not a directory | `resolveProject` | `trail.uso` | 2 |
 | `--root` cannot be canonicalized | `observeWorkspace` | `trail.uso` | 2 |
 | No `.brain` and no Git top level | `resolveProject` | `guard.config_missing` | 2 |
+| `.git` exists but topology is invalid or ambiguous | `resolveProject` | `guard.project_marker_corrupt` | 2 |
 | `.brain` is a file or escapes the root | `resolveProject` | `guard.project_marker_corrupt` | 2 |
 | Legacy sibling Brain present | `resolveProject` | `brain_migration_pending` | 1 |
 | `.brain/config.json` absent | `resolveProject` | `guard.config_missing` | 2 |

--- a/docs/superpowers/specs/2026-08-07-project-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-07-project-discovery-design.md
@@ -1,0 +1,584 @@
+# Project Discovery and `.brain` Configuration Resolution Design
+
+Issue [#18](https://github.com/thiagocorreanet/mestre-yoda/issues/18) (`RUN-03`).
+Epic [#15](https://github.com/thiagocorreanet/mestre-yoda/issues/15).
+Depends on [#16](https://github.com/thiagocorreanet/mestre-yoda/issues/16) (`RUN-01`)
+and [#12](https://github.com/thiagocorreanet/mestre-yoda/issues/12) (`CMP-04`).
+
+## Problem
+
+The runtime has a project-rooted filesystem port but no way to decide what the
+project root is. `createRuntime` roots every effect at
+`overrides.environment?.workingDirectory() ?? process.cwd()`, which is a
+placeholder: it assumes the caller already invoked the command from the exact
+directory the state belongs to. A command run from `src/api/handlers` would
+create a second `.brain` tree three levels below the real one, and nothing in
+the runtime would notice.
+
+The frozen inventory shows how wrong that assumption is. Twenty seven rows carry
+a `--root` flag, each specified as a "nonempty directory path in spaced or `=`
+form, default current directory" that "runs against the Brain/project rooted
+there without changing process cwd". Two more rows, `FLAG-INIT-WORKTREE-LOCAL`
+and `FLAG-DOCTOR-WORKTREE-LOCAL`, show that a linked Git worktree resolves to a
+different Brain than the principal worktree unless the caller says otherwise.
+`REASON-BRAIN-MIGRATION-PENDING` shows that a project can be found and still be
+unusable because its state is in the legacy sibling layout.
+
+Every issue after this one reads or writes `.brain`. If root resolution is
+retrofitted later, each of them will already carry its own idea of where the
+project is, and the guarantee that state never escapes into the wrong repository
+will be a review habit rather than a structural property.
+
+The layering makes this harder than it first looks. The `FileSystem` port
+refuses absolute paths and refuses traversal, which is correct for managed
+project paths and useless for discovery: discovery must look *above* a directory
+it does not yet own. There is no port today that can answer a question about a
+path outside the project, which is exactly the question this issue exists to
+answer.
+
+## Goal
+
+One resolver that turns an invocation (a working directory, an optional
+`--root`, an optional worktree mode) into a single classified answer: which
+absolute directory is the project root, whether it holds a usable `.brain`,
+which configuration values apply, and where each of those values came from.
+
+The decision is pure. The observation that feeds it is collected through a port.
+Discovery reads and never writes, so a run that fails to find a project cannot
+have changed anything on the way to failing.
+
+## Non-goals
+
+- Command routing, flag parsing, the result envelope, and rendering. Those are
+  [#17](https://github.com/thiagocorreanet/mestre-yoda/issues/17) (`RUN-02`).
+  This issue defines what `--root` and `--worktree-local` *mean*; the parser
+  that accepts them and the renderer that reports the failure belong there.
+- Registering any command. `init`, `doctor`, `status`, and `migrate` are owned
+  by their own issues. This issue registers none of them, so it publishes no
+  new command surface.
+- Executing the legacy Brain migration. Discovery classifies the legacy layout
+  and refuses; `migrate brain` (`FORM-MIGRATE-BRAIN`) performs it after explicit
+  confirmation, and ADR 0003 requires that discovery alone never move or rewrite
+  either location.
+- Schema validation machinery. `RUN-04` owns the registry. This issue names the
+  point in the sequence where project configuration is validated, defines the
+  narrow `ConfigurationValidator` seam that registry will satisfy, and tests it
+  with an injected deterministic validator. No second schema interpreter is
+  introduced while `RUN-04` is still unmerged.
+- Atomicity, locks, and crash recovery (`RUN-05` through `RUN-07`). Discovery
+  performs no mutation, so it needs none of them.
+- Repository classification. `RUN-08` owns clean, dirty, detached, and unborn.
+  Discovery asks Git *where* a worktree is, never *what state* it is in.
+- Concrete default values for project configuration. See D9 and the open
+  decisions: the frozen evidence fixes the shape of `.brain/config.json`, not
+  the values `init` writes into it.
+- Classifying unsupported filesystems. No inventory row names an outcome for a
+  filesystem that lacks symlinks, is case insensitive, or cannot canonicalize a
+  path. Refusing a path that cannot be canonicalized is in scope; declaring a
+  filesystem unsupported would be inventing a public contract, so it is not.
+
+## Decisions
+
+### D1: Discovery is a pure resolver over a collected observation
+
+The domain exports one function:
+
+```ts
+resolveProject(
+  request: DiscoveryRequest,
+  observation: WorkspaceObservation,
+  validateConfiguration: ConfigurationValidator,
+): ProjectResolution
+```
+
+`DiscoveryRequest` carries the working directory, the optional `--root` value,
+and the worktree mode. `WorkspaceObservation` is an inert record of what the
+filesystem and Git reported. `ConfigurationValidator` is a pure function over
+parsed unknown data; `RUN-04` will supply the schema-registry implementation.
+`ProjectResolution` is a discriminated union. No port is called inside the
+function, so the whole of root selection, precedence, and refusal is testable
+with literal values and no temporary directory.
+
+This mirrors `RUN-01`'s effect-plan split: the domain describes, the edge
+performs. Discovery is the read-side twin of that rule, so the runtime has one
+shape for "decide purely, touch the world at the boundary" rather than two.
+
+Rejected: a `ProjectLocator` service that holds ports and walks the filesystem
+itself. It would put the precedence rules in `infra`, where the layering test
+cannot protect them and where every test of a tie-break needs a real directory
+tree. The interesting behavior here is the ordering, and ordering is exactly
+what a pure function makes cheap to prove.
+
+### D2: A new `Workspace` port collects what `FileSystem` cannot
+
+```ts
+interface DirectoryProbe {
+  readonly path: string;            // absolute, canonical
+  readonly brain: "absent" | "directory" | "other" | "escaping";
+  readonly git: "absent" | "present";
+  readonly legacyBrain: boolean;    // sibling <name>-brain/.brain present
+  readonly configuration:
+    | { readonly kind: "absent" | "other" }
+    | { readonly kind: "file"; readonly text: string };
+}
+
+interface WorktreeLocation {
+  readonly kind: "principal" | "linked";
+  readonly topLevel: string;        // this worktree
+  readonly principal: string;       // the principal worktree
+}
+
+interface Workspace {
+  canonicalize(path: string): Promise<string | null>;
+  ancestors(start: string): Promise<readonly DirectoryProbe[]>;
+  locateWorktree(start: string): Promise<WorktreeLocation | null>;
+}
+```
+
+`ancestors` returns the chain from `start` up to the filesystem root, nearest
+first. It reads `.brain/config.json` only when `.brain` is a real directory and
+records the raw bytes without interpreting them. Path arithmetic stays in
+`infra`, where `node:path` lives and where drive letters, UNC prefixes, and
+separator differences are already solved. Which entry of the chain wins and
+how the raw document is classified stay in `domain`, because those are policy.
+
+Rejected: reusing `FileSystem`. It is constructed with a root and refuses
+absolute and traversing paths, which is precisely the behavior discovery would
+have to defeat. Widening it would weaken the one port whose narrowness protects
+every managed write in the runtime.
+
+Rejected: extending `Git` with `locateWorktree`. `nodeGit(root)` is bound to a
+root at construction, so using it before the root is known inverts the
+dependency. `RUN-08` also owns that port's semantics, and location is a
+different question from classification: a detached, dirty, or unborn repository
+sits in exactly the same place.
+
+Rejected: writing a path module inside `domain` so the walk could be pure all
+the way down. It would reimplement `node:path` badly across three platforms to
+avoid one port, and `domain` may not import a Node builtin, so it could not
+share the tested implementation.
+
+### D3: Composition is two phase
+
+```text
+argv -> request -> observeWorkspace(bootstrapPorts) -> resolveProject
+                                                            |
+                                       root + configuration |
+                                                            v
+                                     createRuntime({ rooted at the root })
+```
+
+The bootstrap phase composes only `Workspace`, `Environment`, and `Clock`. It
+cannot write, because it holds no `FileSystem` and no `Locks`. Only after the
+root is resolved does `createRuntime` compose a filesystem rooted at it.
+
+This is what makes "fail before mutation" structural rather than a review note:
+during discovery there is no port present that could mutate anything.
+
+Rejected: composing the full runtime at the working directory and re-rooting
+after discovery. A runtime that briefly points at the wrong directory is a
+runtime that can write to the wrong directory if any code between the two steps
+touches it. Not creating it is cheaper than remembering not to use it.
+
+### D4: `--root` pins the root and disables the ancestor walk
+
+When `--root` is supplied, the resolved root is that directory after
+canonicalization, and no ancestor is examined. The value may be relative; it is
+resolved against the process working directory, which is never changed, exactly
+as every `FLAG-*-ROOT` row specifies.
+
+Rejected: treating `--root` as the starting point of the upward walk. A
+`--root` naming a subdirectory of a project would then silently retarget its
+parent. The rows say the command runs against the project "rooted there", and a
+flag whose value is a suggestion is worse than no flag: it makes an operator's
+explicit instruction unpredictable.
+
+### D5: Without `--root`, the nearest ancestor holding `.brain` wins
+
+The chain is walked nearest first. The first entry whose `.brain` is a directory
+is the project root. If no entry has one, the Git top level from D6 is the root
+if there is one, and otherwise the resolution is `not-found` at the working
+directory.
+
+The marker name is fixed, not configured. `project-config.v1.schema.json` pins
+`managedState.directory` to the constant `.brain` and `managedState.eventLog` to
+`events.jsonl`. That closes the bootstrap circle: discovery never has to read
+configuration in order to learn where configuration is.
+
+`.brain` outranks the Git top level because ADR 0003 makes state project-owned
+and project-local, and because a repository can legitimately contain several
+projects while a `.brain` names exactly one.
+
+Rejected: requiring `.brain/config.json` rather than the `.brain` directory as
+the marker. A project whose configuration file was deleted would then resolve as
+no project at all, and the catalog already distinguishes those two situations:
+`guard.config_missing` says configuration is absent, which is only expressible
+if the project was found first.
+
+Rejected: stopping the walk at the Git top level. `no_git` exists in the frozen
+catalog precisely because a project without a repository is legitimate, and a
+`.brain` above a nested repository is a real layout, not a mistake.
+
+### D6: A linked worktree resolves to the principal worktree by default
+
+`FLAG-INIT-WORKTREE-LOCAL` and `FLAG-DOCTOR-WORKTREE-LOCAL` are both boolean and
+both default to false, and both describe that default as the principal worktree:
+`init` "anchors new Brain memory beside the linked worktree instead of the
+principal worktree" only when set, and `doctor` "inspects the linked worktree's
+own Brain rather than resolving to the principal worktree memory" only when set.
+So the resolver takes a worktree mode with the value `principal` by default, and
+only a command that declares the flag may pass `local`.
+
+The two rules compose without conflict. The flag chooses where new state is
+anchored and which Brain `doctor` inspects. Every other command simply runs D5,
+so a linked worktree that was initialized locally is found by the ordinary
+nearest-marker rule, and one that was not falls through to the principal
+worktree.
+
+Rejected: making every command carry `--worktree-local`. Only two rows name it,
+and adding it to the other twenty five root-bearing commands would publish a
+flag the frozen evidence does not show, on commands whose usage text `RUN-02`
+generates from the registry.
+
+Rejected: inferring the mode from the presence of a linked `.brain`. That would
+make `doctor --worktree-local` a no-op whenever the inference already agreed and
+would silently disagree with `init`, whose flag has to be explicit because it
+decides where a directory is created rather than which of two existing ones to
+read.
+
+### D7: The legacy sibling Brain fails with `brain_migration_pending`
+
+When the resolved root has no `.brain` but a sibling `<name>-brain/.brain`
+exists, the resolution is `migration-pending`. Its reason is the frozen
+`brain_migration_pending`: status `failure`, exit 1, `stateChanged: false`,
+retryable, with the catalog recovery text "Run `yoda migrate brain` from the
+project root, verify the sibling Brain repository, and retry."
+
+Discovery reads the sibling to know it exists and does nothing else with it. It
+does not open its files, classify its contract version, or plan a migration.
+ADR 0003 and the architecture specification both require migration to be a
+user-invoked transaction and never a side effect of discovery.
+
+Note the asymmetry this preserves: an in-project `.brain` wins outright. A
+project that has already migrated is never dragged back to the sibling because
+the old directory was left in place, which is what step 8 of the migration
+sequence requires.
+
+Rejected: treating the sibling as a readable state location so ordinary commands
+keep working. The catalog gives this condition a failure status and exit 1, so
+"keep working" would contradict the one piece of frozen evidence that describes
+the situation.
+
+Rejected: `contract.state_version_unsupported`. It is the right shape for a
+persisted state contract outside the supported window, but the legacy layout is
+detected by *location*, before any state file is read or any version string is
+seen, and the catalog already has a reason that names the location problem and
+points at the exact command that fixes it.
+
+### D8: Discovery classifies, the command declares its requirement
+
+`ProjectResolution` is one of:
+
+| Variant | Meaning |
+| --- | --- |
+| `initialized` | Root found, `.brain` present, configuration resolved |
+| `root-only` | Root found, no `.brain`, no legacy sibling |
+| `migration-pending` | Root found, no `.brain`, legacy sibling present |
+| `marker-unusable` | `.brain` exists but is not a usable directory |
+| `not-found` | No root could be resolved |
+| `refused` | The supplied `--root` cannot be used |
+
+The resolver does not decide whether a variant is a failure. `init` needs
+`root-only` and would fail on `initialized` without `--merge` or `--force`;
+`status` needs `initialized`; `doctor` accepts several and reports on them.
+Each command declares its requirement in the `RUN-02` registry, which is the one
+field this issue adds to `CommandSpec`, and the shared pipeline maps an
+unsatisfied requirement to the reason in the error-handling table.
+
+Rejected: a resolver that throws when there is no project. It would force every
+command that legitimately runs without one, starting with `init`, to catch and
+reinterpret an exception, and it would put the policy in the wrong place: only
+the command knows whether an uninitialized directory is a problem or the point.
+
+### D9: Configuration precedence is defaults, then project file, then flags
+
+Three layers, lowest to highest:
+
+| Layer | Source | Scope |
+| --- | --- | --- |
+| `default` | Runtime built-in values | Every setting |
+| `project` | `.brain/config.json` | Every setting the file declares |
+| `flag` | Explicit command flags | Only the settings a flag names |
+
+There is no environment-variable layer. The architecture specification lists
+environment variables among untrusted inputs, no inventory row names an
+environment variable that configures the runtime, and a fourth layer would be a
+public contract invented rather than observed. A caller that needs to override a
+setting passes a flag, which is visible in the invocation and therefore in the
+provenance record.
+
+The concrete default values are not decided here. The schema constrains
+`language` to `en` or `pt-BR` and `policyMode` to `standard` or `strict` but
+declares no default for either, and the frozen `SCHEMA-CONFIG-SCHEMA-JSON` row
+only asserts that validation outcomes are preserved. Choosing a value would be
+choosing observable behavior with no evidence, so the default layer ships as a
+mechanism with the values owned by `CLI-INIT`.
+
+Rejected: last-writer-wins across a merged object. The provenance requirement in
+the issue asks where every resolved setting came from, and a merge that produces
+only the final object cannot answer it after the fact.
+
+### D10: Every resolved setting carries its provenance, project-relative
+
+```ts
+interface Resolved<T> {
+  readonly value: T;
+  readonly source: "default" | "project" | "flag";
+  readonly ref: string | null;   // ".brain/config.json" or "--root"
+}
+```
+
+`ref` is a project-relative path or a flag name. It is never an absolute path,
+because the result contract's output-safety rules reject absolute Unix, Windows,
+and UNC paths in public output, and provenance is meant to be rendered.
+
+The resolved root is the one absolute path in the resolution, and it is
+therefore marked as unsafe to render: a command that reports success names the
+project by its relative marker, not by the operator's home directory layout.
+`CLI-INIT` reports "the initialized root on stdout", so a future issue that
+needs to print it must decide the safe form deliberately rather than inherit an
+absolute string by accident.
+
+Rejected: provenance as a separate parallel map keyed by setting name. It can
+drift from the values it describes, and nothing would fail when it does. Binding
+the two in one type makes a value without provenance a type error.
+
+### D11: Configuration failures are ordered absence, contract, then schema
+
+1. `.brain/config.json` absent: `guard.config_missing`, exit 2.
+2. Present but unparsable as JSON: `guard.config_corrupt`, exit 2.
+3. `stateContract` missing, non-string, or untrimmed:
+   `contract.state_version_invalid`, exit 4.
+4. `stateContract` well formed but outside the supported window:
+   `contract.state_version_unsupported`, exit 4.
+5. Parsed and in window but failing the schema: `guard.config_corrupt`, exit 2.
+
+Steps 3 and 4 precede step 5 because the contract versioning guide states that
+classification happens before payload validation or mutation, and that a future
+value never selects the nearest known schema. Validating an unknown contract
+against the current schema would report a field-level error for a document that
+this runtime is not entitled to interpret at all.
+
+Step 5 calls the injected `ConfigurationValidator`; this issue does not inspect
+schema keywords or assert a `ProjectConfigV1` type. Its tests use a deterministic
+validator double and require that the double is never called for steps 1 through
+4. `RUN-04` later supplies the real registry function without changing the
+resolver or its error ordering.
+
+Rejected: validating first and classifying second, which reads more naturally
+because a malformed document is malformed either way. It produces the wrong
+public answer for a *newer* project: a field the next contract adds would be
+reported as an unknown property rather than as a state contract this runtime
+cannot read.
+
+### D12: No new reason code
+
+Every outcome above already has a name in catalog revision 1.3.
+
+| Outcome | Reason | Exit |
+| --- | --- | --- |
+| No project found | `guard.config_missing` | 2 |
+| `--root` is not a usable directory | `trail.uso` | 2 |
+| `.brain` exists but is unusable | `guard.project_marker_corrupt` | 2 |
+| Legacy sibling layout | `brain_migration_pending` | 1 |
+| Configuration absent or corrupt | `guard.config_missing`, `guard.config_corrupt` | 2 |
+| State contract invalid or unsupported | `contract.state_version_*` | 4 |
+| Unexpected throw at the edge | `runtime.internal_failure` | 2 |
+
+Two of these bindings deserve the argument rather than the assertion.
+
+`guard.config_missing` for "no project anywhere up the chain" reuses a name
+whose frozen description is "Guard evaluation cannot find required project
+configuration". The `guard.` prefix is a frozen name, not a jurisdiction: the
+condition is the absence of required project configuration, which is exactly
+what happened. A new `discovery.project_missing` would mean a catalog revision
+for an outcome the catalog can already name, and revisions 1.1 through 1.3 show
+that additions are reserved for genuinely new families.
+
+`guard.project_marker_corrupt` for a `.brain` that is a regular file, or a
+symlink resolving outside the root, is the closest frozen name and its recovery
+text, "Repair the project marker against its managed contract before rerunning
+the guard", is the correct instruction. The alternative,
+`runtime.internal_failure`, is defined as sanitized with forbidden evidence,
+which would hide a condition the operator can fix in one command.
+
+Both bindings are TypeScript-runtime decisions, not proven parity. The frozen
+provenance for `internal/guard/codes.go` is hash-only, so which file Go v3
+considered the project marker, and which code it emitted when run outside a
+project, are not observable from the inventory. They are recorded as open
+decisions and claim no row.
+
+## Components
+
+| Unit | Responsibility |
+| --- | --- |
+| `domain/project/request.ts` | `DiscoveryRequest` and worktree mode |
+| `domain/project/observation.ts` | `WorkspaceObservation` and probe types |
+| `domain/project/resolve.ts` | `resolveProject`, root selection, precedence |
+| `domain/project/config.ts` | Layered configuration and `Resolved<T>` |
+| `domain/project/validation.ts` | Pure validator seam consumed by discovery and implemented by `RUN-04` |
+| `domain/project/reasons.ts` | Resolution variant to reason-code mapping |
+| `ports/index.ts` | `Workspace` interface added to `RuntimePorts` |
+| `infra/node/workspace.ts` | Ancestor walk, canonicalization, worktree query |
+| `infra/fake/workspace.ts` | In-memory tree honouring the same contract |
+| `composition/discovery.ts` | `observeWorkspace` and the two-phase wiring |
+
+`domain/project/**` imports no Node builtin and calls no port, so the
+architecture test already in place covers it without a new rule.
+
+## Error handling
+
+| Condition | Detected in | Reason | Exit |
+| --- | --- | --- | --- |
+| `--root` empty or malformed | `RUN-02` parser | `trail.uso` | 2 |
+| `--root` absent, unreadable, or not a directory | `resolveProject` | `trail.uso` | 2 |
+| `--root` cannot be canonicalized | `observeWorkspace` | `trail.uso` | 2 |
+| No `.brain` and no Git top level | `resolveProject` | `guard.config_missing` | 2 |
+| `.brain` is a file or escapes the root | `resolveProject` | `guard.project_marker_corrupt` | 2 |
+| Legacy sibling Brain present | `resolveProject` | `brain_migration_pending` | 1 |
+| `.brain/config.json` absent | `resolveProject` | `guard.config_missing` | 2 |
+| Configuration unparsable or schema invalid | `resolveProject` | `guard.config_corrupt` | 2 |
+| `stateContract` malformed | `resolveProject` | `contract.state_version_invalid` | 4 |
+| `stateContract` out of window | `resolveProject` | `contract.state_version_unsupported` | 4 |
+| Filesystem error during observation | `observeWorkspace` | `runtime.internal_failure` | 2 |
+
+Every one of these is `stateChanged: false`, which is not a claim the resolver
+has to make carefully: the bootstrap composition holds no writing port, so no
+discovery failure has anything to declare.
+
+No message echoes the supplied `--root` value or any absolute path. That is the
+same rule `RUN-02` applies to arguments, for the same reason: a misdirected root
+is exactly the input most likely to contain a home directory or a client name.
+
+An escaping symlink is refused, never clamped. `RUN-01` established that rule
+for managed paths, and relaxing it for the root would let a `.brain` symlink
+redirect the whole project silently.
+
+## Testing
+
+| Level | Proves |
+| --- | --- |
+| Resolver unit | Each variant, from literal observations, with no filesystem |
+| Precedence table | Every layer combination resolves to one value and one source |
+| Failure ordering | Contract classification precedes schema validation |
+| Port contract | The Node and fake `Workspace` agree on one shared suite |
+| Property | Canonicalization is idempotent and never yields a path above the root |
+| Property | Traversal, control characters, and empty segments are refused |
+| Integration | Ordinary repository, nested directory, worktree, detached HEAD |
+| Integration | Spaces, Unicode, symlink inside root, symlink escaping root |
+| Integration | Non-repository directory, and repository with no `.brain` |
+| Non-mutation | A full discovery run touches no writing port and creates no file |
+| Determinism | The same tree and request resolve identically across runs |
+
+The detached-HEAD case asserts something specific: the resolved root is
+*identical* to the attached case. Discovery must not depend on HEAD, and a test
+that merely runs in detached HEAD without asserting equality would pass even if
+it did.
+
+The non-mutation test is the one that must be proven non-vacuous, in the way
+`RUN-01` required of the architecture test and `RUN-02` of the help snapshot. It
+runs against a recording filesystem that fails the test if any write, remove, or
+directory creation is observed, and a fixture that deliberately writes has to
+make it fail.
+
+Property tests generate path segments including `..`, `.`, empty strings, NUL
+and other control characters, backslashes, drive-qualified prefixes, and
+combining Unicode, and assert that no generated input resolves to a root outside
+the canonical start.
+
+Coverage for `domain/project/**` and `composition/discovery.ts` is 100%, which
+the existing gate already requires of `domain/**` and `composition/**`.
+`infra/node/workspace.ts` is proven by the shared port contract suite and stays
+outside the gate, on the same reasoning `RUN-01` recorded: forcing 100% on real
+I/O error paths invites defensive branches written for a threshold.
+
+## Compatibility impact
+
+Parity remains `0 / 400 (0.00%)`. No row moves.
+
+The rows this work touches and deliberately does not claim:
+
+| Row | Why it does not move |
+| --- | --- |
+| `FLAG-*-ROOT` (27 rows) | Each belongs to its command; no command is registered here |
+| `FLAG-INIT-WORKTREE-LOCAL` | Requires `init`, which this issue does not implement |
+| `FLAG-DOCTOR-WORKTREE-LOCAL` | Requires `doctor`, likewise |
+| `PKG-INTERNAL-BRAIN` | Layout ownership extends far past discovery |
+| `PKG-INTERNAL-CONFIG` | Configuration writing and generation are not here |
+| `PKG-INTERNAL-DETECT` | Stack detection is a separate concern; see below |
+| `REASON-BRAIN-MIGRATION-PENDING` | Emitted here, but the row needs the four evidence kinds and `migrate brain` |
+| `FILE-BRAIN-CONFIG-JSON` | Discovery reads it; generation is `CLI-INIT` |
+
+A row counts only when unit, differential, integration, and end-to-end evidence
+all pass. This issue produces unit, property, and integration evidence for
+internal structure and no differential or end-to-end evidence against the frozen
+oracle, so claiming any of the rows above would overstate the work.
+
+`PKG-INTERNAL-DETECT` deserves a note because `FLAG-INIT-DETECT-ROOT` is easy to
+confuse with discovery. The row is explicit that it "selects only stack
+detection, not where Brain memory is stored". It is a different root, resolved
+for a different purpose, and it is not part of this design.
+
+No shipped behavior changes. The bundle's public surface is unchanged, because
+no command consumes the resolver yet.
+
+## Open decisions recorded rather than deferred
+
+**The frozen ancestor walk is not observable.** Every `--root` row documents the
+default as "current directory" and `CLI-GLOBAL-REQUIRE-CONTRACT` lists
+"commands executed from a subdirectory" as an edge case, which together prove
+that Go v3 resolves *something* from a nested directory, but not what. The
+legacy references are hash-only provenance, so the stop condition, the order of
+marker and repository checks, and the behavior at a filesystem boundary are all
+undetermined. D5 is therefore the TypeScript runtime's rule, documented as such,
+and no parity is claimed for it. An authorized oracle observation of `yoda
+status` from a nested directory, from a directory whose parent has a `.brain`,
+and from inside a nested repository would settle it.
+
+**Which file Go v3 treated as the project marker.** The reason code
+`guard.project_marker_corrupt` comes from `internal/guard/codes.go` with
+hash-only provenance. Binding it to `.brain` is the reading that fits its
+recovery text, and it is recorded as a binding rather than a fact. The same
+oracle run against a project whose `.brain` is a regular file would confirm or
+replace it.
+
+**The reason for running outside any project.** `guard.config_missing` is the
+closest frozen name, but no row states which code Go v3 emitted when no project
+existed at all. If an oracle observation shows a different code, this is a
+one-line change in `domain/project/reasons.ts` and no other module.
+
+**Tie-break when the principal and a linked worktree both hold `.brain`.** D5
+resolves to the nearest, which for a command run inside the linked worktree is
+the linked one. The frozen evidence covers only where new state is *anchored*
+and which Brain `doctor` *inspects*, not which one an ordinary command in a
+linked worktree reads when both exist. The nearest-marker rule is the
+consistent extension of D5 rather than an observed behavior, and it is recorded
+here so a future oracle observation can correct it in one place.
+
+**Default configuration values.** Deliberately unset, per D9. The default layer
+exists and is exercised by tests using fixture values; the shipped values arrive
+with `CLI-INIT`, which is the row that owns what a new project contains.
+
+**Unsupported filesystems.** The issue lists them among the conditions to defend
+against. What this design provides is a refusal for any path that cannot be
+canonicalized and a resolution that never depends on symlink support. It does
+not classify a filesystem, because no reason code names that outcome and adding
+one would require a catalog revision justified by no evidence. If a real
+platform failure appears in integration testing, it arrives as a filesystem
+error and renders as `runtime.internal_failure` until an authorized observation
+justifies better.
+
+**Where `Workspace` lives.** In `packages/runtime/src/ports/` alongside the
+other seven, not in a new package. The reasoning `RUN-01` recorded still holds:
+the only consumer is the runtime, and `ADP-01` may extract the set when a second
+consumer genuinely exists.

--- a/docs/superpowers/specs/2026-08-07-project-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-07-project-discovery-design.md
@@ -285,6 +285,7 @@ points at the exact command that fixes it.
 | `root-only` | Root found, no `.brain`, no legacy sibling |
 | `migration-pending` | Root found, no `.brain`, legacy sibling present |
 | `marker-unusable` | `.brain` exists but is not a usable directory |
+| `configuration-unusable` | Root and `.brain` found, but configuration classification or validation failed |
 | `not-found` | No root could be resolved |
 | `refused` | The supplied `--root` cannot be used |
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -14,7 +14,8 @@
     "./infra/fake": "./src/infra/fake/index.ts",
     "./infra/node": "./src/infra/node/index.ts",
     "./composition": "./src/composition/index.ts",
-    "./composition/cli": "./src/composition/cli.ts"
+    "./composition/cli": "./src/composition/cli.ts",
+    "./composition/discovery": "./src/composition/discovery.ts"
   },
   "dependencies": {
     "@mestre-yoda/contracts": "0.0.0-development"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,6 +9,7 @@
     "./ports": "./src/ports/index.ts",
     "./domain/effects": "./src/domain/effects.ts",
     "./domain/cli": "./src/domain/cli/index.ts",
+    "./domain/project": "./src/domain/project/index.ts",
     "./domain/result": "./src/domain/result/index.ts",
     "./infra/fake": "./src/infra/fake/index.ts",
     "./infra/node": "./src/infra/node/index.ts",

--- a/packages/runtime/src/composition/discovery.ts
+++ b/packages/runtime/src/composition/discovery.ts
@@ -1,0 +1,91 @@
+import {
+  resolveProject,
+  type ConfigurationValidator,
+  type DiscoveryRequest,
+  type ProjectResolution,
+  type WorkspaceObservation,
+} from "../domain/project/index.js";
+import { nodeEnvironment, nodeWorkspace } from "../infra/node/index.js";
+import type { Environment, Workspace } from "../ports/index.js";
+
+export interface DiscoveryPorts {
+  readonly workspace: Workspace;
+  readonly environment: Environment;
+}
+
+export function createDiscoveryPorts(
+  overrides: Partial<DiscoveryPorts> = {},
+): DiscoveryPorts {
+  return {
+    workspace: nodeWorkspace(),
+    environment: nodeEnvironment(),
+    ...overrides,
+  };
+}
+
+/** Collect every read-only fact needed by the pure resolver. */
+export async function observeWorkspace(
+  request: DiscoveryRequest,
+  ports: DiscoveryPorts,
+): Promise<WorkspaceObservation> {
+  const processWorkingDirectory = ports.environment.workingDirectory();
+  const canonicalWorkingDirectory = await ports.workspace.canonicalize(
+    request.workingDirectory,
+    processWorkingDirectory,
+  );
+  if (request.explicitRoot !== null) {
+    const canonicalExplicitRoot = await ports.workspace.canonicalize(
+      request.explicitRoot,
+      processWorkingDirectory,
+    );
+    return {
+      canonicalWorkingDirectory,
+      canonicalExplicitRoot,
+      ancestors:
+        canonicalExplicitRoot === null
+          ? []
+          : [await ports.workspace.inspect(canonicalExplicitRoot)],
+      principalAncestors: [],
+      worktree: null,
+    };
+  }
+  if (canonicalWorkingDirectory === null) {
+    return {
+      canonicalWorkingDirectory: null,
+      canonicalExplicitRoot: null,
+      ancestors: [],
+      principalAncestors: [],
+      worktree: null,
+    };
+  }
+  const [ancestors, worktree] = await Promise.all([
+    ports.workspace.ancestors(canonicalWorkingDirectory),
+    ports.workspace.locateWorktree(canonicalWorkingDirectory),
+  ]);
+  const principalAncestors =
+    worktree?.kind === "linked" && request.worktreeMode === "principal"
+      ? await ports.workspace.ancestors(worktree.principal)
+      : [];
+  return {
+    canonicalWorkingDirectory,
+    canonicalExplicitRoot: null,
+    ancestors,
+    principalAncestors,
+    worktree,
+  };
+}
+
+/** Observe and resolve without ever composing a mutation port. */
+export async function discoverProject(
+  request: DiscoveryRequest,
+  ports: DiscoveryPorts,
+  validateConfiguration: ConfigurationValidator,
+): Promise<ProjectResolution> {
+  return resolveProject(
+    request,
+    await observeWorkspace(request, ports),
+    validateConfiguration,
+  );
+}
+
+export { createRuntimeAt } from "./index.js";

--- a/packages/runtime/src/composition/index.ts
+++ b/packages/runtime/src/composition/index.ts
@@ -22,6 +22,14 @@ export function createRuntime(
   overrides: Partial<RuntimePorts> = {},
 ): RuntimePorts {
   const root = overrides.environment?.workingDirectory() ?? process.cwd();
+  return createRuntimeAt(root, overrides);
+}
+
+/** Compose mutation ports only after project discovery selects a root. */
+export function createRuntimeAt(
+  root: string,
+  overrides: Partial<RuntimePorts> = {},
+): RuntimePorts {
   return {
     clock: nodeClock(),
     ids: nodeIds(),

--- a/packages/runtime/src/domain/project/configuration.ts
+++ b/packages/runtime/src/domain/project/configuration.ts
@@ -1,0 +1,70 @@
+import {
+  classifyContractVersion,
+  type ProjectConfigV1,
+} from "@mestre-yoda/contracts";
+
+import type { ConfigurationObservation } from "./observation.js";
+import type { ConfigurationValidator } from "./validation.js";
+
+type ConfigurationFailureReason =
+  | "guard.config_missing"
+  | "guard.config_corrupt"
+  | "contract.state_version_invalid"
+  | "contract.state_version_unsupported";
+
+export type ConfigurationOutcome =
+  | { readonly kind: "valid"; readonly value: ProjectConfigV1 }
+  | {
+      readonly kind: "failure";
+      readonly reasonCode: ConfigurationFailureReason;
+    };
+
+function failure(reasonCode: ConfigurationFailureReason): ConfigurationOutcome {
+  return { kind: "failure", reasonCode };
+}
+
+function stateContract(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return (value as Record<string, unknown>).stateContract;
+}
+
+/** Parse, classify, and validate a project configuration without mutation. */
+export function classifyConfiguration(
+  observation: ConfigurationObservation,
+  validate: ConfigurationValidator,
+): ConfigurationOutcome {
+  if (observation.kind === "absent") {
+    return failure("guard.config_missing");
+  }
+  if (observation.kind === "other") {
+    return failure("guard.config_corrupt");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(observation.text) as unknown;
+  } catch {
+    return failure("guard.config_corrupt");
+  }
+
+  const classification = classifyContractVersion(
+    "state",
+    stateContract(parsed),
+  );
+  if (classification.classification === "invalid") {
+    return failure("contract.state_version_invalid");
+  }
+  if (
+    classification.classification === "unsupported" ||
+    classification.classification === "migration_required"
+  ) {
+    return failure("contract.state_version_unsupported");
+  }
+
+  const validated = validate(parsed);
+  return validated.kind === "valid"
+    ? validated
+    : failure("guard.config_corrupt");
+}

--- a/packages/runtime/src/domain/project/index.ts
+++ b/packages/runtime/src/domain/project/index.ts
@@ -10,6 +10,7 @@ export type {
   WorktreeLocation,
 } from "./observation.js";
 export type { DiscoveryRequest, WorktreeMode } from "./request.js";
+export { resolveProject } from "./resolve.js";
 export { resolveRoot } from "./resolve-root.js";
 export type { RootSelection } from "./resolve-root.js";
 export type { ProjectResolution } from "./resolution.js";

--- a/packages/runtime/src/domain/project/index.ts
+++ b/packages/runtime/src/domain/project/index.ts
@@ -6,6 +6,8 @@ export type {
   WorktreeLocation,
 } from "./observation.js";
 export type { DiscoveryRequest, WorktreeMode } from "./request.js";
+export { resolveRoot } from "./resolve-root.js";
+export type { RootSelection } from "./resolve-root.js";
 export type { ProjectResolution } from "./resolution.js";
 export type {
   ConfigurationValidation,

--- a/packages/runtime/src/domain/project/index.ts
+++ b/packages/runtime/src/domain/project/index.ts
@@ -1,0 +1,13 @@
+export type {
+  BrainMarker,
+  ConfigurationObservation,
+  DirectoryProbe,
+  WorkspaceObservation,
+  WorktreeLocation,
+} from "./observation.js";
+export type { DiscoveryRequest, WorktreeMode } from "./request.js";
+export type { ProjectResolution } from "./resolution.js";
+export type {
+  ConfigurationValidation,
+  ConfigurationValidator,
+} from "./validation.js";

--- a/packages/runtime/src/domain/project/index.ts
+++ b/packages/runtime/src/domain/project/index.ts
@@ -1,5 +1,7 @@
 export { classifyConfiguration } from "./configuration.js";
 export type { ConfigurationOutcome } from "./configuration.js";
+export { resolveConfigurationLayers } from "./layers.js";
+export type { ConfigurationLayers, FlagValue, Resolved } from "./layers.js";
 export type {
   BrainMarker,
   ConfigurationObservation,

--- a/packages/runtime/src/domain/project/index.ts
+++ b/packages/runtime/src/domain/project/index.ts
@@ -1,3 +1,5 @@
+export { classifyConfiguration } from "./configuration.js";
+export type { ConfigurationOutcome } from "./configuration.js";
 export type {
   BrainMarker,
   ConfigurationObservation,

--- a/packages/runtime/src/domain/project/layers.ts
+++ b/packages/runtime/src/domain/project/layers.ts
@@ -1,0 +1,73 @@
+export interface Resolved<T> {
+  readonly value: T;
+  readonly source: "default" | "project" | "flag";
+  readonly ref: string | null;
+}
+
+export interface FlagValue<T> {
+  readonly value: T;
+  readonly ref: string;
+}
+
+export interface ConfigurationLayers<T extends object> {
+  readonly defaults: Partial<T>;
+  readonly project: Partial<T>;
+  readonly flags: Partial<{ [K in keyof T]: FlagValue<T[K]> }>;
+}
+
+type ResolvedKeys<T extends object, K extends readonly (keyof T & string)[]> = {
+  readonly [P in K[number]]: Resolved<T[P]>;
+};
+
+function invalid(): never {
+  throw new Error("Configuration layers are invalid");
+}
+
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+/** Apply closed configuration layers while preserving the winning source. */
+export function resolveConfigurationLayers<
+  T extends object,
+  const K extends readonly (keyof T & string)[],
+>(keys: K, layers: ConfigurationLayers<T>): ResolvedKeys<T, K> {
+  const allowed = new Set<string>(keys);
+  for (const layer of [layers.defaults, layers.project, layers.flags]) {
+    if (Object.keys(layer).some((key) => !allowed.has(key))) invalid();
+  }
+
+  const resolved: Record<string, Resolved<unknown>> = {};
+  for (const key of keys) {
+    let value: unknown;
+    let source: Resolved<unknown>["source"];
+    let ref: string | null;
+
+    if (hasOwn(layers.flags, key)) {
+      const selected = layers.flags[key];
+      if (
+        selected?.value === undefined ||
+        !/^--[a-z][a-z0-9-]*$/u.test(selected.ref)
+      ) {
+        invalid();
+      }
+      value = selected.value;
+      source = "flag";
+      ref = selected.ref;
+    } else if (hasOwn(layers.project, key)) {
+      value = layers.project[key];
+      if (value === undefined) invalid();
+      source = "project";
+      ref = ".brain/config.json";
+    } else if (hasOwn(layers.defaults, key)) {
+      value = layers.defaults[key];
+      if (value === undefined) invalid();
+      source = "default";
+      ref = null;
+    } else {
+      throw new Error("Configuration layers are incomplete");
+    }
+    resolved[key] = { value, source, ref };
+  }
+  return resolved as ResolvedKeys<T, K>;
+}

--- a/packages/runtime/src/domain/project/observation.ts
+++ b/packages/runtime/src/domain/project/observation.ts
@@ -1,7 +1,8 @@
 export type BrainMarker = "absent" | "directory" | "other" | "escaping";
 
 export type ConfigurationObservation =
-  | { readonly kind: "absent" | "other" }
+  | { readonly kind: "absent" }
+  | { readonly kind: "other" }
   | { readonly kind: "file"; readonly text: string };
 
 /** One canonical ancestor inspected without interpreting its contents. */

--- a/packages/runtime/src/domain/project/observation.ts
+++ b/packages/runtime/src/domain/project/observation.ts
@@ -1,0 +1,31 @@
+export type BrainMarker = "absent" | "directory" | "other" | "escaping";
+
+export type ConfigurationObservation =
+  | { readonly kind: "absent" | "other" }
+  | { readonly kind: "file"; readonly text: string };
+
+/** One canonical ancestor inspected without interpreting its contents. */
+export interface DirectoryProbe {
+  /** Internal absolute path. It must never be copied to public output. */
+  readonly path: string;
+  readonly brain: BrainMarker;
+  readonly git: "absent" | "present";
+  readonly legacyBrain: boolean;
+  readonly configuration: ConfigurationObservation;
+}
+
+export interface WorktreeLocation {
+  readonly kind: "principal" | "linked";
+  /** Internal absolute path. It must never be copied to public output. */
+  readonly topLevel: string;
+  /** Internal absolute path. It must never be copied to public output. */
+  readonly principal: string;
+}
+
+/** Read-only facts collected by a Workspace adapter. */
+export interface WorkspaceObservation {
+  readonly canonicalWorkingDirectory: string | null;
+  readonly canonicalExplicitRoot: string | null;
+  readonly ancestors: readonly DirectoryProbe[];
+  readonly worktree: WorktreeLocation | null;
+}

--- a/packages/runtime/src/domain/project/observation.ts
+++ b/packages/runtime/src/domain/project/observation.ts
@@ -27,5 +27,7 @@ export interface WorkspaceObservation {
   readonly canonicalWorkingDirectory: string | null;
   readonly canonicalExplicitRoot: string | null;
   readonly ancestors: readonly DirectoryProbe[];
+  /** Principal-worktree chain, populated only for linked worktrees. */
+  readonly principalAncestors: readonly DirectoryProbe[];
   readonly worktree: WorktreeLocation | null;
 }

--- a/packages/runtime/src/domain/project/request.ts
+++ b/packages/runtime/src/domain/project/request.ts
@@ -1,0 +1,9 @@
+/** Whether linked-worktree discovery may fall back to the principal worktree. */
+export type WorktreeMode = "principal" | "local";
+
+/** Untrusted invocation context supplied to project discovery. */
+export interface DiscoveryRequest {
+  readonly workingDirectory: string;
+  readonly explicitRoot: string | null;
+  readonly worktreeMode: WorktreeMode;
+}

--- a/packages/runtime/src/domain/project/resolution.ts
+++ b/packages/runtime/src/domain/project/resolution.ts
@@ -1,0 +1,26 @@
+import type { ProjectConfigV1 } from "@mestre-yoda/contracts";
+
+interface Rooted {
+  /** Internal absolute path. It must never be copied to public output. */
+  readonly root: string;
+}
+
+export type ProjectResolution =
+  | (Rooted & {
+      readonly kind: "initialized";
+      readonly configuration: ProjectConfigV1;
+    })
+  | (Rooted & { readonly kind: "root-only" })
+  | (Rooted & {
+      readonly kind: "migration-pending";
+      readonly reasonCode: "brain_migration_pending";
+    })
+  | (Rooted & {
+      readonly kind: "marker-unusable";
+      readonly reasonCode: "guard.project_marker_corrupt";
+    })
+  | {
+      readonly kind: "not-found";
+      readonly reasonCode: "guard.config_missing";
+    }
+  | { readonly kind: "refused"; readonly reasonCode: "trail.uso" };

--- a/packages/runtime/src/domain/project/resolution.ts
+++ b/packages/runtime/src/domain/project/resolution.ts
@@ -19,6 +19,14 @@ export type ProjectResolution =
       readonly kind: "marker-unusable";
       readonly reasonCode: "guard.project_marker_corrupt";
     })
+  | (Rooted & {
+      readonly kind: "configuration-unusable";
+      readonly reasonCode:
+        | "guard.config_missing"
+        | "guard.config_corrupt"
+        | "contract.state_version_invalid"
+        | "contract.state_version_unsupported";
+    })
   | {
       readonly kind: "not-found";
       readonly reasonCode: "guard.config_missing";

--- a/packages/runtime/src/domain/project/resolve-root.ts
+++ b/packages/runtime/src/domain/project/resolve-root.ts
@@ -1,0 +1,101 @@
+import type { WorkspaceObservation, DirectoryProbe } from "./observation.js";
+import type { DiscoveryRequest } from "./request.js";
+
+export type RootSelection =
+  | {
+      readonly kind: "selected";
+      readonly root: string;
+      readonly probe: DirectoryProbe;
+    }
+  | { readonly kind: "root-only"; readonly root: string }
+  | {
+      readonly kind: "migration-pending";
+      readonly root: string;
+      readonly reasonCode: "brain_migration_pending";
+    }
+  | {
+      readonly kind: "marker-unusable";
+      readonly root: string;
+      readonly reasonCode: "guard.project_marker_corrupt";
+    }
+  | {
+      readonly kind: "not-found";
+      readonly reasonCode: "guard.config_missing";
+    }
+  | { readonly kind: "refused"; readonly reasonCode: "trail.uso" };
+
+function classify(probe: DirectoryProbe): RootSelection | null {
+  if (probe.brain === "directory") {
+    return { kind: "selected", root: probe.path, probe };
+  }
+  if (probe.brain === "other" || probe.brain === "escaping") {
+    return {
+      kind: "marker-unusable",
+      root: probe.path,
+      reasonCode: "guard.project_marker_corrupt",
+    };
+  }
+  if (probe.legacyBrain) {
+    return {
+      kind: "migration-pending",
+      root: probe.path,
+      reasonCode: "brain_migration_pending",
+    };
+  }
+  return null;
+}
+
+function scan(probes: readonly DirectoryProbe[]): RootSelection | null {
+  for (const probe of probes) {
+    const selection = classify(probe);
+    if (selection !== null) return selection;
+  }
+  return null;
+}
+
+/** Select one canonical root without reading or mutating the workspace. */
+export function resolveRoot(
+  request: DiscoveryRequest,
+  observation: WorkspaceObservation,
+): RootSelection {
+  if (request.explicitRoot !== null) {
+    if (observation.canonicalExplicitRoot === null) {
+      return { kind: "refused", reasonCode: "trail.uso" };
+    }
+    const probe = observation.ancestors.find(
+      ({ path }) => path === observation.canonicalExplicitRoot,
+    );
+    if (probe === undefined) {
+      return { kind: "refused", reasonCode: "trail.uso" };
+    }
+    return classify(probe) ?? { kind: "root-only", root: probe.path };
+  }
+
+  if (observation.canonicalWorkingDirectory === null) {
+    return { kind: "refused", reasonCode: "trail.uso" };
+  }
+  const local = scan(observation.ancestors);
+  if (local !== null) return local;
+
+  if (
+    observation.worktree?.kind === "linked" &&
+    request.worktreeMode === "principal"
+  ) {
+    const principal = scan(observation.principalAncestors);
+    return (
+      principal ?? {
+        kind: "root-only",
+        root: observation.worktree.principal,
+      }
+    );
+  }
+
+  if (observation.worktree !== null) {
+    return { kind: "root-only", root: observation.worktree.topLevel };
+  }
+  const gitRoot = observation.ancestors.find(({ git }) => git === "present");
+  if (gitRoot !== undefined) {
+    return { kind: "root-only", root: gitRoot.path };
+  }
+  return { kind: "not-found", reasonCode: "guard.config_missing" };
+}

--- a/packages/runtime/src/domain/project/resolve-root.ts
+++ b/packages/runtime/src/domain/project/resolve-root.ts
@@ -95,7 +95,11 @@ export function resolveRoot(
   }
   const gitRoot = observation.ancestors.find(({ git }) => git === "present");
   if (gitRoot !== undefined) {
-    return { kind: "root-only", root: gitRoot.path };
+    return {
+      kind: "marker-unusable",
+      root: gitRoot.path,
+      reasonCode: "guard.project_marker_corrupt",
+    };
   }
   return { kind: "not-found", reasonCode: "guard.config_missing" };
 }

--- a/packages/runtime/src/domain/project/resolve.ts
+++ b/packages/runtime/src/domain/project/resolve.ts
@@ -1,0 +1,32 @@
+import { classifyConfiguration } from "./configuration.js";
+import type { WorkspaceObservation } from "./observation.js";
+import type { DiscoveryRequest } from "./request.js";
+import { resolveRoot } from "./resolve-root.js";
+import type { ProjectResolution } from "./resolution.js";
+import type { ConfigurationValidator } from "./validation.js";
+
+/** Resolve one complete project answer from inert observations. */
+export function resolveProject(
+  request: DiscoveryRequest,
+  observation: WorkspaceObservation,
+  validateConfiguration: ConfigurationValidator,
+): ProjectResolution {
+  const root = resolveRoot(request, observation);
+  if (root.kind !== "selected") return root;
+  const configuration = classifyConfiguration(
+    root.probe.configuration,
+    validateConfiguration,
+  );
+  if (configuration.kind === "failure") {
+    return {
+      kind: "configuration-unusable",
+      root: root.root,
+      reasonCode: configuration.reasonCode,
+    };
+  }
+  return {
+    kind: "initialized",
+    root: root.root,
+    configuration: configuration.value,
+  };
+}

--- a/packages/runtime/src/domain/project/validation.ts
+++ b/packages/runtime/src/domain/project/validation.ts
@@ -1,0 +1,10 @@
+import type { ProjectConfigV1 } from "@mestre-yoda/contracts";
+
+export type ConfigurationValidation =
+  | { readonly kind: "valid"; readonly value: ProjectConfigV1 }
+  | { readonly kind: "invalid" };
+
+/** Pure seam implemented by the schema registry owned by RUN-04. */
+export type ConfigurationValidator = (
+  value: unknown,
+) => ConfigurationValidation;

--- a/packages/runtime/src/infra/fake/index.ts
+++ b/packages/runtime/src/infra/fake/index.ts
@@ -1,3 +1,10 @@
+import { posix } from "node:path";
+
+import type {
+  ConfigurationObservation,
+  DirectoryProbe,
+  WorktreeLocation,
+} from "../../domain/project/index.js";
 import type {
   Clock,
   Environment,
@@ -9,6 +16,7 @@ import type {
   Locks,
   Output,
   RepositoryState,
+  Workspace,
 } from "../../ports/index.js";
 
 /**
@@ -256,5 +264,146 @@ export function recordingOutput(): RecordingOutput {
     human: (text) => humanLines.push(text),
     structured_: structuredLines,
     human_: humanLines,
+  };
+}
+
+export interface MemoryWorkspaceSeed {
+  readonly directories?: readonly string[];
+  readonly files?: Readonly<Record<string, string>>;
+  readonly symlinks?: Readonly<Record<string, string>>;
+  readonly gitRoots?: readonly string[];
+  readonly worktrees?: readonly WorktreeLocation[];
+}
+
+function unsafeWorkspacePath(path: string): boolean {
+  let control = false;
+  for (const character of path) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) control = true;
+  }
+  return (
+    path.length === 0 ||
+    path.includes("\\") ||
+    /^[A-Za-z]:/u.test(path) ||
+    control
+  );
+}
+
+/** Deterministic read-only workspace observations over an inert POSIX tree. */
+export function memoryWorkspace(seed: MemoryWorkspaceSeed = {}): Workspace {
+  const directories = new Set<string>(["/"]);
+  const files = new Map<string, string>();
+  const symlinks = new Map<string, string>();
+  const gitRoots = new Set(
+    (seed.gitRoots ?? []).map((path) => posix.resolve(path)),
+  );
+  const worktrees = [...(seed.worktrees ?? [])];
+
+  function addParents(path: string): void {
+    let current = posix.dirname(path);
+    for (;;) {
+      directories.add(current);
+      const parent = posix.dirname(current);
+      if (parent === current) return;
+      current = parent;
+    }
+  }
+
+  for (const path of seed.directories ?? []) {
+    const absolute = posix.resolve(path);
+    directories.add(absolute);
+    addParents(absolute);
+  }
+  for (const [path, content] of Object.entries(seed.files ?? {})) {
+    const absolute = posix.resolve(path);
+    files.set(absolute, content);
+    addParents(absolute);
+  }
+  for (const [path, target] of Object.entries(seed.symlinks ?? {})) {
+    const absolute = posix.resolve(path);
+    symlinks.set(absolute, posix.resolve(posix.dirname(absolute), target));
+    addParents(absolute);
+  }
+
+  function canonicalize(path: string, base: string): string | null {
+    if (unsafeWorkspacePath(path) || unsafeWorkspacePath(base)) return null;
+    const absolute = posix.resolve(base, path);
+    const target = symlinks.get(absolute) ?? absolute;
+    return directories.has(target) ? target : null;
+  }
+
+  function inside(root: string, candidate: string): boolean {
+    const relative = posix.relative(root, candidate);
+    return (
+      relative === "" || (!relative.startsWith("../") && relative !== "..")
+    );
+  }
+
+  function configuration(
+    marker: string,
+    brain: DirectoryProbe["brain"],
+  ): ConfigurationObservation {
+    if (brain !== "directory") return { kind: "absent" };
+    const target = symlinks.get(marker) ?? marker;
+    const config = posix.join(target, "config.json");
+    const text = files.get(config);
+    if (text !== undefined) return { kind: "file", text };
+    return directories.has(config) ? { kind: "other" } : { kind: "absent" };
+  }
+
+  function inspect(path: string): DirectoryProbe {
+    const marker = posix.join(path, ".brain");
+    const linked = symlinks.get(marker);
+    let brain: DirectoryProbe["brain"];
+    if (linked !== undefined) {
+      brain = !inside(path, linked)
+        ? "escaping"
+        : directories.has(linked)
+          ? "directory"
+          : "other";
+    } else if (directories.has(marker)) {
+      brain = "directory";
+    } else if (files.has(marker)) {
+      brain = "other";
+    } else {
+      brain = "absent";
+    }
+    const legacy = posix.join(
+      posix.dirname(path),
+      `${posix.basename(path)}-brain`,
+      ".brain",
+    );
+    return {
+      path,
+      brain,
+      git: gitRoots.has(path) ? "present" : "absent",
+      legacyBrain: directories.has(legacy),
+      configuration: configuration(marker, brain),
+    };
+  }
+
+  return {
+    canonicalize: (path, base) => Promise.resolve(canonicalize(path, base)),
+    ancestors: (start) => {
+      const canonical = canonicalize(start, start);
+      if (canonical === null) return Promise.resolve([]);
+      const probes: DirectoryProbe[] = [];
+      let current = canonical;
+      for (;;) {
+        probes.push(inspect(current));
+        const parent = posix.dirname(current);
+        if (parent === current) break;
+        current = parent;
+      }
+      return Promise.resolve(probes);
+    },
+    locateWorktree: (start) => {
+      const canonical = canonicalize(start, start);
+      if (canonical === null) return Promise.resolve(null);
+      const location = worktrees
+        .filter(({ topLevel }) => inside(topLevel, canonical))
+        .sort((left, right) => right.topLevel.length - left.topLevel.length)[0];
+      return Promise.resolve(location ?? null);
+    },
   };
 }

--- a/packages/runtime/src/infra/fake/index.ts
+++ b/packages/runtime/src/infra/fake/index.ts
@@ -384,6 +384,12 @@ export function memoryWorkspace(seed: MemoryWorkspaceSeed = {}): Workspace {
 
   return {
     canonicalize: (path, base) => Promise.resolve(canonicalize(path, base)),
+    inspect: (path) =>
+      deferred(() => {
+        const canonical = canonicalize(path, path);
+        if (canonical === null) throw new Error("Workspace path is unusable");
+        return inspect(canonical);
+      }),
     ancestors: (start) => {
       const canonical = canonicalize(start, start);
       if (canonical === null) return Promise.resolve([]);

--- a/packages/runtime/src/infra/node/index.ts
+++ b/packages/runtime/src/infra/node/index.ts
@@ -26,6 +26,8 @@ import type {
   RepositoryState,
 } from "../../ports/index.js";
 
+export { nodeWorkspace } from "./workspace.js";
+
 const run = promisify(execFile);
 
 export function nodeClock(): Clock {

--- a/packages/runtime/src/infra/node/workspace.ts
+++ b/packages/runtime/src/infra/node/workspace.ts
@@ -146,6 +146,11 @@ export function nodeWorkspace(): Workspace {
 
   return {
     canonicalize,
+    inspect: async (path) => {
+      const canonical = await canonicalize(path, path);
+      if (canonical === null) throw new Error("Workspace path is unusable");
+      return probe(canonical);
+    },
     ancestors: async (start) => {
       const canonical = await canonicalize(start, start);
       if (canonical === null) return [];

--- a/packages/runtime/src/infra/node/workspace.ts
+++ b/packages/runtime/src/infra/node/workspace.ts
@@ -129,6 +129,12 @@ async function gitOutput(
   }
 }
 
+function principalFromWorktreeList(output: string): string | null {
+  const field = output.split("\0", 1)[0];
+  const prefix = "worktree ";
+  return field?.startsWith(prefix) === true ? field.slice(prefix.length) : null;
+}
+
 /** Real read-only workspace observations before a project root is trusted. */
 export function nodeWorkspace(): Workspace {
   const canonicalize = async (
@@ -139,8 +145,9 @@ export function nodeWorkspace(): Workspace {
     try {
       const candidate = await realpath(resolve(base, path));
       return (await stat(candidate)).isDirectory() ? candidate : null;
-    } catch {
-      return null;
+    } catch (error) {
+      if (absent(error)) return null;
+      throw error;
     }
   };
 
@@ -167,32 +174,37 @@ export function nodeWorkspace(): Workspace {
     locateWorktree: async (start): Promise<WorktreeLocation | null> => {
       const canonical = await canonicalize(start, start);
       if (canonical === null) return null;
-      const [topLevelText, commonText, gitDirText] = await Promise.all([
+      const [topLevelText, commonText, worktreesText] = await Promise.all([
         gitOutput(canonical, ["rev-parse", "--show-toplevel"]),
         gitOutput(canonical, [
           "rev-parse",
           "--path-format=absolute",
           "--git-common-dir",
         ]),
-        gitOutput(canonical, [
-          "rev-parse",
-          "--path-format=absolute",
-          "--git-dir",
-        ]),
+        gitOutput(canonical, ["worktree", "list", "--porcelain", "-z"]),
       ]);
-      if (topLevelText === null || commonText === null || gitDirText === null) {
+      const principalText =
+        worktreesText === null
+          ? null
+          : principalFromWorktreeList(worktreesText);
+      if (
+        topLevelText === null ||
+        commonText === null ||
+        principalText === null
+      ) {
         return null;
       }
-      const [topLevel, common, gitDirectory] = await Promise.all([
+      const [topLevel, common, principal] = await Promise.all([
         realpath(topLevelText),
         realpath(commonText),
-        realpath(gitDirText),
+        realpath(principalText),
       ]);
-      const linked = common !== gitDirectory;
+      if (principal === common) return null;
+      const linked = topLevel !== principal;
       return {
         kind: linked ? "linked" : "principal",
         topLevel,
-        principal: linked ? dirname(common) : topLevel,
+        principal,
       };
     },
   };

--- a/packages/runtime/src/infra/node/workspace.ts
+++ b/packages/runtime/src/infra/node/workspace.ts
@@ -1,0 +1,194 @@
+import { execFile } from "node:child_process";
+import { lstat, readFile, realpath, stat } from "node:fs/promises";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { promisify } from "node:util";
+
+import type {
+  ConfigurationObservation,
+  DirectoryProbe,
+  WorktreeLocation,
+} from "../../domain/project/index.js";
+import type { Workspace } from "../../ports/index.js";
+
+const run = promisify(execFile);
+
+function unsafe(path: string): boolean {
+  let control = false;
+  for (const character of path) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) control = true;
+  }
+  return (
+    path.length === 0 ||
+    path.includes("\\") ||
+    /^[A-Za-z]:/u.test(path) ||
+    control
+  );
+}
+
+function inside(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith(`..${sep}`) && path !== "..");
+}
+
+function absent(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === "ENOTDIR")
+  );
+}
+
+async function optionalStat(
+  path: string,
+): Promise<Awaited<ReturnType<typeof lstat>> | null> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (absent(error)) return null;
+    throw error;
+  }
+}
+
+async function markerKind(root: string): Promise<DirectoryProbe["brain"]> {
+  const marker = join(root, ".brain");
+  const details = await optionalStat(marker);
+  if (details === null) return "absent";
+  if (!details.isSymbolicLink()) {
+    return details.isDirectory() ? "directory" : "other";
+  }
+  let target: string;
+  try {
+    target = await realpath(marker);
+  } catch {
+    return "other";
+  }
+  if (!inside(root, target)) return "escaping";
+  return (await stat(target)).isDirectory() ? "directory" : "other";
+}
+
+async function configuration(
+  root: string,
+  brain: DirectoryProbe["brain"],
+): Promise<ConfigurationObservation> {
+  if (brain !== "directory") return { kind: "absent" };
+  const path = join(root, ".brain", "config.json");
+  const details = await optionalStat(path);
+  if (details === null) return { kind: "absent" };
+  if (details.isDirectory()) return { kind: "other" };
+  if (details.isSymbolicLink()) {
+    let target: string;
+    try {
+      target = await realpath(path);
+    } catch {
+      return { kind: "other" };
+    }
+    if (!inside(root, target) || !(await stat(target)).isFile()) {
+      return { kind: "other" };
+    }
+  } else if (!details.isFile()) {
+    return { kind: "other" };
+  }
+  return { kind: "file", text: await readFile(path, "utf8") };
+}
+
+async function probe(path: string): Promise<DirectoryProbe> {
+  const brain = await markerKind(path);
+  const legacy = join(dirname(path), `${basename(path)}-brain`, ".brain");
+  const [gitMarker, legacyMarker, observedConfiguration] = await Promise.all([
+    optionalStat(join(path, ".git")),
+    optionalStat(legacy),
+    configuration(path, brain),
+  ]);
+  return {
+    path,
+    brain,
+    git: gitMarker === null ? "absent" : "present",
+    legacyBrain:
+      legacyMarker !== null &&
+      !legacyMarker.isSymbolicLink() &&
+      legacyMarker.isDirectory(),
+    configuration: observedConfiguration,
+  };
+}
+
+async function gitOutput(
+  cwd: string,
+  args: readonly string[],
+): Promise<string | null> {
+  try {
+    const result = await run("git", [...args], {
+      cwd,
+      encoding: "utf8",
+      env: { PATH: process.env.PATH, GIT_CONFIG_NOSYSTEM: "1", LC_ALL: "C" },
+    });
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Real read-only workspace observations before a project root is trusted. */
+export function nodeWorkspace(): Workspace {
+  const canonicalize = async (
+    path: string,
+    base: string,
+  ): Promise<string | null> => {
+    if (unsafe(path) || unsafe(base)) return null;
+    try {
+      const candidate = await realpath(resolve(base, path));
+      return (await stat(candidate)).isDirectory() ? candidate : null;
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    canonicalize,
+    ancestors: async (start) => {
+      const canonical = await canonicalize(start, start);
+      if (canonical === null) return [];
+      const paths: string[] = [];
+      let current = canonical;
+      for (;;) {
+        paths.push(current);
+        const parent = dirname(current);
+        if (parent === current) break;
+        current = parent;
+      }
+      return Promise.all(paths.map((path) => probe(path)));
+    },
+    locateWorktree: async (start): Promise<WorktreeLocation | null> => {
+      const canonical = await canonicalize(start, start);
+      if (canonical === null) return null;
+      const [topLevelText, commonText, gitDirText] = await Promise.all([
+        gitOutput(canonical, ["rev-parse", "--show-toplevel"]),
+        gitOutput(canonical, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ]),
+        gitOutput(canonical, [
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-dir",
+        ]),
+      ]);
+      if (topLevelText === null || commonText === null || gitDirText === null) {
+        return null;
+      }
+      const [topLevel, common, gitDirectory] = await Promise.all([
+        realpath(topLevelText),
+        realpath(commonText),
+        realpath(gitDirText),
+      ]);
+      const linked = common !== gitDirectory;
+      return {
+        kind: linked ? "linked" : "principal",
+        topLevel,
+        principal: linked ? dirname(common) : topLevel,
+      };
+    },
+  };
+}

--- a/packages/runtime/src/ports/index.ts
+++ b/packages/runtime/src/ports/index.ts
@@ -80,6 +80,7 @@ export interface Output {
 /** Read-only filesystem and Git facts available before a project root exists. */
 export interface Workspace {
   canonicalize(path: string, base: string): Promise<string | null>;
+  inspect(path: string): Promise<DirectoryProbe>;
   ancestors(start: string): Promise<readonly DirectoryProbe[]>;
   locateWorktree(start: string): Promise<WorktreeLocation | null>;
 }

--- a/packages/runtime/src/ports/index.ts
+++ b/packages/runtime/src/ports/index.ts
@@ -1,3 +1,8 @@
+import type {
+  DirectoryProbe,
+  WorktreeLocation,
+} from "../domain/project/observation.js";
+
 /**
  * Injected effect boundaries.
  *
@@ -70,6 +75,13 @@ export interface Environment {
 export interface Output {
   structured(text: string): void;
   human(text: string): void;
+}
+
+/** Read-only filesystem and Git facts available before a project root exists. */
+export interface Workspace {
+  canonicalize(path: string, base: string): Promise<string | null>;
+  ancestors(start: string): Promise<readonly DirectoryProbe[]>;
+  locateWorktree(start: string): Promise<WorktreeLocation | null>;
 }
 
 /** The complete set of injected boundaries a runtime is composed from. */

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -91,7 +91,11 @@ describe("import extraction", () => {
       await collectImports(
         join(repositoryRoot, "packages/runtime/src/infra/fake/index.ts"),
       ),
-    ).toEqual(["../../ports/index.js"]);
+    ).toEqual([
+      "node:path",
+      "../../domain/project/index.js",
+      "../../ports/index.js",
+    ]);
 
     expect(
       await collectImports(

--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -48,6 +48,13 @@ afterAll(async () => {
 });
 
 describe("standalone runtime bundle", () => {
+  it("keeps the command surface unchanged while discovery remains internal", () => {
+    const result = execute("--help");
+
+    expect(result.stdout).not.toContain("discover");
+    expect(result.stdout).not.toContain("init");
+  });
+
   it("prints help outside the repository", () => {
     const result = execute("--help");
 

--- a/tests/contract-documentation.test.ts
+++ b/tests/contract-documentation.test.ts
@@ -11,22 +11,70 @@ let readme: string;
 let schemaIndex: string;
 let fixtureIndex: string;
 let resultContract: string;
+let projectDiscovery: string;
+let runtimeBoundaries: string;
 
 beforeAll(async () => {
-  [guide, readme, schemaIndex, fixtureIndex, resultContract] =
-    await Promise.all([
-      readFile(
-        join(repositoryRoot, "docs/compatibility/contract-versioning.md"),
-        "utf8",
-      ),
-      readFile(join(repositoryRoot, "README.md"), "utf8"),
-      readFile(join(repositoryRoot, "schemas/README.md"), "utf8"),
-      readFile(join(repositoryRoot, "fixtures/README.md"), "utf8"),
-      readFile(
-        join(repositoryRoot, "docs/compatibility/result-contract.md"),
-        "utf8",
-      ),
-    ]);
+  [
+    guide,
+    readme,
+    schemaIndex,
+    fixtureIndex,
+    resultContract,
+    projectDiscovery,
+    runtimeBoundaries,
+  ] = await Promise.all([
+    readFile(
+      join(repositoryRoot, "docs/compatibility/contract-versioning.md"),
+      "utf8",
+    ),
+    readFile(join(repositoryRoot, "README.md"), "utf8"),
+    readFile(join(repositoryRoot, "schemas/README.md"), "utf8"),
+    readFile(join(repositoryRoot, "fixtures/README.md"), "utf8"),
+    readFile(
+      join(repositoryRoot, "docs/compatibility/result-contract.md"),
+      "utf8",
+    ),
+    readFile(
+      join(repositoryRoot, "docs/architecture/project-discovery.md"),
+      "utf8",
+    ),
+    readFile(
+      join(repositoryRoot, "docs/architecture/runtime-boundaries.md"),
+      "utf8",
+    ),
+  ]);
+});
+
+describe("project discovery documentation", () => {
+  it("publishes the root, worktree, and migration precedence", () => {
+    for (const token of [
+      "explicit `--root`",
+      "nearest ancestor",
+      "linked Git worktree",
+      "principal checkout",
+      "migration-only",
+      "project-owned `.brain/`",
+    ]) {
+      expect(projectDiscovery).toContain(token);
+    }
+  });
+
+  it("publishes configuration safety and ownership boundaries", () => {
+    for (const token of [
+      "no environment-variable configuration layer",
+      "safe to render",
+      "RUN-04",
+      "ConfigurationValidator",
+      "does not add a command",
+      "0 / 400",
+    ]) {
+      expect(projectDiscovery).toContain(token);
+    }
+    expect(projectDiscovery).not.toContain("mestre-yoda-old");
+    expect(runtimeBoundaries).toContain("Workspace");
+    expect(runtimeBoundaries).toContain("project discovery");
+  });
 });
 
 describe("contract versioning documentation", () => {

--- a/tests/fake-workspace.test.ts
+++ b/tests/fake-workspace.test.ts
@@ -1,0 +1,81 @@
+import { memoryWorkspace } from "@mestre-yoda/runtime/infra/fake";
+import { describe, expect, it } from "vitest";
+
+import { describeWorkspaceContract } from "./support/workspace-contract.js";
+
+const principal = "/repos/café project";
+const project = "/worktrees/café task";
+const start = `${project}/src/deep`;
+
+function fixture() {
+  return memoryWorkspace({
+    directories: [start, `${project}/.brain`, principal],
+    files: {
+      [`${project}/.brain/config.json`]: '{"stateContract":"1.0.0"}\n',
+    },
+    gitRoots: [project, principal],
+    worktrees: [
+      { kind: "linked", topLevel: project, principal },
+      { kind: "principal", topLevel: principal, principal },
+    ],
+  });
+}
+
+describeWorkspaceContract("memory", () =>
+  Promise.resolve({
+    port: fixture(),
+    start,
+    project,
+    principal,
+    dispose: () => Promise.resolve(),
+  }),
+);
+
+describe("memory workspace edge classifications", () => {
+  it("distinguishes marker files from directories", async () => {
+    const workspace = memoryWorkspace({
+      directories: ["/project"],
+      files: { "/project/.brain": "not a directory" },
+    });
+    expect((await workspace.ancestors("/project"))[0]).toMatchObject({
+      brain: "other",
+      configuration: { kind: "absent" },
+    });
+  });
+
+  it("accepts an internal marker symlink and reads through it", async () => {
+    const workspace = memoryWorkspace({
+      directories: ["/project", "/project/state"],
+      files: { "/project/state/config.json": "safe" },
+      symlinks: { "/project/.brain": "/project/state" },
+    });
+    expect((await workspace.ancestors("/project"))[0]).toMatchObject({
+      brain: "directory",
+      configuration: { kind: "file", text: "safe" },
+    });
+  });
+
+  it("classifies an escaping marker symlink without reading it", async () => {
+    const workspace = memoryWorkspace({
+      directories: ["/project", "/private/state"],
+      files: { "/private/state/config.json": "secret" },
+      symlinks: { "/project/.brain": "/private/state" },
+    });
+    expect((await workspace.ancestors("/project"))[0]).toMatchObject({
+      brain: "escaping",
+      configuration: { kind: "absent" },
+    });
+  });
+
+  it("observes a legacy sibling without reading its configuration", async () => {
+    const workspace = memoryWorkspace({
+      directories: ["/project", "/project-brain/.brain"],
+      files: { "/project-brain/.brain/config.json": "legacy" },
+    });
+    expect((await workspace.ancestors("/project"))[0]).toMatchObject({
+      brain: "absent",
+      legacyBrain: true,
+      configuration: { kind: "absent" },
+    });
+  });
+});

--- a/tests/node-workspace.test.ts
+++ b/tests/node-workspace.test.ts
@@ -1,0 +1,154 @@
+import { execFile } from "node:child_process";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+import { nodeWorkspace } from "@mestre-yoda/runtime/infra/node";
+import { describe, expect, it } from "vitest";
+
+import { describeWorkspaceContract } from "./support/workspace-contract.js";
+
+const run = promisify(execFile);
+
+async function git(cwd: string, args: readonly string[]): Promise<void> {
+  await run("git", [...args], {
+    cwd,
+    env: { PATH: process.env.PATH, GIT_CONFIG_NOSYSTEM: "1", LC_ALL: "C" },
+  });
+}
+
+async function linkedFixture() {
+  const base = await mkdtemp(join(tmpdir(), "yoda-workspace-"));
+  const principal = join(base, "repos", "café project");
+  const project = join(base, "worktrees", "café task");
+  const start = join(project, "src", "deep");
+  await mkdir(principal, { recursive: true });
+  await git(principal, ["init"]);
+  await writeFile(join(principal, "README.md"), "fixture\n");
+  await git(principal, ["add", "README.md"]);
+  await git(principal, [
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.test",
+    "commit",
+    "-m",
+    "fixture",
+  ]);
+  await mkdir(dirname(project), { recursive: true });
+  await git(principal, ["worktree", "add", "-b", "fixture-task", project]);
+  await mkdir(join(project, ".brain"));
+  await writeFile(
+    join(project, ".brain", "config.json"),
+    '{"stateContract":"1.0.0"}\n',
+  );
+  await mkdir(start, { recursive: true });
+  return {
+    port: nodeWorkspace(),
+    start,
+    project,
+    principal,
+    dispose: () => rm(base, { recursive: true, force: true }),
+  };
+}
+
+describeWorkspaceContract("node", linkedFixture);
+
+describe("node workspace edge classifications", () => {
+  it("classifies marker files and missing explicit directories", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-workspace-file-"));
+    try {
+      await writeFile(join(root, ".brain"), "not a directory");
+      const workspace = nodeWorkspace();
+      expect((await workspace.ancestors(root))[0]).toMatchObject({
+        brain: "other",
+        configuration: { kind: "absent" },
+      });
+      expect(await workspace.canonicalize("missing", root)).toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts an internal marker symlink and refuses an escaping one", async () => {
+    const base = await mkdtemp(join(tmpdir(), "yoda-workspace-link-"));
+    const project = join(base, "project");
+    const internal = join(project, "state");
+    const external = join(base, "private");
+    await Promise.all([
+      mkdir(internal, { recursive: true }),
+      mkdir(external, { recursive: true }),
+    ]);
+    await writeFile(join(internal, "config.json"), "safe");
+    try {
+      await symlink(internal, join(project, ".brain"));
+      const workspace = nodeWorkspace();
+      expect((await workspace.ancestors(project))[0]).toMatchObject({
+        brain: "directory",
+        configuration: { kind: "file", text: "safe" },
+      });
+      await rm(join(project, ".brain"));
+      await symlink(external, join(project, ".brain"));
+      expect((await workspace.ancestors(project))[0]).toMatchObject({
+        brain: "escaping",
+        configuration: { kind: "absent" },
+      });
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("observes legacy sibling state without reading it", async () => {
+    const base = await mkdtemp(join(tmpdir(), "yoda-workspace-legacy-"));
+    const project = join(base, "project");
+    const legacy = join(base, "project-brain", ".brain");
+    await Promise.all([mkdir(project), mkdir(legacy, { recursive: true })]);
+    await writeFile(join(legacy, "config.json"), "legacy-secret");
+    try {
+      expect((await nodeWorkspace().ancestors(project))[0]).toMatchObject({
+        brain: "absent",
+        legacyBrain: true,
+        configuration: { kind: "absent" },
+      });
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("locates the same repository while detached", async () => {
+    const fixture = await linkedFixture();
+    try {
+      await git(fixture.project, ["checkout", "--detach"]);
+      expect(await fixture.port.locateWorktree(fixture.start)).toEqual({
+        kind: "linked",
+        topLevel: fixture.project,
+        principal: fixture.principal,
+      });
+      expect((await lstat(fixture.project)).isDirectory()).toBe(true);
+    } finally {
+      await fixture.dispose();
+    }
+  });
+
+  it("locates an unborn ordinary repository", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-workspace-unborn-"));
+    try {
+      await git(root, ["init"]);
+      expect(await nodeWorkspace().locateWorktree(root)).toEqual({
+        kind: "principal",
+        topLevel: root,
+        principal: root,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/node-workspace.test.ts
+++ b/tests/node-workspace.test.ts
@@ -12,6 +12,8 @@ import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 
 import { nodeWorkspace } from "@mestre-yoda/runtime/infra/node";
+import { discoverProject } from "@mestre-yoda/runtime/composition/discovery";
+import { fixedEnvironment } from "@mestre-yoda/runtime/infra/fake";
 import { describe, expect, it } from "vitest";
 
 import { describeWorkspaceContract } from "./support/workspace-contract.js";
@@ -73,6 +75,17 @@ describe("node workspace edge classifications", () => {
         configuration: { kind: "absent" },
       });
       expect(await workspace.canonicalize("missing", root)).toBeNull();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates unexpected canonicalization failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-workspace-error-"));
+    try {
+      await expect(
+        nodeWorkspace().canonicalize("x".repeat(5_000), root),
+      ).rejects.toMatchObject({ code: "ENAMETOOLONG" });
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -146,6 +159,64 @@ describe("node workspace edge classifications", () => {
         kind: "principal",
         topLevel: root,
         principal: root,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses ambiguous principal topology when Git metadata is stored separately", async () => {
+    const base = await mkdtemp(join(tmpdir(), "yoda-workspace-separated-"));
+    const principal = join(base, "principal");
+    const metadata = join(base, "metadata", "project.git");
+    const linked = join(base, "linked");
+    try {
+      await mkdir(principal, { recursive: true });
+      await mkdir(dirname(metadata), { recursive: true });
+      await git(principal, ["init", "--separate-git-dir", metadata]);
+      await writeFile(join(principal, "README.md"), "fixture\n");
+      await git(principal, ["add", "README.md"]);
+      await git(principal, [
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=fixture@example.test",
+        "commit",
+        "-m",
+        "fixture",
+      ]);
+      await git(principal, ["worktree", "add", "-b", "separated", linked]);
+
+      expect(await nodeWorkspace().locateWorktree(linked)).toBeNull();
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a malformed Git marker instead of selecting it as a root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-workspace-malformed-git-"));
+    try {
+      await writeFile(
+        join(root, ".git"),
+        "gitdir: /missing/private/location\n",
+      );
+      await expect(
+        discoverProject(
+          {
+            workingDirectory: root,
+            explicitRoot: null,
+            worktreeMode: "principal",
+          },
+          {
+            workspace: nodeWorkspace(),
+            environment: fixedEnvironment({}, root),
+          },
+          () => ({ kind: "invalid" }),
+        ),
+      ).resolves.toEqual({
+        kind: "marker-unusable",
+        root,
+        reasonCode: "guard.project_marker_corrupt",
       });
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/tests/project-configuration-layers.test.ts
+++ b/tests/project-configuration-layers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveConfigurationLayers,
+  type ConfigurationLayers,
+} from "@mestre-yoda/runtime/domain/project";
+
+interface Settings {
+  language: "en" | "pt-BR";
+  policyMode: "standard" | "strict";
+  snapshots: boolean;
+}
+
+const keys = ["language", "policyMode", "snapshots"] as const;
+
+function layers(
+  overrides: Partial<ConfigurationLayers<Settings>> = {},
+): ConfigurationLayers<Settings> {
+  return {
+    defaults: {
+      language: "en",
+      policyMode: "standard",
+      snapshots: false,
+    },
+    project: {},
+    flags: {},
+    ...overrides,
+  };
+}
+
+describe("project configuration layers", () => {
+  it("applies default, project, and flag precedence with provenance", () => {
+    expect(
+      resolveConfigurationLayers(
+        keys,
+        layers({
+          project: { language: "pt-BR", policyMode: "strict" },
+          flags: {
+            policyMode: { value: "standard", ref: "--policy-mode" },
+          },
+        }),
+      ),
+    ).toEqual({
+      language: {
+        value: "pt-BR",
+        source: "project",
+        ref: ".brain/config.json",
+      },
+      policyMode: {
+        value: "standard",
+        source: "flag",
+        ref: "--policy-mode",
+      },
+      snapshots: { value: false, source: "default", ref: null },
+    });
+  });
+
+  it("preserves lower-layer values and provenance when overrides are absent", () => {
+    expect(resolveConfigurationLayers(keys, layers()).language).toEqual({
+      value: "en",
+      source: "default",
+      ref: null,
+    });
+  });
+
+  it("does not mutate any input layer", () => {
+    const input = layers({ project: { language: "pt-BR" } });
+    const before = structuredClone(input);
+    resolveConfigurationLayers(keys, input);
+    expect(input).toEqual(before);
+  });
+
+  it("emits keys in the declared deterministic order", () => {
+    const result = resolveConfigurationLayers(keys, layers());
+    expect(Object.keys(result)).toEqual(keys);
+  });
+
+  it.each([
+    [
+      "an unknown default key",
+      { defaults: { language: "en", privatePath: "/home/customer" } },
+    ],
+    ["an undefined value", { defaults: { language: undefined } }],
+    [
+      "an unsafe flag ref",
+      { flags: { language: { value: "pt-BR", ref: "/home/customer" } } },
+    ],
+  ])("fails closed for %s", (_label, override) => {
+    const input = {
+      ...layers(),
+      ...override,
+    } as unknown as ConfigurationLayers<Settings>;
+    expect(() => resolveConfigurationLayers(keys, input)).toThrow(
+      "Configuration layers are invalid",
+    );
+  });
+
+  it("requires every declared setting to resolve", () => {
+    expect(() =>
+      resolveConfigurationLayers<Settings, typeof keys>(keys, {
+        defaults: { language: "en" },
+        project: {},
+        flags: {},
+      }),
+    ).toThrow("Configuration layers are incomplete");
+  });
+});

--- a/tests/project-configuration-layers.test.ts
+++ b/tests/project-configuration-layers.test.ts
@@ -81,6 +81,7 @@ describe("project configuration layers", () => {
       { defaults: { language: "en", privatePath: "/home/customer" } },
     ],
     ["an undefined value", { defaults: { language: undefined } }],
+    ["an undefined project value", { project: { language: undefined } }],
     [
       "an unsafe flag ref",
       { flags: { language: { value: "pt-BR", ref: "/home/customer" } } },

--- a/tests/project-configuration.test.ts
+++ b/tests/project-configuration.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProjectConfigV1 } from "@mestre-yoda/contracts";
+import {
+  classifyConfiguration,
+  type ConfigurationObservation,
+  type ConfigurationValidator,
+} from "@mestre-yoda/runtime/domain/project";
+
+const validConfiguration: ProjectConfigV1 = {
+  contractVersion: "1.0.0",
+  stateContract: "1.0.0",
+  pluginVersion: "0.0.0-development",
+  hostContract: "1.0.0",
+  language: "en",
+  policyMode: "strict",
+  managedState: {
+    directory: ".brain",
+    eventLog: "events.jsonl",
+    snapshots: true,
+  },
+};
+
+function file(value: unknown): ConfigurationObservation {
+  return { kind: "file", text: JSON.stringify(value) };
+}
+
+function recordingValidator(result: "valid" | "invalid") {
+  const values: unknown[] = [];
+  const validator: ConfigurationValidator = (value) => {
+    values.push(value);
+    return result === "valid"
+      ? { kind: "valid", value: validConfiguration }
+      : { kind: "invalid" };
+  };
+  return { validator, values };
+}
+
+describe("project configuration classification", () => {
+  it.each([
+    ["an absent document", { kind: "absent" } as const, "guard.config_missing"],
+    ["a non-file document", { kind: "other" } as const, "guard.config_corrupt"],
+    [
+      "invalid JSON",
+      { kind: "file", text: '{"stateContract":' } as const,
+      "guard.config_corrupt",
+    ],
+    ["a missing identity", file({}), "contract.state_version_invalid"],
+    [
+      "a non-string identity",
+      file({ stateContract: 1 }),
+      "contract.state_version_invalid",
+    ],
+    [
+      "an untrimmed identity",
+      file({ stateContract: " 1.0.0" }),
+      "contract.state_version_invalid",
+    ],
+    [
+      "a future identity",
+      file({ stateContract: "2.0.0" }),
+      "contract.state_version_unsupported",
+    ],
+    [
+      "a migration-only identity",
+      file({ stateContract: "go-v3@0.6.5" }),
+      "contract.state_version_unsupported",
+    ],
+  ])("rejects %s before schema validation", (_label, input, reasonCode) => {
+    const { validator, values } = recordingValidator("valid");
+    expect(classifyConfiguration(input, validator)).toEqual({
+      kind: "failure",
+      reasonCode,
+    });
+    expect(values).toEqual([]);
+  });
+
+  it("maps a current schema rejection without exposing caller data", () => {
+    const secret = "/home/customer/token=private";
+    const { validator } = recordingValidator("invalid");
+    const result = classifyConfiguration(
+      file({ stateContract: "1.0.0", unexpected: secret }),
+      validator,
+    );
+    expect(result).toEqual({
+      kind: "failure",
+      reasonCode: "guard.config_corrupt",
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("returns only the value accepted by the validator", () => {
+    const parsed = { stateContract: "1.0.0", language: "pt-BR" };
+    const { validator, values } = recordingValidator("valid");
+    expect(classifyConfiguration(file(parsed), validator)).toEqual({
+      kind: "valid",
+      value: validConfiguration,
+    });
+    expect(values).toEqual([parsed]);
+  });
+
+  it("uses JSON last-key semantics without publishing parser input", () => {
+    const { validator, values } = recordingValidator("invalid");
+    const input = {
+      kind: "file",
+      text: '{"stateContract":"2.0.0","stateContract":"1.0.0"}',
+    } as const;
+    expect(classifyConfiguration(input, validator)).toEqual({
+      kind: "failure",
+      reasonCode: "guard.config_corrupt",
+    });
+    expect(values).toEqual([{ stateContract: "1.0.0" }]);
+  });
+});

--- a/tests/project-configuration.test.ts
+++ b/tests/project-configuration.test.ts
@@ -46,6 +46,8 @@ describe("project configuration classification", () => {
       "guard.config_corrupt",
     ],
     ["a missing identity", file({}), "contract.state_version_invalid"],
+    ["a null document", file(null), "contract.state_version_invalid"],
+    ["an array document", file([]), "contract.state_version_invalid"],
     [
       "a non-string identity",
       file({ stateContract: 1 }),

--- a/tests/project-discovery-composition.test.ts
+++ b/tests/project-discovery-composition.test.ts
@@ -118,6 +118,67 @@ describe("project discovery composition", () => {
     ]);
   });
 
+  it("stops observation when the working directory is unavailable", async () => {
+    const calls: string[] = [];
+    const workspace: Workspace = {
+      canonicalize: (path) => {
+        calls.push(`canonicalize:${path}`);
+        return Promise.resolve(null);
+      },
+      inspect: () => {
+        throw new Error("inspect must not run");
+      },
+      ancestors: () => {
+        throw new Error("ancestors must not run");
+      },
+      locateWorktree: () => {
+        throw new Error("worktree lookup must not run");
+      },
+    };
+
+    await expect(
+      observeWorkspace(
+        {
+          workingDirectory: "/missing",
+          explicitRoot: null,
+          worktreeMode: "principal",
+        },
+        {
+          workspace,
+          environment: fixedEnvironment({}, "/process"),
+        },
+      ),
+    ).resolves.toEqual({
+      canonicalWorkingDirectory: null,
+      canonicalExplicitRoot: null,
+      ancestors: [],
+      principalAncestors: [],
+      worktree: null,
+    });
+    expect(calls).toEqual(["canonicalize:/missing"]);
+  });
+
+  it("does not inspect an explicit root that cannot be canonicalized", async () => {
+    const workspace = memoryWorkspace({ directories: ["/process"] });
+    await expect(
+      observeWorkspace(
+        {
+          workingDirectory: ".",
+          explicitRoot: "/missing",
+          worktreeMode: "principal",
+        },
+        {
+          workspace,
+          environment: fixedEnvironment({}, "/process"),
+        },
+      ),
+    ).resolves.toMatchObject({
+      canonicalWorkingDirectory: "/process",
+      canonicalExplicitRoot: null,
+      ancestors: [],
+    });
+  });
+
   it("returns configuration failures without constructing mutation ports", async () => {
     const root = "/project";
     const ports = {

--- a/tests/project-discovery-composition.test.ts
+++ b/tests/project-discovery-composition.test.ts
@@ -1,0 +1,167 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ProjectConfigV1 } from "@mestre-yoda/contracts";
+import {
+  createDiscoveryPorts,
+  createRuntimeAt,
+  discoverProject,
+  observeWorkspace,
+} from "@mestre-yoda/runtime/composition/discovery";
+import {
+  fixedEnvironment,
+  memoryWorkspace,
+} from "@mestre-yoda/runtime/infra/fake";
+import type { Workspace } from "@mestre-yoda/runtime/ports";
+import { describe, expect, it } from "vitest";
+
+const configuration: ProjectConfigV1 = {
+  contractVersion: "1.0.0",
+  stateContract: "1.0.0",
+  pluginVersion: "0.0.0-development",
+  hostContract: "1.0.0",
+  language: "en",
+  policyMode: "standard",
+  managedState: {
+    directory: ".brain",
+    eventLog: "events.jsonl",
+    snapshots: false,
+  },
+};
+
+const validator = () => ({ kind: "valid", value: configuration }) as const;
+
+describe("project discovery composition", () => {
+  it("collects a linked workspace and resolves its local project", async () => {
+    const local = "/worktrees/project";
+    const principal = "/repos/project";
+    const start = `${local}/src`;
+    const workspace = memoryWorkspace({
+      directories: [start, `${local}/.brain`, principal],
+      files: {
+        [`${local}/.brain/config.json`]: JSON.stringify(configuration),
+      },
+      gitRoots: [local, principal],
+      worktrees: [
+        { kind: "linked", topLevel: local, principal },
+        { kind: "principal", topLevel: principal, principal },
+      ],
+    });
+    const request = {
+      workingDirectory: start,
+      explicitRoot: null,
+      worktreeMode: "principal" as const,
+    };
+    const ports = {
+      workspace,
+      environment: fixedEnvironment({}, start),
+    };
+
+    const observed = await observeWorkspace(request, ports);
+    expect(observed.principalAncestors[0]?.path).toBe(principal);
+    expect(await discoverProject(request, ports, validator)).toEqual({
+      kind: "initialized",
+      root: local,
+      configuration,
+    });
+    expect(await observeWorkspace(request, ports)).toEqual(observed);
+  });
+
+  it("pins an explicit relative root without observing its ancestors", async () => {
+    const calls: string[] = [];
+    const target = "/workspace/target";
+    const workspace: Workspace = {
+      canonicalize: (path, base) => {
+        calls.push(`canonicalize:${path}:${base}`);
+        return Promise.resolve(
+          path === "../target" ? target : "/workspace/src",
+        );
+      },
+      inspect: (path) => {
+        calls.push(`inspect:${path}`);
+        return Promise.resolve({
+          path,
+          brain: "absent",
+          git: "absent",
+          legacyBrain: false,
+          configuration: { kind: "absent" },
+        });
+      },
+      ancestors: (path) => {
+        calls.push(`ancestors:${path}`);
+        return Promise.resolve([]);
+      },
+      locateWorktree: (path) => {
+        calls.push(`worktree:${path}`);
+        return Promise.resolve(null);
+      },
+    };
+    const request = {
+      workingDirectory: ".",
+      explicitRoot: "../target",
+      worktreeMode: "principal" as const,
+    };
+    const resolution = await discoverProject(
+      request,
+      {
+        workspace,
+        environment: fixedEnvironment({}, "/workspace/src"),
+      },
+      validator,
+    );
+    expect(resolution).toEqual({ kind: "root-only", root: target });
+    expect(calls).toEqual([
+      "canonicalize:.:/workspace/src",
+      "canonicalize:../target:/workspace/src",
+      `inspect:${target}`,
+    ]);
+  });
+
+  it("returns configuration failures without constructing mutation ports", async () => {
+    const root = "/project";
+    const ports = {
+      workspace: memoryWorkspace({
+        directories: [root, `${root}/.brain`],
+        files: {
+          [`${root}/.brain/config.json`]: '{"stateContract":"1.0.0"}',
+        },
+      }),
+      environment: fixedEnvironment({}, root),
+    };
+    expect(
+      await discoverProject(
+        {
+          workingDirectory: root,
+          explicitRoot: null,
+          worktreeMode: "principal",
+        },
+        ports,
+        () => ({ kind: "invalid" }),
+      ),
+    ).toEqual({
+      kind: "configuration-unusable",
+      root,
+      reasonCode: "guard.config_corrupt",
+    });
+    expect(Object.keys(ports).sort()).toEqual(["environment", "workspace"]);
+  });
+
+  it("creates rooted mutation ports only after discovery succeeds", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-rooted-runtime-"));
+    try {
+      const runtime = createRuntimeAt(root);
+      await runtime.fileSystem.write("proof.txt", "rooted");
+      expect(await readFile(join(root, "proof.txt"), "utf8")).toBe("rooted");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("provides a production bootstrap with no mutation capability", () => {
+    expect(Object.keys(createDiscoveryPorts()).sort()).toEqual([
+      "environment",
+      "workspace",
+    ]);
+  });
+});

--- a/tests/project-discovery-properties.test.ts
+++ b/tests/project-discovery-properties.test.ts
@@ -1,0 +1,128 @@
+import { posix } from "node:path";
+
+import {
+  discoverProject,
+  observeWorkspace,
+} from "@mestre-yoda/runtime/composition/discovery";
+import {
+  fixedEnvironment,
+  memoryWorkspace,
+} from "@mestre-yoda/runtime/infra/fake";
+import { describe, expect, it } from "vitest";
+
+function generator(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state;
+  };
+}
+
+describe("project discovery properties", () => {
+  it("canonicalizes generated safe directories idempotently", async () => {
+    const seed = 0x18_20_26;
+    const next = generator(seed);
+    const segments = ["ordinary", "space name", "café", "cafe\u0301"];
+    const paths = Array.from({ length: 100 }, () => {
+      const depth = (next() % 4) + 1;
+      return `/${Array.from(
+        { length: depth },
+        () => segments[next() % segments.length] ?? "ordinary",
+      ).join("/")}`;
+    });
+    const workspace = memoryWorkspace({ directories: paths });
+    for (const path of paths) {
+      const first = await workspace.canonicalize(path, "/");
+      expect(first, `seed=${String(seed)} path=${path}`).not.toBeNull();
+      expect(
+        await workspace.canonicalize(first ?? "", "/"),
+        `seed=${String(seed)} path=${path}`,
+      ).toBe(first);
+    }
+  });
+
+  it("refuses every generated unsafe spelling", async () => {
+    const seed = 0x18_00_bad;
+    const next = generator(seed);
+    const unsafe = ["", "bad\u0000name", "bad\nname", "a\\b", "C:\\root"];
+    const workspace = memoryWorkspace({ directories: ["/project"] });
+    for (let index = 0; index < 100; index += 1) {
+      const path = unsafe[next() % unsafe.length] ?? "";
+      expect(
+        await workspace.canonicalize(path, "/project"),
+        `seed=${String(seed)} path=${JSON.stringify(path)}`,
+      ).toBeNull();
+    }
+  });
+
+  it("resolves a relative explicit root only when that directory exists", async () => {
+    const workspace = memoryWorkspace({
+      directories: ["/workspace/current", "/workspace/target"],
+    });
+    expect(
+      await workspace.canonicalize("../target", "/workspace/current"),
+    ).toBe("/workspace/target");
+    expect(
+      await workspace.canonicalize("../../private", "/workspace/current"),
+    ).toBeNull();
+  });
+
+  it("never turns an escaping marker into selected project state", async () => {
+    const root = "/workspace/project";
+    const workspace = memoryWorkspace({
+      directories: [root, "/workspace/private"],
+      files: { "/workspace/private/config.json": "secret" },
+      symlinks: { [`${root}/.brain`]: "/workspace/private" },
+    });
+    const ports = {
+      workspace,
+      environment: fixedEnvironment({}, root),
+    };
+    const request = {
+      workingDirectory: root,
+      explicitRoot: null,
+      worktreeMode: "principal" as const,
+    };
+    const before = await observeWorkspace(request, ports);
+    expect(
+      await discoverProject(request, ports, () => {
+        throw new Error("escaping state must not be validated");
+      }),
+    ).toEqual({
+      kind: "marker-unusable",
+      root,
+      reasonCode: "guard.project_marker_corrupt",
+    });
+    expect(await observeWorkspace(request, ports)).toEqual(before);
+    expect(posix.relative(root, "/workspace/private")).toBe("../private");
+  });
+
+  it("performs a full failed discovery with read-only ports only", async () => {
+    const root = "/outside/project";
+    const ports = {
+      workspace: memoryWorkspace({ directories: [root] }),
+      environment: fixedEnvironment({}, root),
+    };
+    const result = await discoverProject(
+      {
+        workingDirectory: root,
+        explicitRoot: null,
+        worktreeMode: "principal",
+      },
+      ports,
+      () => {
+        throw new Error("no configuration should be validated");
+      },
+    );
+    expect(result).toEqual({
+      kind: "not-found",
+      reasonCode: "guard.config_missing",
+    });
+    expect(Object.keys(ports.workspace).sort()).toEqual([
+      "ancestors",
+      "canonicalize",
+      "inspect",
+      "locateWorktree",
+    ]);
+  });
+});

--- a/tests/project-root-resolution.test.ts
+++ b/tests/project-root-resolution.test.ts
@@ -71,6 +71,18 @@ describe("project root resolution", () => {
     ).toEqual({ kind: "refused", reasonCode: "trail.uso" });
   });
 
+  it("refuses an explicit root whose probe was not observed", () => {
+    expect(
+      resolveRoot(
+        request({ explicitRoot: "/work/missing-probe" }),
+        observation({
+          canonicalExplicitRoot: "/work/missing-probe",
+          ancestors: [],
+        }),
+      ),
+    ).toEqual({ kind: "refused", reasonCode: "trail.uso" });
+  });
+
   it("returns an explicit usable directory without a marker as root-only", () => {
     const root = probe("/work/new-project");
     expect(
@@ -104,6 +116,12 @@ describe("project root resolution", () => {
       root: "/work/project/packages/api",
       probe: nearest,
     });
+  });
+
+  it("refuses a working directory that could not be canonicalized", () => {
+    expect(
+      resolveRoot(request(), observation({ canonicalWorkingDirectory: null })),
+    ).toEqual({ kind: "refused", reasonCode: "trail.uso" });
   });
 
   it.each(["other", "escaping"] as const)(
@@ -186,6 +204,23 @@ describe("project root resolution", () => {
     });
   });
 
+  it("uses the principal checkout root when it has no marker", () => {
+    expect(
+      resolveRoot(
+        request(),
+        observation({
+          ancestors: [probe("/worktrees/task")],
+          principalAncestors: [probe("/repos/project")],
+          worktree: {
+            kind: "linked",
+            topLevel: "/worktrees/task",
+            principal: "/repos/project",
+          },
+        }),
+      ),
+    ).toEqual({ kind: "root-only", root: "/repos/project" });
+  });
+
   it("keeps local worktree mode at the linked Git root", () => {
     expect(
       resolveRoot(
@@ -217,6 +252,21 @@ describe("project root resolution", () => {
             topLevel: "/work/project",
             principal: "/work/project",
           },
+        }),
+      ),
+    ).toEqual({ kind: "root-only", root: "/work/project" });
+  });
+
+  it("uses an ancestor Git marker when topology lookup is unavailable", () => {
+    expect(
+      resolveRoot(
+        request(),
+        observation({
+          ancestors: [
+            probe("/work/project/src"),
+            probe("/work/project", { git: "present" }),
+          ],
+          worktree: null,
         }),
       ),
     ).toEqual({ kind: "root-only", root: "/work/project" });

--- a/tests/project-root-resolution.test.ts
+++ b/tests/project-root-resolution.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveRoot,
+  type DirectoryProbe,
+  type DiscoveryRequest,
+  type WorkspaceObservation,
+} from "@mestre-yoda/runtime/domain/project";
+
+function probe(
+  path: string,
+  overrides: Partial<DirectoryProbe> = {},
+): DirectoryProbe {
+  return {
+    path,
+    brain: "absent",
+    git: "absent",
+    legacyBrain: false,
+    configuration: { kind: "absent" },
+    ...overrides,
+  };
+}
+
+function request(overrides: Partial<DiscoveryRequest> = {}): DiscoveryRequest {
+  return {
+    workingDirectory: "/work/project/src",
+    explicitRoot: null,
+    worktreeMode: "principal",
+    ...overrides,
+  };
+}
+
+function observation(
+  overrides: Partial<WorkspaceObservation> = {},
+): WorkspaceObservation {
+  return {
+    canonicalWorkingDirectory: "/work/project/src",
+    canonicalExplicitRoot: null,
+    ancestors: [
+      probe("/work/project/src"),
+      probe("/work/project"),
+      probe("/work"),
+      probe("/"),
+    ],
+    principalAncestors: [],
+    worktree: null,
+    ...overrides,
+  };
+}
+
+describe("project root resolution", () => {
+  it("pins an explicit canonical root without walking ancestors", () => {
+    const selected = probe("/other/project", { brain: "directory" });
+    expect(
+      resolveRoot(
+        request({ explicitRoot: "../../other/project" }),
+        observation({
+          canonicalExplicitRoot: "/other/project",
+          ancestors: [selected, probe("/other", { brain: "directory" })],
+        }),
+      ),
+    ).toEqual({ kind: "selected", root: "/other/project", probe: selected });
+  });
+
+  it("refuses an explicit root that could not be canonicalized", () => {
+    expect(
+      resolveRoot(
+        request({ explicitRoot: "missing" }),
+        observation({ canonicalExplicitRoot: null, ancestors: [] }),
+      ),
+    ).toEqual({ kind: "refused", reasonCode: "trail.uso" });
+  });
+
+  it("returns an explicit usable directory without a marker as root-only", () => {
+    const root = probe("/work/new-project");
+    expect(
+      resolveRoot(
+        request({ explicitRoot: "/work/new-project" }),
+        observation({
+          canonicalExplicitRoot: "/work/new-project",
+          ancestors: [root],
+        }),
+      ),
+    ).toEqual({ kind: "root-only", root: "/work/new-project" });
+  });
+
+  it("chooses the nearest project-local marker", () => {
+    const nearest = probe("/work/project/packages/api", {
+      brain: "directory",
+    });
+    expect(
+      resolveRoot(
+        request(),
+        observation({
+          ancestors: [
+            probe("/work/project/packages/api/src"),
+            nearest,
+            probe("/work/project", { brain: "directory" }),
+          ],
+        }),
+      ),
+    ).toEqual({
+      kind: "selected",
+      root: "/work/project/packages/api",
+      probe: nearest,
+    });
+  });
+
+  it.each(["other", "escaping"] as const)(
+    "refuses a nearest %s marker instead of falling through",
+    (brain) => {
+      expect(
+        resolveRoot(
+          request(),
+          observation({
+            ancestors: [
+              probe("/work/project/src"),
+              probe("/work/project", { brain }),
+              probe("/work", { brain: "directory" }),
+            ],
+          }),
+        ),
+      ).toEqual({
+        kind: "marker-unusable",
+        root: "/work/project",
+        reasonCode: "guard.project_marker_corrupt",
+      });
+    },
+  );
+
+  it("classifies a legacy sibling without using it as current state", () => {
+    expect(
+      resolveRoot(
+        request(),
+        observation({
+          ancestors: [
+            probe("/work/project/src"),
+            probe("/work/project", { legacyBrain: true }),
+          ],
+        }),
+      ),
+    ).toEqual({
+      kind: "migration-pending",
+      root: "/work/project",
+      reasonCode: "brain_migration_pending",
+    });
+  });
+
+  it("lets a local marker win before principal worktree fallback", () => {
+    const local = probe("/worktrees/café task", { brain: "directory" });
+    expect(
+      resolveRoot(
+        request(),
+        observation({
+          ancestors: [local],
+          principalAncestors: [probe("/repos/café", { brain: "directory" })],
+          worktree: {
+            kind: "linked",
+            topLevel: "/worktrees/café task",
+            principal: "/repos/café",
+          },
+        }),
+      ),
+    ).toMatchObject({ kind: "selected", root: "/worktrees/café task" });
+  });
+
+  it("falls back to the principal worktree by default", () => {
+    const principal = probe("/repos/project", { brain: "directory" });
+    expect(
+      resolveRoot(
+        request(),
+        observation({
+          ancestors: [probe("/worktrees/task")],
+          principalAncestors: [principal],
+          worktree: {
+            kind: "linked",
+            topLevel: "/worktrees/task",
+            principal: "/repos/project",
+          },
+        }),
+      ),
+    ).toEqual({
+      kind: "selected",
+      root: "/repos/project",
+      probe: principal,
+    });
+  });
+
+  it("keeps local worktree mode at the linked Git root", () => {
+    expect(
+      resolveRoot(
+        request({ worktreeMode: "local" }),
+        observation({
+          ancestors: [probe("/worktrees/task", { git: "present" })],
+          principalAncestors: [probe("/repos/project", { brain: "directory" })],
+          worktree: {
+            kind: "linked",
+            topLevel: "/worktrees/task",
+            principal: "/repos/project",
+          },
+        }),
+      ),
+    ).toEqual({ kind: "root-only", root: "/worktrees/task" });
+  });
+
+  it("uses an ordinary Git top level when no marker exists", () => {
+    expect(
+      resolveRoot(
+        request(),
+        observation({
+          ancestors: [
+            probe("/work/project/src"),
+            probe("/work/project", { git: "present" }),
+          ],
+          worktree: {
+            kind: "principal",
+            topLevel: "/work/project",
+            principal: "/work/project",
+          },
+        }),
+      ),
+    ).toEqual({ kind: "root-only", root: "/work/project" });
+  });
+
+  it("returns a stable not-found result outside a project", () => {
+    const input = observation();
+    expect(resolveRoot(request(), input)).toEqual({
+      kind: "not-found",
+      reasonCode: "guard.config_missing",
+    });
+    expect(resolveRoot(request(), input)).toEqual(
+      resolveRoot(request(), input),
+    );
+  });
+});

--- a/tests/project-root-resolution.test.ts
+++ b/tests/project-root-resolution.test.ts
@@ -257,7 +257,7 @@ describe("project root resolution", () => {
     ).toEqual({ kind: "root-only", root: "/work/project" });
   });
 
-  it("uses an ancestor Git marker when topology lookup is unavailable", () => {
+  it("refuses an ancestor Git marker when topology lookup is unavailable", () => {
     expect(
       resolveRoot(
         request(),
@@ -269,7 +269,11 @@ describe("project root resolution", () => {
           worktree: null,
         }),
       ),
-    ).toEqual({ kind: "root-only", root: "/work/project" });
+    ).toEqual({
+      kind: "marker-unusable",
+      root: "/work/project",
+      reasonCode: "guard.project_marker_corrupt",
+    });
   });
 
   it("returns a stable not-found result outside a project", () => {

--- a/tests/project-types.test.ts
+++ b/tests/project-types.test.ts
@@ -30,6 +30,7 @@ const observation: WorkspaceObservation = {
   canonicalWorkingDirectory: "/workspace/project/src",
   canonicalExplicitRoot: null,
   ancestors: [probe],
+  principalAncestors: [],
   worktree: {
     kind: "principal",
     topLevel: "/workspace/project",

--- a/tests/project-types.test.ts
+++ b/tests/project-types.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import type { ProjectConfigV1 } from "@mestre-yoda/contracts";
+import type {
+  ConfigurationValidator,
+  DirectoryProbe,
+  DiscoveryRequest,
+  ProjectResolution,
+  WorkspaceObservation,
+} from "@mestre-yoda/runtime/domain/project";
+
+const request: DiscoveryRequest = {
+  workingDirectory: "/workspace/project/src",
+  explicitRoot: null,
+  worktreeMode: "principal",
+};
+
+const probe: DirectoryProbe = {
+  path: "/workspace/project",
+  brain: "directory",
+  git: "present",
+  legacyBrain: false,
+  configuration: {
+    kind: "file",
+    text: '{"stateContract":"1.0.0"}',
+  },
+};
+
+const observation: WorkspaceObservation = {
+  canonicalWorkingDirectory: "/workspace/project/src",
+  canonicalExplicitRoot: null,
+  ancestors: [probe],
+  worktree: {
+    kind: "principal",
+    topLevel: "/workspace/project",
+    principal: "/workspace/project",
+  },
+};
+
+describe("project discovery vocabulary", () => {
+  it("keeps requests and observations inert", () => {
+    expect(request).toEqual({
+      workingDirectory: "/workspace/project/src",
+      explicitRoot: null,
+      worktreeMode: "principal",
+    });
+    expect(observation.ancestors).toEqual([probe]);
+  });
+
+  it("requires validation before configuration becomes typed", () => {
+    const validator: ConfigurationValidator = (value) =>
+      typeof value === "object" && value !== null
+        ? { kind: "valid", value: value as ProjectConfigV1 }
+        : { kind: "invalid" };
+
+    expect(validator(null)).toEqual({ kind: "invalid" });
+    expectTypeOf(validator).returns.toEqualTypeOf<
+      | { readonly kind: "valid"; readonly value: ProjectConfigV1 }
+      | { readonly kind: "invalid" }
+    >();
+  });
+
+  it("exposes a closed resolution union", () => {
+    const resolutions = [
+      {
+        kind: "initialized",
+        root: "/workspace/project",
+        configuration: {} as ProjectConfigV1,
+      },
+      { kind: "root-only", root: "/workspace/project" },
+      {
+        kind: "migration-pending",
+        root: "/workspace/project",
+        reasonCode: "brain_migration_pending",
+      },
+      {
+        kind: "marker-unusable",
+        root: "/workspace/project",
+        reasonCode: "guard.project_marker_corrupt",
+      },
+      { kind: "not-found", reasonCode: "guard.config_missing" },
+      { kind: "refused", reasonCode: "trail.uso" },
+    ] as const satisfies readonly ProjectResolution[];
+
+    expect(resolutions.map(({ kind }) => kind)).toEqual([
+      "initialized",
+      "root-only",
+      "migration-pending",
+      "marker-unusable",
+      "not-found",
+      "refused",
+    ]);
+  });
+});

--- a/tests/project-types.test.ts
+++ b/tests/project-types.test.ts
@@ -79,6 +79,11 @@ describe("project discovery vocabulary", () => {
         root: "/workspace/project",
         reasonCode: "guard.project_marker_corrupt",
       },
+      {
+        kind: "configuration-unusable",
+        root: "/workspace/project",
+        reasonCode: "guard.config_corrupt",
+      },
       { kind: "not-found", reasonCode: "guard.config_missing" },
       { kind: "refused", reasonCode: "trail.uso" },
     ] as const satisfies readonly ProjectResolution[];
@@ -88,6 +93,7 @@ describe("project discovery vocabulary", () => {
       "root-only",
       "migration-pending",
       "marker-unusable",
+      "configuration-unusable",
       "not-found",
       "refused",
     ]);

--- a/tests/readme-honesty.test.ts
+++ b/tests/readme-honesty.test.ts
@@ -89,6 +89,8 @@ describe("README honesty", () => {
     expect(readme).toContain("embedded ESM runtime");
     expect(readme).toContain("runtime/yoda.mjs");
     expect(readme).toContain("Node.js 24");
+    expect(readme).toContain("project discovery contract");
+    expect(readme).toContain("no new runnable command");
   });
 
   it("links every required public path", () => {

--- a/tests/support/workspace-contract.ts
+++ b/tests/support/workspace-contract.ts
@@ -43,10 +43,8 @@ export function describeWorkspaceContract(
     });
 
     it("observes project-local marker and configuration bytes", async () => {
-      await withWorkspace(async ({ port, start, project }) => {
-        const candidate = (await port.ancestors(start)).find(
-          ({ path }) => path === project,
-        );
+      await withWorkspace(async ({ port, project }) => {
+        const candidate = await port.inspect(project);
         expect(candidate).toMatchObject({
           path: project,
           brain: "directory",
@@ -82,6 +80,7 @@ export function describeWorkspaceContract(
         expect(Object.keys(port).sort()).toEqual([
           "ancestors",
           "canonicalize",
+          "inspect",
           "locateWorktree",
         ]);
         return Promise.resolve();

--- a/tests/support/workspace-contract.ts
+++ b/tests/support/workspace-contract.ts
@@ -1,0 +1,91 @@
+import type { Workspace } from "@mestre-yoda/runtime/ports";
+import { describe, expect, it } from "vitest";
+
+import type { Disposable } from "./port-contracts.js";
+
+export interface WorkspaceContractFixture extends Disposable<Workspace> {
+  readonly start: string;
+  readonly project: string;
+  readonly principal: string;
+}
+
+export function describeWorkspaceContract(
+  label: string,
+  factory: () => Promise<WorkspaceContractFixture>,
+): void {
+  describe(`Workspace contract: ${label}`, () => {
+    async function withWorkspace(
+      body: (fixture: WorkspaceContractFixture) => Promise<void>,
+    ): Promise<void> {
+      const fixture = await factory();
+      try {
+        await body(fixture);
+      } finally {
+        await fixture.dispose();
+      }
+    }
+
+    it("canonicalizes directories idempotently", async () => {
+      await withWorkspace(async ({ port, project }) => {
+        const first = await port.canonicalize(project, project);
+        expect(first).toBe(project);
+        expect(await port.canonicalize(first ?? "", project)).toBe(first);
+      });
+    });
+
+    it("returns nearest-first ancestors ending at the filesystem root", async () => {
+      await withWorkspace(async ({ port, start, project }) => {
+        const ancestors = await port.ancestors(start);
+        expect(ancestors[0]?.path).toBe(start);
+        expect(ancestors.some(({ path }) => path === project)).toBe(true);
+        expect(ancestors.at(-1)?.path).toBe("/");
+      });
+    });
+
+    it("observes project-local marker and configuration bytes", async () => {
+      await withWorkspace(async ({ port, start, project }) => {
+        const candidate = (await port.ancestors(start)).find(
+          ({ path }) => path === project,
+        );
+        expect(candidate).toMatchObject({
+          path: project,
+          brain: "directory",
+          configuration: {
+            kind: "file",
+            text: '{"stateContract":"1.0.0"}\n',
+          },
+        });
+      });
+    });
+
+    it("locates a linked worktree and its principal root", async () => {
+      await withWorkspace(async ({ port, start, project, principal }) => {
+        expect(await port.locateWorktree(start)).toEqual({
+          kind: project === principal ? "principal" : "linked",
+          topLevel: project,
+          principal,
+        });
+      });
+    });
+
+    it.each(["", "bad\u0000path", "bad\\path", "C:\\private"])(
+      "refuses an unsafe canonicalization input %j",
+      async (path) => {
+        await withWorkspace(async ({ port, project }) => {
+          expect(await port.canonicalize(path, project)).toBeNull();
+        });
+      },
+    );
+
+    it("exposes no mutation operation", async () => {
+      await withWorkspace(({ port }) => {
+        expect(Object.keys(port).sort()).toEqual([
+          "ancestors",
+          "canonicalize",
+          "locateWorktree",
+        ]);
+        return Promise.resolve();
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #18

## Summary

- add deterministic project-root discovery for explicit roots, ancestors, Git repositories, and linked worktrees
- classify project-owned `.brain/config.json` before schema validation and preserve safe layered-setting provenance
- add read-only fake and Node workspace adapters with traversal, symlink, malformed Git, and ambiguous-topology defenses
- compose mutation ports only after an initialized project is selected
- publish the internal discovery contract without changing the shipped CLI surface or parity claims

## Design and compatibility

The implementation keeps state inside the project-owned `.brain/`. Legacy sibling state is observed only as migration-pending and is never read as current state. The `ConfigurationValidator` seam remains owned by RUN-04. No parity row moves; parity remains 0 / 400. No private predecessor source, path, or payload is published.

## Verification

- `npm run verify`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml .github/workflows/docs.yml`
- 53 test files / 664 tests
- 100% statements, branches, functions, and lines
- independent review: no remaining Critical or Important findings

## TDD failure evidence

Tests were observed failing before implementation for root selection, configuration classification, workspace adapters, path-safety properties, malformed Git markers, separate metadata ambiguity, and unexpected canonicalization errors.