### PR TITLE
feat: implement atomic filesystem transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ uses embedded schemas for validation before domain use and revalidates typed
 output before producing canonical JSON. Today this is validation infrastructure
 and project-configuration wiring only; it adds no state command or effect.
 
+The internal
+[atomic filesystem transaction contract](docs/architecture/atomic-transactions.md)
+now stages managed `.brain/` mutations, records incomplete work, and requires
+explicit token-bound crash recovery. It provides typed runtime infrastructure,
+not a public recovery command or a usable SDD trail.
+
 ### No global Yoda binary
 
 The new runtime is developed in TypeScript and distributed as a self-contained JavaScript ESM bundle inside the plugin. This avoids a separately installed global binary, PATH problems, and runtime/plugin version drift.

--- a/docs/architecture/atomic-transactions.md
+++ b/docs/architecture/atomic-transactions.md
@@ -7,9 +7,10 @@ It does not add a public state command or complete the SDD trail. The staged CLI
 still supports only `help`, `version`, and `handshake`.
 
 The boundary turns one normalized, ordered managed mutation plan into a durable
-transaction below `.brain/`. A dry run renders that same normalized plan and
-does not create transaction metadata. A plan whose results are already present
-is a no-op and also creates no transaction.
+transaction below `.brain/`. That normalized plan is currently an internal
+input to execution. This issue adds no public dry-run wiring; a future command
+can render the same plan without creating transaction metadata. A plan whose
+results are already present is a no-op and also creates no transaction.
 
 ## Managed scope and layout
 
@@ -99,8 +100,9 @@ bytes are not parsed and bounded abort cleanup removes it. A directory,
 symlink, special entry, unknown layout name, or a manifest referenced by a
 non-null digest remains strict corrupt-state evidence and is preserved.
 
-At and after `publishing`, recovery only rolls forward. It observes each
-destination instead of trusting whether the prior promise resolved:
+At and after `publishing`, recovery never aborts. It observes each destination
+instead of trusting whether the prior promise resolved, then rolls forward
+toward `committed` or blocks on unexpected evidence:
 
 - a destination matching its precondition is published next;
 - a destination already matching its result is recorded and skipped;
@@ -119,9 +121,10 @@ atomicity, not simultaneous visibility.
 
 While `publishing` exists, individual destinations may contain a mix of old and
 new bytes. Ordinary mutation and canonical-state consumption are blocked until
-explicit recovery either reaches `committed` or proves a safe pre-publication
-abort. The durable marker makes the mixed interval unavailable rather than
-pretending it did not occur.
+explicit recovery reaches `committed`. If the observed evidence cannot safely
+support roll-forward, recovery blocks and preserves it for diagnosis; it never
+aborts a publishing transaction. The durable marker makes the mixed interval
+unavailable rather than pretending it did not occur.
 
 ## Root bootstrap and synchronization
 

--- a/docs/architecture/atomic-transactions.md
+++ b/docs/architecture/atomic-transactions.md
@@ -1,0 +1,191 @@
+# Atomic Filesystem Transactions and Crash Recovery
+
+Issue [#20](https://github.com/thiagocorreanet/mestre-yoda/issues/20)
+(`RUN-05`) supplies the internal durable mutation boundary for the deterministic
+runtime epic [#15](https://github.com/thiagocorreanet/mestre-yoda/issues/15).
+It does not add a public state command or complete the SDD trail. The staged CLI
+still supports only `help`, `version`, and `handshake`.
+
+The boundary turns one normalized, ordered managed mutation plan into a durable
+transaction below `.brain/`. A dry run renders that same normalized plan and
+does not create transaction metadata. A plan whose results are already present
+is a no-op and also creates no transaction.
+
+## Managed scope and layout
+
+Caller-owned operations may create directories, write files, or delete regular
+files below `.brain/`. The transaction manager exclusively owns
+`.brain/transactions/**`; a caller cannot target that namespace, even through a
+case variant.
+
+An active or retained transaction uses this bounded layout:
+
+```text
+.brain/transactions/<transaction-id>/
+|-- manifest.json
+|-- progress.json
+`-- staging/
+    |-- operation-0001.payload
+    `-- operation-0002.payload
+```
+
+`progress.next` is the only progress scratch name. It is written, synchronized,
+renamed over `progress.json`, and removed after an interruption or terminal
+cleanup. Staging and scratch entries exist only while needed. A transaction
+that aborts before binding a manifest may retain only terminal `progress.json`;
+an abort after preparation or a committed transaction retains the immutable
+manifest and terminal progress but no staged payload bytes.
+
+The manifest contains the transaction identity, plan digest, creation time,
+ordered operation metadata, relative destinations, precondition and result
+fingerprints, and relative staged-payload references. It contains no payload
+content or absolute path.
+
+## Five monotonic phases
+
+| Phase | Durable meaning | Recovery direction |
+| --- | --- | --- |
+| `begun` | The exclusive transaction directory and identity progress exist. No managed destination has been published. | Abort after validating the bounded layout and identity. |
+| `prepared` | Payloads and the immutable manifest are durable, preconditions were rechecked, and the progress token is bound to the manifest digest. | Abort while destinations still match their preconditions. |
+| `publishing` | Roll-forward was durably authorized before the first destination mutation. | Publish or record each exact manifest result in order. |
+| `committed` | Every destination was inspected and matches its manifest result. | Finish bounded cleanup and return the same receipt. |
+| `aborted` | No managed destination was published. | Finish bounded cleanup without touching destinations and return the same receipt. |
+
+The only legal forward transitions are `begun` to `prepared`, `prepared` to
+`publishing`, `publishing` to `committed`, and `begun` or `prepared` to
+`aborted`. Terminal phases never transition back.
+
+## Preparation and publication
+
+Execution follows one observable sequence:
+
+1. reject or reconcile existing transaction metadata before loading canonical
+   state for mutation;
+2. freeze the input and validate every operation, path relationship,
+   fingerprint, staged name, and payload digest before I/O;
+3. require or explicitly bootstrap the managed roots;
+4. create the transaction directory exclusively and persist `begun`;
+5. write and synchronize each staged payload, then synchronize staging;
+6. write and synchronize the canonical manifest, then synchronize its
+   directory;
+7. recheck every precondition and persist `prepared`;
+8. persist `publishing` before changing the first destination;
+9. publish operations in manifest order, synchronizing the affected directory,
+   inspecting the result, and atomically advancing progress after each one;
+10. inspect all results, persist `committed`, and remove staging and scratch
+    entries.
+
+Each file write is published by a same-filesystem atomic rename. A delete
+removes only the regular file matching its precondition. Directory creation is
+an explicit plan operation and never hides recursive parent creation.
+
+## Recovery identity and direction
+
+Inspection is read-only. It returns relative evidence and the transaction
+identifier, phase, manifest digest where one is bound, and recovery token. A
+normal mutation that finds a non-terminal marker or terminal cleanup residue
+returns `runtime.recovery_required`; it never recovers implicitly or consumes
+possibly mixed canonical state.
+
+Explicit recovery must present both the exact transaction identifier and its
+recovery token. The `begun` token digests the immutable transaction identity.
+The transition to `prepared` replaces it with the manifest digest, after which
+it never changes. A stale identifier or token cannot authorize a replacement
+transaction.
+
+Before `publishing`, recovery aborts. A regular `manifest.json` with a null
+`manifestDigest` is known transaction-manager scratch, not an authority: its
+bytes are not parsed and bounded abort cleanup removes it. A directory,
+symlink, special entry, unknown layout name, or a manifest referenced by a
+non-null digest remains strict corrupt-state evidence and is preserved.
+
+At and after `publishing`, recovery only rolls forward. It observes each
+destination instead of trusting whether the prior promise resolved:
+
+- a destination matching its precondition is published next;
+- a destination already matching its result is recorded and skipped;
+- a destination matching neither fingerprint blocks as corruption;
+- a missing or mismatched required payload blocks as corruption; and
+- committed or aborted cleanup can be repeated without changing the receipt.
+
+Recovery is therefore idempotent across failures before an effect, after an
+effect, after synchronization, or after a terminal cleanup operation.
+
+## Recoverable atomicity
+
+A portable filesystem cannot make several independent destination renames
+simultaneously visible. This contract provides recoverable multi-file
+atomicity, not simultaneous visibility.
+
+While `publishing` exists, individual destinations may contain a mix of old and
+new bytes. Ordinary mutation and canonical-state consumption are blocked until
+explicit recovery either reaches `committed` or proves a safe pre-publication
+abort. The durable marker makes the mixed interval unavailable rather than
+pretending it did not occur.
+
+## Root bootstrap and synchronization
+
+`existing` is the default root mode. It requires both `.brain/` and
+`.brain/transactions/` to be real no-follow directories. It creates neither.
+
+The explicit `initialize` mode may create only a missing empty `.brain/` and
+its transaction namespace. A pre-existing `.brain/` must be empty before the
+reserved namespace can be bootstrapped. Bootstrap directory creation is
+idempotent metadata setup, not accepted workflow state.
+
+File synchronization is mandatory. Directory synchronization is attempted and
+recorded as `supported` or `unsupported`. Only the specifically classified
+Windows directory-handle error is downgraded to `unsupported`; an unexpected
+synchronization error fails the operation. Progress and receipts record the
+capability actually observed.
+
+## Stable failures
+
+| Condition | Universal reason |
+| --- | --- |
+| Incomplete transaction or terminal cleanup residue | `runtime.recovery_required` |
+| Destination drift before publication | `runtime.revision_conflict` |
+| Invalid marker, bound manifest, progress, payload, layout, or ambiguous destination | `runtime.state_corrupt` |
+| Destination outside `.brain/` or inside the reserved namespace | `guard.outside_allow` |
+| Unexpected failure before a durable marker exists | `runtime.internal_failure` |
+
+Universal results use catalog text and relative evidence only. They never
+interpolate internal error messages, absolute project roots, environment data,
+or staged bytes. A partial publication reports `stateChanged: false` because no
+new canonical transaction was accepted; explicit recovery must make the
+transaction terminal first.
+
+## Path and cleanup safety
+
+Every destination must be one canonical project-relative spelling below
+`.brain/`. Absolute, drive-qualified, backslash-bearing, control-character,
+traversing, empty, reserved, overlapping, contradictory, and case-colliding
+paths are rejected before mutation.
+
+The Node adapter anchors operations to the original canonical project root and
+revalidates that root plus every existing path component without following
+symlinks. Existing write and delete destinations must be regular files. FIFOs,
+devices, sockets, symlinks, and other special entries are observed but never
+read, replaced, or removed.
+
+Cleanup enumerates only the validated transaction layout. It removes known
+payloads, `progress.next`, an unbound regular manifest, and the empty staging
+directory. It never performs an unconstrained recursive deletion.
+
+## Verification evidence
+
+The deterministic fake enumerates all 13 `DurableOperation` variants. The
+two-write and one-delete campaign reaches 12 variants and 110 operation
+occurrences; `read_text` is correctly recorded as unreachable during normal
+execution. Injecting both `before` and `after` at every reached occurrence
+produces 220 recovery cases. Every case inspects, explicitly recovers when a
+marker exists, recovers again, and checks the exact terminal destinations and
+receipt.
+
+Synthetic `permission` and `disk_full` labels prove catalog-backed sanitized
+results without changing host permissions or consuming disk capacity. Separate
+process tests bundle a temporary worker, stop the real Node adapter at 13 IPC
+barriers from `begun` through cleanup, and inspect and recover in fresh
+processes. The tests use only temporary directories and explicit IPC timeouts;
+they never fill a disk, change global permissions, or pass payloads through the
+environment.

--- a/docs/architecture/runtime-boundaries.md
+++ b/docs/architecture/runtime-boundaries.md
@@ -184,22 +184,27 @@ That separation is what makes a dry run the same decision with the plan rendered
 instead of applied, rather than a parallel code path that can drift from the
 real one.
 
-`applyPlan` switches exhaustively over the effect kinds. Exhaustiveness is
-enforced by assigning the default case to `never`: because the function returns
-`void`, the switch would otherwise carry no obligation at all and a new variant
-would be silently no-op'd. Effects are applied in declared order.
+`applyPlan` snapshots the effect plan before its first asynchronous boundary.
+It normalizes managed create, write, and delete effects into one exact ordered
+plan, then commits them through the
+[atomic transaction boundary](atomic-transactions.md). Structured and human
+emits remain outside that transaction and run in declared order only after a
+commit. `append_event` remains refused until its owning event-store issue
+supplies the canonical append operation.
 
-A failing effect **stops** the run rather than being stepped over. The
-already-applied prefix is not rolled back: atomicity is `RUN-05`'s transaction
-boundary, and this issue does not claim to provide it.
+The transaction driver observes one durable primitive at a time and asks the
+pure recovery policy what to do next. A rejected promise is not treated as
+proof that its effect did not happen; fresh destination fingerprints determine
+whether explicit recovery aborts or rolls forward.
 
 ## Scope
 
-These foundation issues deliver the runtime and schema boundaries; they define
-no workflow policy, transition, state writer, or new command. The objective
-lifecycle, guardrails, event store, locks, and host adapters fill them in
-through their own issues. Read-only project discovery now uses the schema
-registry without changing the shipped command surface.
+These foundation issues deliver runtime, schema, and internal durable mutation
+boundaries; they define no workflow policy, objective transition, event writer,
+or new command. The objective lifecycle, guardrails, event store, locks, and
+host adapters fill them in through their own issues. Read-only project
+discovery and typed transaction inspection remain internal and do not change
+the shipped command surface.
 
 Parity remains `0 / 400 (0.00%)`. This is internal structure and adds no
 differential, integration, or E2E evidence to any row.

--- a/docs/architecture/runtime-boundaries.md
+++ b/docs/architecture/runtime-boundaries.md
@@ -180,9 +180,11 @@ schema discovery.
 The domain does not call ports. It returns an ordered `EffectPlan` describing
 what should happen, and the caller applies it.
 
-That separation is what makes a dry run the same decision with the plan rendered
-instead of applied, rather than a parallel code path that can drift from the
-real one.
+That separation keeps the decision previewable without creating a second
+decision path. The normalized managed plan is currently internal to execution;
+public dry-run wiring is outside these foundation issues. A future dry-run
+surface must render that same normalized plan instead of deriving a parallel
+plan that can drift from the applied one.
 
 `applyPlan` snapshots the effect plan before its first asynchronous boundary.
 It normalizes managed create, write, and delete effects into one exact ordered
@@ -192,10 +194,13 @@ emits remain outside that transaction and run in declared order only after a
 commit. `append_event` remains refused until its owning event-store issue
 supplies the canonical append operation.
 
-The transaction driver observes one durable primitive at a time and asks the
-pure recovery policy what to do next. A rejected promise is not treated as
-proof that its effect did not happen; fresh destination fingerprints determine
-whether explicit recovery aborts or rolls forward.
+Normal execution follows the fixed prepare-and-publish sequence and does not use
+`decideRecovery` as its control loop. That pure policy is limited to explicit
+recovery and failure classification after an execution attempt rejects. A
+rejected promise is not proof that its effect did not happen: those paths use
+fresh destination fingerprints. Explicit recovery may abort before
+`publishing`; once `publishing` is durable, it only rolls forward to `committed`
+or blocks on unexpected evidence.
 
 ## Scope
 

--- a/docs/superpowers/plans/2026-08-09-atomic-filesystem-transactions.md
+++ b/docs/superpowers/plans/2026-08-09-atomic-filesystem-transactions.md
@@ -1,0 +1,1155 @@
+# Atomic Filesystem Transactions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `.brain/`-confined durable transaction boundary that stages,
+publishes, diagnoses, and explicitly recovers multi-file state mutations.
+
+**Architecture:** Pure domain modules normalize effect plans and decide legal
+transaction/recovery transitions. A narrow `DurableFileSystem` port exposes the
+observable filesystem primitives; deterministic memory and real Node adapters
+share one contract, while composition drives one primitive at a time and maps
+typed failures into the existing result catalog.
+
+**Tech Stack:** TypeScript 6, Node.js 24.18.0, npm 11.16.0, Vitest 4, Ajv 8,
+JSON Schema draft 2020-12, esbuild, and Node `fs/promises`/`crypto`.
+
+## Global Constraints
+
+- Do not start Task 1 until PR #91 (`RUN-04`) is merged and the implementation
+  branch is rebased on the resulting `origin/main`.
+- Use exactly Node.js `24.18.0` and npm `11.16.0`.
+- Keep source, schemas, fixtures, tests, errors, docs, commits, and PR text in
+  English.
+- Add no runtime network access and no new production dependency.
+- Domain and ports must not import a Node builtin.
+- Caller destinations are limited to normalized paths below `.brain/`;
+  `.brain/transactions/**` is reserved for the transaction manager.
+- `existing` root mode is the default. Only explicit `initialize` mode may
+  create empty `.brain/` and `.brain/transactions/` bootstrap directories.
+- Before `publishing`, recovery may abort. At or after `publishing`, recovery
+  only rolls forward or blocks on unexpected evidence.
+- Never expose payload bytes, absolute paths, or secrets in public artifacts.
+- Run narrow tests first and end every task with a signed-off English commit.
+
+## File Structure
+
+- `domain/transactions/model.ts`: immutable domain types.
+- `domain/transactions/normalize.ts`: effect-plan and managed-path policy.
+- `domain/transactions/transition.ts`: legal phase changes.
+- `domain/transactions/recovery.ts`: pure recovery decisions.
+- `ports/transactions.ts`: durable filesystem and digest interfaces.
+- `infra/digests.ts`: SHA-256 adapter.
+- `infra/fake/transactions.ts`: memory adapter and failure controller.
+- `infra/node/transactions.ts`: no-follow Node primitives.
+- `composition/transactions.ts`: execution, inspection, and recovery driver.
+- `tests/support/transaction-port-contract.ts`: shared adapter contract.
+- `tests/fixtures/transactions/worker.ts`: child-process crash driver.
+
+---
+
+### Task 1: Register transaction manifest and progress contracts
+
+**Files:**
+
+- Create: `schemas/state/transaction-manifest.v1.schema.json`
+- Create: `schemas/state/transaction-progress.v1.schema.json`
+- Create: `fixtures/contracts/v1/transaction-manifest.json`
+- Create: `fixtures/contracts/v1/transaction-progress.json`
+- Modify: `packages/contracts/catalogs/contract-families.v1.json`
+- Modify: `packages/contracts/src/generated/contracts.ts` through the generator
+- Modify: `packages/contracts/src/index.ts`
+- Modify: `packages/runtime/src/domain/schema/contracts.ts`
+- Modify: `packages/runtime/src/infra/schema/catalog.ts`
+- Modify: `schemas/README.md`
+- Test: `tests/contract-schemas.test.ts`
+- Test: `tests/contract-type-generation.test.ts`
+- Test: `tests/schema-catalog.test.ts`
+- Test: `tests/schema-registry-types.test.ts`
+
+**Interfaces:**
+
+- Consumes: merged `SchemaRegistry.validate()` and `canonicalizeJson()`.
+- Produces: generated `TransactionManifestV1`, `TransactionProgressV1`, and
+  registry IDs `state.transaction-manifest` and `state.transaction-progress`.
+
+- [ ] **Step 1: Add failing contract inventory tests**
+
+Add both artifacts to `tests/contract-schemas.test.ts` and both IDs to the
+closed registry type test:
+
+```ts
+[
+  "state/transaction-manifest.v1.schema.json",
+  "transaction-manifest.json",
+  "state",
+],
+[
+  "state/transaction-progress.v1.schema.json",
+  "transaction-progress.json",
+  "state",
+],
+```
+
+```ts
+expectTypeOf<
+  ContractValue<"state.transaction-manifest">
+>().toEqualTypeOf<TransactionManifestV1>();
+expectTypeOf<
+  ContractValue<"state.transaction-progress">
+>().toEqualTypeOf<TransactionProgressV1>();
+```
+
+Change the closed schema count from 8 to 10.
+
+- [ ] **Step 2: Verify the tests fail for absent contracts**
+
+```bash
+npm test -- tests/contract-schemas.test.ts tests/schema-registry-types.test.ts
+```
+
+Expected: FAIL because schemas, fixtures, exports, and IDs are absent.
+
+- [ ] **Step 3: Add closed schemas and fixtures**
+
+The manifest must require these exact top-level fields:
+
+```json
+{
+  "contractVersion": "1.0.0",
+  "stateContract": "1.0.0",
+  "transactionId": "transaction-01",
+  "planDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "createdAt": "2026-08-09T00:00:00.000Z",
+  "operations": [
+    {
+      "operationId": "operation-0001",
+      "kind": "write_file",
+      "path": ".brain/state.json",
+      "expected": { "kind": "missing" },
+      "result": {
+        "kind": "file",
+        "size": 3,
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "stagedPath": ".brain/transactions/transaction-01/staging/operation-0001.payload"
+    }
+  ]
+}
+```
+
+Set `operations.minItems` to 1. Each closed operation requires
+`operationId`, `kind`, `path`, `expected`, `result`, and `stagedPath`. Use kinds
+`create_directory`, `write_file`, and `delete_file`; fingerprints are the closed
+union `missing`, `directory`, or `file` with safe integer byte size and SHA-256.
+Require non-null `stagedPath` only for a write through `allOf` conditionals.
+
+The progress schema and fixture use:
+
+```json
+{
+  "contractVersion": "1.0.0",
+  "stateContract": "1.0.0",
+  "transactionId": "transaction-01",
+  "manifestDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "recoveryToken": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "phase": "prepared",
+  "publishedOperationIds": [],
+  "fileSync": "required",
+  "directorySync": "supported",
+  "createdAt": "2026-08-09T00:00:00.000Z",
+  "updatedAt": "2026-08-09T00:00:01.000Z"
+}
+```
+
+Require `recoveryToken` as SHA-256. Allow `manifestDigest: null` for `begun` and
+for an `aborted` transaction that never reached `prepared`; require a digest
+for `prepared`, `publishing`, and `committed`. Phases are `begun`, `prepared`,
+`publishing`, `committed`, and `aborted`. Reuse the neighboring state schemas'
+bounded ID, safe relative reference, SHA-256, integer, and UTC definitions.
+
+- [ ] **Step 4: Register and generate types**
+
+Append these manifest entries in order:
+
+```json
+{
+  "id": "state.transaction-manifest",
+  "family": "state",
+  "version": "1.0.0",
+  "path": "schemas/state/transaction-manifest.v1.schema.json",
+  "boundary": "persisted",
+  "typeName": "TransactionManifestV1"
+},
+{
+  "id": "state.transaction-progress",
+  "family": "state",
+  "version": "1.0.0",
+  "path": "schemas/state/transaction-progress.v1.schema.json",
+  "boundary": "persisted",
+  "typeName": "TransactionProgressV1"
+}
+```
+
+Wire both into contract exports, `ContractValues`, embedded catalog imports,
+entries, and expected IDs. Run `npm run contracts:generate`.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+npm test -- tests/contract-schemas.test.ts tests/contract-type-generation.test.ts tests/schema-catalog.test.ts tests/schema-registry-types.test.ts
+npm run contracts:check
+git add schemas fixtures/contracts/v1 packages/contracts packages/runtime/src/domain/schema/contracts.ts packages/runtime/src/infra/schema/catalog.ts tests/contract-schemas.test.ts tests/contract-type-generation.test.ts tests/schema-catalog.test.ts tests/schema-registry-types.test.ts
+git commit -s -m "feat: register transaction state contracts"
+```
+
+Expected: PASS and contract verification reports 10 schemas.
+
+---
+
+### Task 2: Normalize managed mutation plans
+
+**Files:**
+
+- Create: `packages/runtime/src/domain/transactions/model.ts`
+- Create: `packages/runtime/src/domain/transactions/normalize.ts`
+- Create: `packages/runtime/src/domain/transactions/index.ts`
+- Modify: `packages/runtime/package.json`
+- Test: `tests/transaction-normalization.test.ts`
+- Test: `tests/transaction-normalization-properties.test.ts`
+
+**Interfaces:**
+
+- Consumes: `EffectPlan`, an observed path map, and injected SHA-256 function.
+- Produces: `normalizeManagedMutationPlan`, `ManagedMutationPlan`,
+  `ManagedOperation`, `PathFingerprint`, and `TransactionPolicyError`.
+
+- [ ] **Step 1: Write failing examples**
+
+Assert a `.brain/runs/a/state.json` write becomes `operation-0001`; output
+effects are excluded; missing parents become explicit earlier operations;
+already-equal writes produce `{ kind: "noop" }`; and declared order is stable.
+Assert `append_event`, outside `.brain/`, `.brain` itself, reserved metadata,
+traversal, backslashes, drives, controls, overlaps, and delete-directory fail.
+
+```ts
+expect(() =>
+  normalizeManagedMutationPlan(
+    planOf({
+      kind: "write_file",
+      path: ".brain/transactions/forbidden",
+      content: "x",
+    }),
+    new Map(),
+    sha256,
+  ),
+).toThrowError(
+  expect.objectContaining({ reasonCode: "guard.outside_allow" }),
+);
+```
+
+- [ ] **Step 2: Confirm the module is absent**
+
+```bash
+npm test -- tests/transaction-normalization.test.ts tests/transaction-normalization-properties.test.ts
+```
+
+Expected: FAIL on missing package export.
+
+- [ ] **Step 3: Define the exact domain vocabulary**
+
+```ts
+export type PathFingerprint =
+  | { readonly kind: "missing" }
+  | { readonly kind: "directory" }
+  | { readonly kind: "file"; readonly size: number; readonly sha256: string };
+
+export interface ManagedMutationPlan {
+  readonly operations: readonly ManagedOperation[];
+}
+
+export class TransactionPolicyError extends Error {
+  public constructor(
+    public readonly reasonCode:
+      | "guard.outside_allow"
+      | "runtime.state_corrupt",
+  ) {
+    super("Managed mutation plan is invalid");
+    this.name = "TransactionPolicyError";
+  }
+}
+```
+
+Define the three-operation discriminated union with `operationId`, `kind`,
+`path`, `expected`, `result`, and `stagedPath`; only writes carry transient
+`content`, and persisted conversion must omit it.
+
+- [ ] **Step 4: Implement normalization**
+
+```ts
+export function normalizeManagedMutationPlan(
+  effectPlan: EffectPlan,
+  observations: ReadonlyMap<string, PathFingerprint>,
+  sha256: (text: string) => string,
+):
+  | { readonly kind: "noop" }
+  | { readonly kind: "ready"; readonly plan: ManagedMutationPlan };
+```
+
+Use forward-slash segments, require `.brain` first, refuse `transactions`
+second, synthesize each absent parent once, calculate UTF-8 size without Node,
+remove satisfied operations, and assign IDs after final ordering.
+
+- [ ] **Step 5: Add deterministic generated cases and commit**
+
+Generate 200 safe and 200 unsafe paths with the repository's seeded generator.
+Assert repeated normalization is identical and no accepted path escapes.
+
+```bash
+npm test -- tests/transaction-normalization.test.ts tests/transaction-normalization-properties.test.ts
+npm run typecheck
+git add packages/runtime/src/domain/transactions packages/runtime/package.json tests/transaction-normalization*.test.ts
+git commit -s -m "feat: normalize managed mutation plans"
+```
+
+---
+
+### Task 3: Implement pure phase and recovery decisions
+
+**Files:**
+
+- Create: `packages/runtime/src/domain/transactions/transition.ts`
+- Create: `packages/runtime/src/domain/transactions/recovery.ts`
+- Modify: `packages/runtime/src/domain/transactions/model.ts`
+- Modify: `packages/runtime/src/domain/transactions/index.ts`
+- Test: `tests/transaction-transition.test.ts`
+- Test: `tests/transaction-recovery-properties.test.ts`
+
+**Interfaces:**
+
+- Consumes: manifest, progress, and observed fingerprints.
+- Produces: `assertPhaseTransition`, `decideRecovery`,
+  `TransactionObservation`, and `RecoveryDecision`.
+
+```ts
+export interface TransactionObservation {
+  readonly destinations: ReadonlyMap<string, PathFingerprint>;
+  readonly stagedPayloads: ReadonlyMap<string, PathFingerprint>;
+}
+
+export function assertPhaseTransition(
+  from: TransactionProgressV1["phase"],
+  to: TransactionProgressV1["phase"],
+): void;
+
+export function decideRecovery(
+  manifest: TransactionManifestV1,
+  progress: TransactionProgressV1,
+  observation: TransactionObservation,
+): RecoveryDecision;
+```
+
+- [ ] **Step 1: Write the complete phase table test**
+
+Legal edges are exactly:
+
+```ts
+const legal = [
+  ["begun", "prepared"],
+  ["begun", "aborted"],
+  ["prepared", "publishing"],
+  ["prepared", "aborted"],
+  ["publishing", "committed"],
+] as const;
+```
+
+Test every pair in the five-phase Cartesian product; all other edges throw
+`Illegal transaction phase transition`.
+
+- [ ] **Step 2: Write the recovery table tests**
+
+```ts
+expect(decideRecovery(manifest, begun, allPreconditions)).toEqual({
+  kind: "abort",
+});
+expect(decideRecovery(manifest, publishing, firstAlreadyPublished)).toEqual({
+  kind: "record_published",
+  operationId: "operation-0001",
+});
+expect(decideRecovery(manifest, publishing, nextAtPrecondition)).toEqual({
+  kind: "publish",
+  operationId: "operation-0002",
+});
+expect(decideRecovery(manifest, publishing, unexpectedTarget)).toEqual({
+  kind: "blocked",
+  reasonCode: "runtime.state_corrupt",
+  operationId: "operation-0002",
+});
+```
+
+Add committed/aborted cleanup and all-results commit cases.
+
+- [ ] **Step 3: Confirm missing behavior**
+
+```bash
+npm test -- tests/transaction-transition.test.ts tests/transaction-recovery-properties.test.ts
+```
+
+Expected: FAIL on missing exports.
+
+- [ ] **Step 4: Implement the closed decision union**
+
+```ts
+export type RecoveryDecision =
+  | { readonly kind: "abort" }
+  | { readonly kind: "record_published"; readonly operationId: string }
+  | { readonly kind: "publish"; readonly operationId: string }
+  | { readonly kind: "commit" }
+  | { readonly kind: "cleanup"; readonly terminal: "committed" | "aborted" }
+  | { readonly kind: "complete"; readonly terminal: "committed" | "aborted" }
+  | {
+      readonly kind: "blocked";
+      readonly reasonCode: "runtime.state_corrupt";
+      readonly operationId: string | null;
+    };
+```
+
+Validate identity, digest, unique progress IDs, and manifest-order prefix.
+Compare each destination with both expected and result fingerprints; never
+infer success from progress alone.
+
+- [ ] **Step 5: Add generated crash-state properties and commit**
+
+Generate 1-20 operation plans at every crash index. Assert pre-publication only
+aborts, publishing never aborts, successful decisions terminate, published IDs
+are monotonic, and terminal decisions are idempotent.
+
+```bash
+npm test -- tests/transaction-transition.test.ts tests/transaction-recovery-properties.test.ts
+npm run typecheck
+git add packages/runtime/src/domain/transactions tests/transaction-transition.test.ts tests/transaction-recovery-properties.test.ts
+git commit -s -m "feat: decide deterministic transaction recovery"
+```
+
+---
+
+### Task 4: Define the durable filesystem port and shared contract
+
+**Files:**
+
+- Create: `packages/runtime/src/ports/transactions.ts`
+- Modify: `packages/runtime/src/ports/index.ts`
+- Create: `packages/runtime/src/infra/digests.ts`
+- Create: `tests/support/transaction-port-contract.ts`
+- Modify: `tests/ports-contract.test.ts`
+- Test: `tests/transaction-digests.test.ts`
+
+**Interfaces:**
+
+- Consumes: project-relative paths and UTF-8 strings.
+- Produces: `DurableFileSystem`, `Digests`, `DurableEntry`, and
+  `sha256Digests()`.
+
+- [ ] **Step 1: Add compile-time and behavioral tests first**
+
+Define the expected interface in the tests:
+
+```ts
+export interface DurableFileSystem {
+  inspect(path: string): Promise<DurableEntry>;
+  list(path: string): Promise<readonly string[]>;
+  readText(path: string): Promise<string>;
+  createDirectory(path: string): Promise<void>;
+  createDirectoryExclusive(path: string): Promise<void>;
+  writeSynced(path: string, content: string): Promise<void>;
+  replaceFile(stagedPath: string, targetPath: string): Promise<void>;
+  removeFile(path: string): Promise<void>;
+  removeEmptyDirectory(path: string): Promise<void>;
+  syncDirectory(path: string): Promise<"supported" | "unsupported">;
+}
+
+export interface Digests {
+  sha256(text: string): string;
+}
+```
+
+`DurableEntry` is a closed union of `missing`, `directory`, `symlink`,
+`special`, and regular `file` with byte size and SHA-256. The shared contract
+asserts complete write/read, exclusive create, replace, regular delete,
+empty-directory-only removal, sorted listing, and identical unsafe-path refusal.
+
+```ts
+export type DurableEntry =
+  | { readonly kind: "missing" }
+  | { readonly kind: "directory" | "symlink" | "special" }
+  | { readonly kind: "file"; readonly size: number; readonly sha256: string };
+```
+
+- [ ] **Step 2: Confirm the types are absent**
+
+Run `npm run typecheck`; expect missing transaction port exports.
+
+- [ ] **Step 3: Add the interface and digest implementation**
+
+```ts
+import { createHash } from "node:crypto";
+import type { Digests } from "../ports/index.js";
+
+export function sha256Digests(): Digests {
+  return {
+    sha256: (text) => createHash("sha256").update(text, "utf8").digest("hex"),
+  };
+}
+```
+
+Keep this Node import in `infra`; domain and ports remain builtin-free.
+
+- [ ] **Step 4: Export the shared contract suite**
+
+Create `describeDurableFileSystemContract(label, factory)` using the same
+`Disposable<T>` shape as other port suites. Do not broaden the existing simple
+`FileSystem` contract.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+npm test -- tests/transaction-digests.test.ts tests/architecture.test.ts
+npm run typecheck
+git add packages/runtime/src/ports packages/runtime/src/infra/digests.ts tests/support/transaction-port-contract.ts tests/ports-contract.test.ts tests/transaction-digests.test.ts
+git commit -s -m "feat: define durable filesystem transaction port"
+```
+
+The shared suite may remain without a factory only until Task 5; do not skip
+individual assertions.
+
+---
+
+### Task 5: Build the memory adapter and failure controller
+
+**Files:**
+
+- Create: `packages/runtime/src/infra/fake/transactions.ts`
+- Modify: `packages/runtime/src/infra/fake/index.ts`
+- Modify: `tests/ports-contract.test.ts`
+- Test: `tests/fake-transactions.test.ts`
+
+**Interfaces:**
+
+- Consumes: optional seed files/directories.
+- Produces: `memoryTransactionStorage`, shared simple/durable views,
+  `snapshot()`, `calls()`, and `fail(rule)`.
+
+- [ ] **Step 1: Invoke the shared contract before the factory exists**
+
+```ts
+describeDurableFileSystemContract("memory", async () => {
+  const storage = memoryTransactionStorage();
+  return { port: storage.durableFileSystem, dispose: async () => undefined };
+});
+```
+
+Add an ambiguous after-effect failure assertion:
+
+```ts
+storage.fail({ operation: "replace_file", timing: "after", occurrence: 1 });
+await storage.durableFileSystem.writeSynced(".brain/staged", "new");
+await expect(
+  storage.durableFileSystem.replaceFile(".brain/staged", ".brain/state.json"),
+).rejects.toThrow("Injected durable filesystem failure");
+expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+```
+
+- [ ] **Step 2: Run and observe the missing factory**
+
+```bash
+npm test -- tests/ports-contract.test.ts tests/fake-transactions.test.ts
+```
+
+Expected: FAIL on `memoryTransactionStorage`.
+
+- [ ] **Step 3: Implement one shared memory model**
+
+```ts
+export type DurableOperation =
+  | "inspect"
+  | "list"
+  | "read_text"
+  | "create_directory"
+  | "create_directory_exclusive"
+  | "open_file"
+  | "write_file"
+  | "sync_file"
+  | "close_file"
+  | "replace_file"
+  | "remove_file"
+  | "remove_empty_directory"
+  | "sync_directory";
+
+export interface FailureRule {
+  readonly operation: DurableOperation;
+  readonly timing: "before" | "after";
+  readonly occurrence: number;
+  readonly fault?: "generic" | "permission" | "disk_full";
+}
+
+export interface MemoryTransactionStorage {
+  readonly fileSystem: FileSystem;
+  readonly durableFileSystem: DurableFileSystem;
+  readonly digests: Digests;
+  readonly fail: (rule: FailureRule) => void;
+  readonly calls: () => readonly DurableOperation[];
+  readonly snapshot: () => {
+    readonly files: Readonly<Record<string, string>>;
+    readonly directories: readonly string[];
+  };
+}
+```
+
+Use one map/set model for both views. Check failure rules immediately before and
+after primitives, count occurrences per operation, and clone snapshots.
+`writeSynced` must emit `open_file`, `write_file`, `sync_file`, and `close_file`
+in that order so the fault campaign reaches every durable boundary.
+
+- [ ] **Step 4: Prove before/after behavior for every operation**
+
+Table-drive all `DurableOperation` values. Before-fail leaves storage unchanged;
+after-fail exposes the completed effect. Assert recorded calls contain no
+content or absolute path values.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+npm test -- tests/ports-contract.test.ts tests/fake-transactions.test.ts
+npm run typecheck
+git add packages/runtime/src/infra/fake tests/ports-contract.test.ts tests/fake-transactions.test.ts
+git commit -s -m "test: add fault-injectable transaction storage"
+```
+
+---
+
+### Task 6: Drive preparation, publication, inspection, and recovery
+
+**Files:**
+
+- Create: `packages/runtime/src/composition/transactions.ts`
+- Modify: `packages/runtime/src/composition/index.ts`
+- Test: `tests/transaction-execution.test.ts`
+- Test: `tests/transaction-recovery.test.ts`
+- Test: `tests/transaction-schema-boundary.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ManagedMutationPlan`, clock, IDs, digests, durable filesystem, and
+  schema registry.
+- Produces: `executeManagedMutation`, `inspectManagedTransactions`,
+  `recoverManagedMutation`, `TransactionReceipt`, and `TransactionFailure`.
+
+```ts
+export interface TransactionReceipt {
+  readonly transactionId: string;
+  readonly manifestDigest: string | null;
+  readonly recoveryToken: string;
+  readonly phase: "committed" | "aborted";
+  readonly directorySync: "not_attempted" | "supported" | "unsupported";
+}
+
+export interface TransactionSummary {
+  readonly transactionId: string;
+  readonly manifestDigest: string | null;
+  readonly recoveryToken: string;
+  readonly phase: TransactionProgressV1["phase"];
+  readonly evidenceRef: string;
+}
+
+export function executeManagedMutation(
+  plan: ManagedMutationPlan,
+  options: { readonly rootMode: "existing" | "initialize" },
+  services: TransactionServices,
+): Promise<TransactionReceipt>;
+
+export function inspectManagedTransactions(
+  services: TransactionServices,
+): Promise<readonly TransactionSummary[]>;
+
+export function recoverManagedMutation(
+  request: { readonly transactionId: string; readonly recoveryToken: string },
+  services: TransactionServices,
+): Promise<TransactionReceipt>;
+```
+
+- [ ] **Step 1: Write successful execution first**
+
+```ts
+const receipt = await executeManagedMutation(plan, { rootMode: "existing" }, {
+  clock: fixedClock("2026-08-09T00:00:00.000Z"),
+  ids: sequentialIds("transaction"),
+  digests: storage.digests,
+  durableFileSystem: storage.durableFileSystem,
+  schemaRegistry: createSchemaRegistry(),
+});
+expect(receipt).toMatchObject({
+  transactionId: "transaction-1",
+  phase: "committed",
+  directorySync: "supported",
+});
+```
+
+Create `storage` with seeded `.brain` and `.brain/transactions` directories so
+this example tests `existing` mode. Add a separate empty-storage test for
+`initialize` mode.
+
+Assert terminal metadata remains, staging payloads are gone, and manifest/
+progress validate without a `content` property.
+
+- [ ] **Step 2: Write explicit recovery tests**
+
+Cover failure after prepared progress, after first rename, after directory sync,
+committed cleanup failure, stale ID/token, and an unexpected destination.
+Normal execution with a marker must throw:
+
+```ts
+expect(error).toMatchObject({
+  reasonCode: "runtime.recovery_required",
+  evidence: [
+    {
+      kind: "artifact",
+      ref: ".brain/transactions/transaction-1/progress.json",
+    },
+  ],
+});
+```
+
+Repeated recovery returns the same terminal receipt.
+
+- [ ] **Step 3: Confirm missing composition exports**
+
+```bash
+npm test -- tests/transaction-execution.test.ts tests/transaction-recovery.test.ts tests/transaction-schema-boundary.test.ts
+```
+
+Expected: FAIL on missing functions.
+
+- [ ] **Step 4: Add typed services and safe failure**
+
+```ts
+export interface TransactionServices {
+  readonly clock: Clock;
+  readonly ids: Ids;
+  readonly digests: Digests;
+  readonly durableFileSystem: DurableFileSystem;
+  readonly schemaRegistry: SchemaRegistry;
+}
+
+export class TransactionFailure extends Error {
+  public constructor(
+    public readonly reasonCode:
+      | "guard.outside_allow"
+      | "runtime.internal_failure"
+      | "runtime.recovery_required"
+      | "runtime.revision_conflict"
+      | "runtime.state_corrupt",
+    public readonly evidence: readonly EvidenceRef[],
+  ) {
+    super("Managed transaction failed");
+    this.name = "TransactionFailure";
+  }
+}
+```
+
+- [ ] **Step 5: Implement the observe/decide/apply driver**
+
+Order: reject incomplete markers; verify root mode; create exclusive transaction
+directory; persist `begun`; stage/sync payloads; canonicalize, validate, and sync
+manifest; recheck preconditions; persist `prepared`; persist `publishing`; then
+publish in order and finish `committed` cleanup.
+
+Use this single atomic progress helper:
+
+```ts
+async function persistProgress(
+  progress: TransactionProgressV1,
+  services: TransactionServices,
+): Promise<void> {
+  validateProgress(progress, services.schemaRegistry);
+  const encoded = `${canonicalizeJson(progress)}\n`;
+  const root = transactionRoot(progress.transactionId);
+  await services.durableFileSystem.writeSynced(`${root}/progress.next`, encoded);
+  await services.durableFileSystem.replaceFile(
+    `${root}/progress.next`,
+    `${root}/progress.json`,
+  );
+  await services.durableFileSystem.syncDirectory(root);
+}
+```
+
+After a rejected primitive, re-observe phase and targets before classifying it.
+
+- [ ] **Step 6: Implement bootstrap and safe cleanup**
+
+`existing` refuses missing `.brain`; `initialize` creates and syncs only empty
+`.brain` and `.brain/transactions`. Cleanup removes validated staged regular
+files and known empty directories, never recursively removing unknown content.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+npm test -- tests/transaction-execution.test.ts tests/transaction-recovery.test.ts tests/transaction-schema-boundary.test.ts
+npm run typecheck
+git add packages/runtime/src/composition tests/transaction-execution.test.ts tests/transaction-recovery.test.ts tests/transaction-schema-boundary.test.ts
+git commit -s -m "feat: execute and recover managed transactions"
+```
+
+---
+
+### Task 7: Implement no-follow durable Node primitives
+
+**Files:**
+
+- Create: `packages/runtime/src/infra/node/transactions.ts`
+- Modify: `packages/runtime/src/infra/node/index.ts`
+- Modify: `packages/runtime/src/composition/index.ts`
+- Modify: `packages/runtime/src/ports/index.ts`
+- Modify: `tests/ports-contract.test.ts`
+- Test: `tests/node-transactions.test.ts`
+- Test: `tests/node-transaction-security.test.ts`
+- Modify: `tests/runtime-composition.test.ts`
+
+**Interfaces:**
+
+- Consumes: canonical project root.
+- Produces: `nodeDurableFileSystem(root, observer?)` and production runtime
+  ports.
+
+```ts
+export interface DurableOperationEvent {
+  readonly operation: DurableOperation;
+  readonly timing: "before" | "after";
+}
+
+export type DurableOperationObserver = (
+  event: DurableOperationEvent,
+) => Promise<void>;
+```
+
+- [ ] **Step 1: Run the shared contract against the absent factory**
+
+```ts
+describeDurableFileSystemContract("node", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yoda-transaction-port-"));
+  return {
+    port: nodeDurableFileSystem(root),
+    dispose: () => rm(root, { force: true, recursive: true }),
+  };
+});
+```
+
+Run `npm test -- tests/ports-contract.test.ts`; expect FAIL.
+
+- [ ] **Step 2: Add real security tests before implementation**
+
+Cover internal and escaping symlinks, FIFO where supported, directory-as-file,
+case-colliding sibling on case-sensitive filesystems, and substitution between
+observations. No external sentinel may change.
+
+- [ ] **Step 3: Implement anchored no-follow inspection and synced writes**
+
+Use `lstat` on every existing component below canonical `.brain`; refuse every
+symlink on a mutation path. Use `open` with create/exclusive flags,
+`FileHandle.writeFile()`, `sync()`, and `close()` in `finally`. Hash bytes read
+from a proven regular file without following a final symlink.
+
+Call the optional observer before and after each internal operation. Production
+composition passes no observer; fault and child-process tests pass explicit
+observers. An observer rejection must be able to model both pre-effect and
+post-effect failure without changing the public port interface.
+
+Do not reuse ordinary `resolveInside()`, which permits internal symlinks for
+reads and has a deliberately weaker contract.
+
+- [ ] **Step 4: Implement rename, delete, and directory sync narrowly**
+
+Use same-filesystem `rename` after revalidating both parents. Delete only a
+regular file with `unlink`; remove only empty directories with `rmdir`. Downgrade
+directory sync only for the exact platform errors asserted by tests; rethrow
+every unexpected error. File sync and rename remain mandatory.
+
+- [ ] **Step 5: Compose the ports**
+
+Extend `RuntimePorts`:
+
+```ts
+readonly digests: Digests;
+readonly durableFileSystem: DurableFileSystem;
+```
+
+Add `sha256Digests()` and `nodeDurableFileSystem(root)` in `createRuntimeAt` and
+update the exact port-key assertion. Overrides still replace one named port.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+npm test -- tests/ports-contract.test.ts tests/node-transactions.test.ts tests/node-transaction-security.test.ts tests/runtime-composition.test.ts
+npm run typecheck
+git add packages/runtime/src/infra/node packages/runtime/src/infra/digests.ts packages/runtime/src/composition/index.ts packages/runtime/src/ports tests/ports-contract.test.ts tests/node-transactions.test.ts tests/node-transaction-security.test.ts tests/runtime-composition.test.ts
+git commit -s -m "feat: add durable Node transaction storage"
+```
+
+---
+
+### Task 8: Route effects and stable transaction failures
+
+**Files:**
+
+- Modify: `packages/runtime/src/composition/index.ts`
+- Modify: `packages/runtime/src/composition/cli.ts`
+- Modify: `packages/runtime/src/domain/result/result.ts`
+- Modify: `packages/runtime/src/domain/result/index.ts`
+- Modify: `tests/runtime-composition.test.ts`
+- Modify: `tests/cli-composition.test.ts`
+- Modify: `tests/cli-contracts.test.ts`
+
+**Interfaces:**
+
+- Consumes: `EffectPlan`, `RuntimePorts`, and production schema registry.
+- Produces: atomic `applyPlan`, post-commit output, and
+  `transactionFailureResult`.
+
+- [ ] **Step 1: Replace partial-prefix expectations with atomic ones**
+
+Use `memoryTransactionStorage()` and override `fileSystem`,
+`durableFileSystem`, and `digests` from that same storage. Assert an invalid
+second effect does not apply the first:
+
+```ts
+await expect(
+  applyPlan(
+    planOf(
+      { kind: "write_file", path: ".brain/first.json", content: "one" },
+      {
+        kind: "write_file",
+        path: ".brain/transactions/forbidden",
+        content: "two",
+      },
+    ),
+    ports,
+  ),
+).rejects.toMatchObject({ reasonCode: "guard.outside_allow" });
+expect(storage.snapshot().files).not.toHaveProperty(".brain/first.json");
+```
+
+Update all state paths to `.brain/`, assert output only appears after commit,
+and assert `append_event` fails closed until `RUN-06`.
+
+- [ ] **Step 2: Add CLI result mapping tests**
+
+For each transaction reason, inject a `TransactionFailure` and assert exact
+catalog status, exit code, retry policy, recovery, and relative evidence in
+human and JSON output. Assert absolute roots and payload content are absent.
+
+- [ ] **Step 3: Confirm legacy behavior fails**
+
+```bash
+npm test -- tests/runtime-composition.test.ts tests/cli-composition.test.ts tests/cli-contracts.test.ts
+```
+
+Expected: FAIL because `applyPlan` still writes prefixes and CLI collapses typed
+failures to `runtime.internal_failure`.
+
+- [ ] **Step 4: Route managed effects through one transaction**
+
+Separate `emit` effects, observe and normalize managed effects, execute one
+transaction, and emit only after a committed receipt. Reject `append_event` with
+`runtime.state_corrupt`. Add an options argument defaulting to
+`{ rootMode: "existing" }`; only an initialization caller passes `initialize`.
+
+```ts
+export async function applyPlan(
+  plan: EffectPlan,
+  ports: RuntimePorts,
+  options: { readonly rootMode: "existing" | "initialize" } = {
+    rootMode: "existing",
+  },
+): Promise<void>;
+```
+
+- [ ] **Step 5: Add catalog-backed failure rendering**
+
+```ts
+export function transactionFailureResult(error: TransactionFailure): Result {
+  return resultFor(error.reasonCode, {
+    evidence:
+      error.reasonCode === "runtime.internal_failure" ? [] : error.evidence,
+    summary: "The managed transaction did not reach a committed state.",
+    why: ["The durable transaction boundary reported a blocked condition."],
+  });
+}
+```
+
+Catch `TransactionFailure` before the generic fallback in `runCommandLine`.
+Never classify by matching an error message. An `append_event` refusal uses
+`runtime.state_corrupt` with `.brain/events.jsonl` as required relative
+artifact evidence; internal failure has no evidence because the catalog
+forbids it.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+npm test -- tests/runtime-composition.test.ts tests/cli-composition.test.ts tests/cli-contracts.test.ts
+npm run typecheck
+git add packages/runtime/src/composition packages/runtime/src/domain/result tests/runtime-composition.test.ts tests/cli-composition.test.ts tests/cli-contracts.test.ts
+git commit -s -m "feat: apply state effects through transactions"
+```
+
+---
+
+### Task 9: Prove fault, termination, security, and idempotence behavior
+
+**Files:**
+
+- Create: `tests/transaction-fault-campaign.test.ts`
+- Create: `tests/transaction-process-recovery.test.ts`
+- Create: `tests/fixtures/transactions/worker.ts`
+- Modify: `vitest.config.ts` only if the existing timeout is insufficient
+- Create: `docs/architecture/atomic-transactions.md`
+- Modify: `docs/architecture/runtime-boundaries.md`
+- Modify: `README.md`
+- Modify: `.cspell.json` only for genuine project vocabulary
+
+**Interfaces:**
+
+- Consumes: production transaction composition and both adapters.
+- Produces: required crash/fault evidence and public architecture docs.
+
+- [ ] **Step 1: Add the deterministic fake matrix**
+
+Enumerate every `DurableOperation`, `before`/`after`, and every occurrence
+reached by a two-write/one-delete plan. Execute, inspect, recover, and recover
+again. Assert terminal state and exact results:
+
+```ts
+expect(secondRecovery).toEqual(firstRecovery);
+expect(finalSnapshot.files[".brain/a.json"]).toBe("a2");
+expect(finalSnapshot.files[".brain/b.json"]).toBe("b1");
+expect(finalSnapshot.files).not.toHaveProperty(".brain/delete.json");
+```
+
+Before publication the expected terminal phase is `aborted`; after publication
+it is `committed`.
+
+- [ ] **Step 2: Add named permission and disk-full injection**
+
+Use sanitized internal labels `permission` and `disk_full`, but expose only
+catalog-backed results. Assert staging bytes and absolute roots never enter
+output or receipts.
+
+- [ ] **Step 3: Build a killable worker fixture**
+
+The worker accepts project root, barrier, and plan JSON as arguments, imports
+the real Node transaction path, passes a test-only observer to
+`nodeDurableFileSystem`, and sends IPC `{ kind: "barrier", name }` immediately
+before or after the selected primitive. The parent bundles the TS fixture into
+a temporary `.mjs` with esbuild, forks it with IPC, kills it at the barrier,
+then inspects and recovers in a fresh process.
+
+Do not pass payloads through environment variables or print them.
+
+- [ ] **Step 4: Cover all durable process boundaries**
+
+Cover after `begun`, final staged sync, manifest sync, `prepared`, `publishing`,
+each rename/delete, each directory sync, `committed`, and cleanup. Use `SIGKILL`
+where supported and an explicit forced-termination branch on Windows.
+
+- [ ] **Step 5: Document the contract accurately**
+
+Document the five phases, directory layout, explicit recovery binding, root
+bootstrap modes, roll-forward rule, sync capabilities, reason mapping, reserved
+namespace, and recoverable-vs-simultaneous atomicity. Link from runtime
+boundaries and README without claiming a complete SDD trail.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+npm test -- tests/transaction-fault-campaign.test.ts tests/transaction-process-recovery.test.ts tests/node-transaction-security.test.ts
+npm run spellcheck
+npx --yes markdownlint-cli2@0.23.2 '**/*.md'
+git add tests/transaction-fault-campaign.test.ts tests/transaction-process-recovery.test.ts tests/fixtures/transactions/worker.ts docs/architecture/atomic-transactions.md docs/architecture/runtime-boundaries.md README.md
+git commit -s -m "test: prove transaction crash recovery"
+```
+
+Add `vitest.config.ts` or `.cspell.json` only if they actually changed.
+
+---
+
+### Task 10: Verify package boundaries and record evidence
+
+**Files:**
+
+- Modify: `tests/architecture.test.ts`
+- Modify: `tests/runtime-distribution.test.ts`
+- Modify: `tests/package-verifier.test.ts`
+- Create: `docs/verification/issue-20-transaction-evidence.md`
+
+**Interfaces:**
+
+- Consumes: all transaction slices.
+- Produces: bundle/package proof and PR-ready verification evidence.
+
+- [ ] **Step 1: Add final boundary assertions**
+
+Assert domain/ports import no builtins, the bundle embeds both transaction
+schemas and the `runtime.recovery_required` policy, no checkout-relative schema
+import survives, and the isolated three-file plugin still runs its public
+orientation commands without global Yoda. Task 8's composition test owns actual
+transaction-failure rendering until a public recovery command exists.
+
+- [ ] **Step 2: Run package gates**
+
+```bash
+npm test -- tests/architecture.test.ts tests/runtime-distribution.test.ts tests/package-verifier.test.ts
+npm run build
+npm run package:verify
+```
+
+Expected: PASS and a version-coherent built manifest.
+
+- [ ] **Step 3: Run complete repository verification**
+
+```bash
+npm run verify
+```
+
+Expected: formatting, spelling, lint, type, unit, coverage, oracle, parity,
+result, contracts, differential, build, and package gates all pass.
+
+- [ ] **Step 4: Write reproducible issue evidence**
+
+Record exact toolchain, commands, test counts, fault-matrix count, termination
+barriers, directory-sync capability, package result, issue/PR links, and explicit
+out-of-scope status for `RUN-06`, `RUN-07`, and public recovery command wiring.
+Do not include absolute local paths or staged content.
+
+- [ ] **Step 5: Validate and commit evidence**
+
+```bash
+npx prettier --check docs/verification/issue-20-transaction-evidence.md
+npx cspell --no-progress --show-suggestions --no-gitignore docs/verification/issue-20-transaction-evidence.md
+npx --yes markdownlint-cli2@0.23.2 docs/verification/issue-20-transaction-evidence.md
+git diff --check
+git add tests/architecture.test.ts tests/runtime-distribution.test.ts tests/package-verifier.test.ts docs/verification/issue-20-transaction-evidence.md
+git commit -s -m "docs: record transaction verification evidence"
+```
+
+- [ ] **Step 6: Re-run from a clean worktree**
+
+```bash
+test -z "$(git status --short)"
+npm run verify
+git status --short
+```
+
+Expected: both status checks are empty and verification exits 0. Update the PR
+body with `Closes #20`, design decisions, compatibility impact, exact commands,
+and CI links.

--- a/docs/superpowers/specs/2026-08-09-atomic-filesystem-transactions-design.md
+++ b/docs/superpowers/specs/2026-08-09-atomic-filesystem-transactions-design.md
@@ -245,8 +245,13 @@ canonical state. They report recovery required before loading it.
 ### D6: Explicit recovery rolls forward after publication
 
 Inspection is read-only and returns a classified transaction summary. Recovery
-requires the exact transaction identifier and manifest digest so a stale
-operator action cannot recover a replacement transaction accidentally.
+requires the exact transaction identifier and recovery token so a stale
+operator action cannot recover a replacement transaction accidentally. The
+token is stored in progress. In `begun`, it is the digest of the immutable
+transaction identity (`contractVersion`, `stateContract`, `transactionId`, and
+`createdAt`). The transition to `prepared` replaces it once with the manifest
+digest. It never changes after that, including during terminal cleanup, so the
+same explicit request remains idempotent.
 
 Recovery behavior is deterministic:
 
@@ -405,7 +410,7 @@ executeManagedMutation(
 recoverManagedMutation(
   request: {
     transactionId: string;
-    manifestDigest: string;
+    recoveryToken: string;
   },
   ports: TransactionPorts,
 ): Promise<TransactionReceipt>;

--- a/docs/superpowers/specs/2026-08-09-atomic-filesystem-transactions-design.md
+++ b/docs/superpowers/specs/2026-08-09-atomic-filesystem-transactions-design.md
@@ -1,0 +1,517 @@
+# Atomic Filesystem Transactions and Crash Recovery Design
+
+Issue [#20](https://github.com/thiagocorreanet/mestre-yoda/issues/20)
+(`RUN-05`). Epic
+[#15](https://github.com/thiagocorreanet/mestre-yoda/issues/15). Depends on
+[#18](https://github.com/thiagocorreanet/mestre-yoda/issues/18) (`RUN-03`) and
+[#19](https://github.com/thiagocorreanet/mestre-yoda/issues/19) (`RUN-04`).
+
+## Problem
+
+The runtime already separates pure decisions from effects, but `applyPlan`
+applies filesystem effects one at a time and deliberately leaves an applied
+prefix behind when a later effect fails. That is sufficient to prove the
+runtime boundary and unsafe for persisted workflow state. A process stopped
+between a new approval record, an appended event, and an advanced snapshot can
+leave `.brain/` describing mutually incompatible histories.
+
+A single rename can publish one file atomically. No portable filesystem API can
+make several independent renames appear simultaneously. The runtime therefore
+needs recoverable transaction semantics: before any managed destination changes,
+it must durably describe the complete intended result; while publication is in
+progress, it must leave an unambiguous marker; and after an interruption, it
+must refuse normal mutation until an explicit operation validates and completes
+that exact transaction.
+
+This boundary is also a security boundary. A transaction must not turn a safe
+project-relative effect into a write through a symlink, a special file, a
+case-colliding alias, an undeclared parent creation, or an unrelated user-owned
+path.
+
+## Goals
+
+- Convert an ordered, previewable mutation plan into a durable transaction
+  without introducing a second decision path for dry-run.
+- Confine every managed destination in this issue to `.brain/` and reserve the
+  transaction metadata namespace for the transaction manager itself.
+- Publish each individual destination atomically and make a partially published
+  multi-file transaction diagnosable and deterministically recoverable.
+- Require explicit recovery when a durable incomplete marker exists.
+- After the first destination is published, recover by rolling forward to the
+  exact manifest result. Before that point, abort without changing a managed
+  destination.
+- Share one behavioral contract between the real Node adapter and the
+  deterministic fault-injectable fake.
+- Preserve evidence without retaining staged sensitive content after commit or
+  abort.
+
+## Non-goals
+
+- A public CLI spelling for recovery. This issue exports typed inspection and
+  recovery operations. The command-owning workflow can expose them without
+  redefining transaction semantics.
+- Event-chain behavior. `RUN-06` will implement `append_event` and route it
+  through this transaction boundary.
+- Lease expiry, fencing, or concurrent-writer ownership. `RUN-07` owns locks.
+  This issue detects changed preconditions but does not claim that hash checks
+  replace a write lease.
+- Git classification or approved source-change scope. `RUN-08` owns those
+  policies.
+- Mutating `.claude/`, `.codex/`, application files, plugin files, or arbitrary
+  paths supplied by a caller. Host integrations must add explicit managed-file
+  contracts in their owning issues.
+- General backup and rollback. Migration rollback belongs to the migration
+  contract. A transaction that has started publication rolls forward.
+- Silent repair of a malformed marker or unexpected destination. Ambiguity is a
+  blocked integrity condition, not permission to guess.
+
+## Decisions
+
+### D1: Pure transaction state machine, durable-filesystem port
+
+Transaction policy lives in `domain`. It defines immutable plan and manifest
+types, legal phases, precondition evaluation, publication decisions, and
+recovery classification without importing Node or calling a port.
+
+A dedicated durable-filesystem port exposes the narrow primitives whose
+outcomes the state machine observes. These include exclusive transaction
+directory creation, no-follow inspection, staged writes, atomic file
+replacement, file removal, atomic progress replacement, file synchronization,
+directory synchronization, and cleanup. The Node adapter implements the effects;
+the in-memory adapter implements the same contract and supports deterministic
+failure injection.
+
+Composition owns the driver loop: observe, ask the pure state machine for the
+next action, apply one primitive, and observe again. The loop does not decide
+whether an interrupted operation is complete. It feeds facts back to the state
+machine, which compares them with the manifest.
+
+Rejected: implementing the complete manager independently in Node and fake.
+That would duplicate the most important recovery decisions at the exact boundary
+the fake is meant to prove.
+
+Rejected: adding one opaque `applyTransaction` method to the existing
+`FileSystem`. A coarse method would hide failure boundaries, make ambiguous
+post-effect failures difficult to model, and mix durable mutation semantics into
+the simple project-scoped read/write port.
+
+### D2: The existing effect plan is normalized into an exact managed mutation plan
+
+The domain continues to return `EffectPlan`. Before dry-run output or execution,
+composition normalizes its managed filesystem effects into a
+`ManagedMutationPlan` containing only:
+
+- `create_directory`;
+- `write_file`; and
+- `delete_file`.
+
+Normalization preserves declared order. If a write requires a missing parent,
+the normalized plan contains an explicit preceding `create_directory`; the
+executor never creates a destination parent as a hidden side effect. Duplicate
+or contradictory destinations, parent-after-child dependencies, deletion of a
+directory through `delete_file`, and overlapping file/directory targets are
+rejected before mutation.
+
+After read-only observation, normalization removes operations whose result is
+already satisfied. A plan containing only satisfied operations returns a no-op
+result and creates no transaction. Consequently, every operation in a durable
+manifest has observably different precondition and result fingerprints, which
+keeps recovery classification unambiguous.
+
+`emit` remains outside the transaction and runs only after commit. `append_event`
+is rejected by this issue's executor until `RUN-06` supplies its canonical
+append operation. This prevents a placeholder append implementation from
+creating a second durability protocol.
+
+Dry-run returns this exact ordered plan plus observed preconditions and writes
+nothing. Execution re-observes those preconditions, rejects drift, allocates the
+transaction identity, and binds the same canonical plan digest into the durable
+manifest.
+
+### D3: Versioned immutable manifest and atomic progress document
+
+Each transaction owns this project-local directory:
+
+```text
+.brain/transactions/<transaction-id>/
+|-- manifest.json
+|-- progress.json
+`-- staging/
+    `-- <operation-index>.payload
+```
+
+The transaction manager owns `.brain/transactions/**`. A caller cannot target,
+delete, or shadow that namespace through an effect plan.
+
+`manifest.json` is written once and becomes immutable before the transaction
+enters `prepared`. Its versioned schema contains:
+
+- contract and state-contract versions;
+- transaction identifier;
+- canonical plan digest;
+- creation timestamp from the injected clock;
+- ordered operations with stable operation identifiers;
+- project-relative destination paths;
+- expected destination kind, presence, size, and SHA-256 digest where
+  applicable;
+- resulting kind, size, and SHA-256 digest where applicable; and
+- relative staged-payload references for writes.
+
+The manifest contains no payload bytes, absolute paths, raw prompts, secrets,
+host identity, or environment values. The schema registry from `RUN-04`
+validates the document before any recovery decision uses it. Canonical
+serialization from `RUN-04` produces its digest.
+
+`progress.json` is a small versioned document replaced through write, file sync,
+atomic rename, and directory sync. It records the current phase, the published
+operation indexes known at the last durable observation, durability capability
+facts, and timestamps. It is a hint backed by destination inspection, not an
+authority that can overrule manifest hashes. A crash after publishing a target
+but before advancing progress is resolved by observing that the destination
+already equals the manifest result.
+
+An empty transaction directory or an interrupted `begun` marker is recoverable
+only when its identifier and contents match the reserved transaction layout.
+Unexpected content blocks as corruption rather than being recursively removed.
+
+### D4: Five monotonic phases
+
+The legal phases are:
+
+```text
+begun -> prepared -> publishing -> committed
+   |          |
+   `----------+------------------> aborted
+```
+
+- `begun`: the exclusive transaction directory and initial progress identity
+  exist. Managed destinations have not changed.
+- `prepared`: every path and precondition is valid; every write payload and the
+  immutable manifest are durable; managed destinations have not changed.
+- `publishing`: publication was durably authorized before the first destination
+  mutation. One or more destinations may already equal the manifest result.
+- `committed`: every destination has been inspected and equals the manifest
+  result.
+- `aborted`: no destination was published, and payload cleanup is safe.
+
+`committed` and `aborted` are terminal. No transition returns to an earlier
+phase. Only `begun` and `prepared` can abort. Once `publishing` is durable,
+recovery must complete the manifest or block on an unexpected observation.
+
+### D5: Publication preserves plan order and records facts after each effect
+
+The normal sequence is:
+
+1. Reject any existing incomplete transaction before canonical state is loaded
+   for a mutating operation.
+2. Normalize and render the managed mutation plan.
+3. Inspect every destination and bind its precondition.
+4. Create the transaction directory exclusively and persist `begun`.
+5. Write, hash, and synchronize every payload in staging.
+6. Persist and synchronize the immutable manifest.
+7. Reinspect all preconditions and persist `prepared`.
+8. Persist `publishing` before the first destination mutation.
+9. Apply operations in manifest order. Before each operation, revalidate its
+   target and parent. After it, synchronize the affected directory, inspect the
+   result, and atomically advance progress.
+10. Reinspect every destination against the manifest, persist `committed`, and
+    remove staged payload bytes.
+
+Writes use an atomic rename from a staged file on the same `.brain` filesystem.
+Deletes remove only a regular file whose precondition matches the manifest.
+Directory creation is explicit and idempotent only when the observed directory
+matches the operation's expected state.
+
+The result is recoverable multi-file atomicity, not simultaneous visibility.
+While `publishing` is present, ordinary commands cannot consume possibly mixed
+canonical state. They report recovery required before loading it.
+
+### D6: Explicit recovery rolls forward after publication
+
+Inspection is read-only and returns a classified transaction summary. Recovery
+requires the exact transaction identifier and manifest digest so a stale
+operator action cannot recover a replacement transaction accidentally.
+
+Recovery behavior is deterministic:
+
+| Observation | Recovery |
+| --- | --- |
+| `begun` or `prepared`, no destination equals a new result | Persist `aborted` and remove staged payloads |
+| `publishing`, an operation still equals its precondition and its payload exists | Apply that operation and continue |
+| `publishing`, a destination already equals its result | Record it as published and continue |
+| `committed` with leftover staged payloads | Verify all results and finish cleanup |
+| `aborted` with leftover staged payloads | Finish cleanup without touching destinations |
+| Destination equals neither precondition nor result | Block; preserve marker and evidence |
+| Staged payload or manifest digest is wrong | Block; preserve marker and evidence |
+
+Recovery is idempotent. The adapter can fail before an operation, after the
+filesystem performed it, or after synchronization; every retry begins with a
+fresh observation and derives the next action from facts rather than assuming
+the previous call failed before taking effect.
+
+Normal mutation never invokes recovery implicitly. Finding an incomplete marker
+returns `runtime.recovery_required`. Diagnostic operations may inspect and
+report the marker but may not load mixed state as canonical. The explicit
+recovery operation is the only path that may advance or abort it.
+
+### D7: Durability is capability-aware and evidence-backed
+
+For every staged or progress file, the Node adapter writes all bytes, flushes
+the file handle, closes it, publishes it by atomic rename, and synchronizes the
+containing directory when the platform supports directory synchronization.
+Target publication follows the same file and directory durability sequence.
+
+Atomic same-filesystem rename is mandatory. File synchronization is mandatory.
+Directory synchronization is attempted and classified as `supported` or
+`unsupported` only for explicitly recognized platform errors. An unexpected
+sync error fails the operation; it is not downgraded to an unsupported
+capability. The capability observation is recorded in progress and the final
+receipt so evidence states the guarantee actually achieved.
+
+The design does not advertise that unsupported directory sync has occurred.
+Cross-platform tests own the accepted error classification. Adding a platform
+exception requires a focused contract change, not a broad catch.
+
+### D8: Managed-path policy is stricter than ordinary reads
+
+Every destination must be a normalized relative path below `.brain/` and must
+not be below `.brain/transactions/`. Absolute, drive-qualified,
+backslash-bearing, empty, control-character, traversing, special-file, and
+case-colliding targets are refused.
+
+The Node adapter anchors inspection at the canonical `.brain` directory. Before
+staging and immediately before publication, it uses no-follow metadata checks
+for every existing component and rejects mutation through a symlink, even when
+that symlink currently resolves inside the project. This stricter write policy
+prevents aliases and destination substitution; it does not change the existing
+read-side project-discovery contract.
+
+An existing destination must be a regular file for `write_file` or
+`delete_file`, and a directory for an already-satisfied `create_directory`.
+Sockets, devices, FIFOs, and other special entries are never read, replaced, or
+removed. Unexpected entries remain untouched.
+
+### D9: Stable failure mapping uses the existing result catalog
+
+Transaction internals return typed failures. Composition maps them to the
+existing universal reasons:
+
+| Condition | Reason |
+| --- | --- |
+| Incomplete durable transaction blocks a normal operation | `runtime.recovery_required` |
+| Destination changed between plan observation and preparation | `runtime.revision_conflict` |
+| Invalid marker, manifest, progress, payload digest, or ambiguous recovery destination | `runtime.state_corrupt` |
+| Requested destination is outside the `.brain/` allowlist or inside the reserved transaction namespace | `guard.outside_allow` |
+| Unexpected filesystem failure before `publishing`, with no destination change | `runtime.internal_failure` |
+| Filesystem failure after `publishing` leaves a valid incomplete marker | `runtime.recovery_required` |
+
+Errors never include staged content or absolute paths in universal output.
+Evidence may reference the relative transaction directory, transaction
+identifier, manifest digest, failed operation identifier, phase, and durability
+capabilities. An unexpected failure after `begun` preserves the marker unless
+the state machine proves that no destination changed and cleanup is safe.
+
+`stateChanged: false` means no new canonical transaction was committed. A
+partially published filesystem is never reported as accepted state: the durable
+marker makes it unavailable to ordinary state consumers until explicit
+recovery reaches `committed` or proves a safe pre-publication abort.
+
+This issue does not add a new public reason merely to mirror an implementation
+exception. A future need for observably distinct recovery policy requires a
+versioned result-catalog decision.
+
+### D10: Successful cleanup keeps a compact receipt, not payload bytes
+
+After commit or abort, staged payloads and incomplete temporary files are
+removed. The transaction directory is compacted to validated metadata containing
+the immutable manifest, terminal progress, plan digest, terminal phase, and
+durability capability facts. Payload content is not retained.
+
+These receipts make tests, diagnosis, and later event integration reproducible.
+Retention and archival policy are not invented here. A later evidence or
+retention issue may move or prune terminal receipts through its own managed
+transaction; it may not reinterpret them.
+
+## Component boundaries
+
+The intended dependency direction is:
+
+```text
+EffectPlan
+    |
+    v
+pure normalization/validation ---> ManagedMutationPlan (dry-run output)
+    |                                      |
+    | execute                              | no writes
+    v                                      v
+transaction driver <--- pure transaction state machine
+    |
+    v
+DurableFileSystem port
+    |
+    +-- Node adapter
+    `-- fault-injectable memory adapter
+```
+
+Suggested units, with final names settled during planning:
+
+- `domain/transactions/model`: plan, manifest, progress, observation, and
+  failure types;
+- `domain/transactions/normalize`: effect-plan normalization and path policy;
+- `domain/transactions/transition`: legal phase transitions and next-action
+  decisions;
+- `domain/transactions/recovery`: pure recovery classification;
+- `ports`: durable-filesystem interface and capability types;
+- `composition/transactions`: driver, failure mapping, inspection, and recovery
+  entry points;
+- `infra/node/transactions`: Node filesystem primitives;
+- `infra/fake/transactions`: model adapter and failure-injection controller.
+
+The exact file split should keep each unit focused; the design does not require
+one file per bullet.
+
+## Public internal API shape
+
+The transaction boundary exposes three operations to composition consumers:
+
+```ts
+planManagedMutation(
+  effectPlan: EffectPlan,
+  observation: ManagedPathObservation,
+): ManagedMutationPlan;
+
+executeManagedMutation(
+  plan: ManagedMutationPlan,
+  ports: TransactionPorts,
+): Promise<TransactionReceipt>;
+
+recoverManagedMutation(
+  request: {
+    transactionId: string;
+    manifestDigest: string;
+  },
+  ports: TransactionPorts,
+): Promise<TransactionReceipt>;
+```
+
+Inspection remains a read-only composition operation that lists and validates
+transaction summaries without returning payload content. The detailed types are
+versioned internal contracts until an owning public command exposes them.
+
+## Verification strategy
+
+### Pure unit and property tests
+
+- Every legal and illegal phase transition.
+- Plan normalization preserves order and makes implicit parent creation
+  explicit.
+- Already-satisfied operations disappear, and an all-satisfied plan creates no
+  transaction marker.
+- Duplicate, overlapping, contradictory, outside-allowlist, reserved, and
+  unsafe paths are rejected.
+- Canonical plan and manifest digests are stable under repeated serialization.
+- Random valid plans plus a crash at every action boundary satisfy the model:
+  before publication, destinations remain at preconditions; after explicit
+  recovery from publication, every destination equals the manifest result.
+- Repeated inspection and recovery produce the same terminal result.
+
+### Shared adapter contract
+
+The Node and memory adapters run the same assertions for:
+
+- exclusive transaction directory creation;
+- no-follow kind and digest observation;
+- complete writes and file synchronization;
+- atomic replacement;
+- directory synchronization capability classification;
+- regular-file deletion;
+- atomic progress replacement;
+- cleanup; and
+- identical safe path refusal.
+
+### Fault-injection campaign
+
+The fake can fail immediately before and immediately after every primitive. The
+campaign covers open, write, partial write, file sync, close, rename, directory
+sync, metadata inspection, permission refusal, synthetic disk-full, delete, and
+cleanup. Post-effect failures are mandatory because they prove that recovery
+does not equate a rejected promise with an unapplied effect.
+
+For every injected point, tests assert the marker phase, destination facts,
+stable failure classification, lack of sensitive output, and idempotent explicit
+recovery.
+
+### Real-filesystem and process tests
+
+- Temporary-project integration tests exercise creation, replacement, deletion,
+  Unicode, spaces, long paths within platform limits, case behavior, and
+  same-filesystem rename.
+- Security tests cover traversal, absolute and drive paths, escaping and
+  internal symlinks, symlink substitution between observations, special files
+  where the platform supports them, and the reserved transaction namespace.
+- Child-process tests stop the process at deterministic barriers before and
+  after publication primitives, then invoke inspection and recovery in a fresh
+  process.
+- Platform CI records whether directory sync is supported and verifies only the
+  narrow accepted unsupported errors on Linux, Windows, and macOS.
+
+Synthetic permission and disk-full failures provide deterministic coverage on
+every platform. Focused native tests supplement them where the operating system
+can produce the condition safely; the suite never fills the host disk or changes
+global permissions.
+
+### Repository verification
+
+Narrow tests run first. Before review, the branch runs the repository's exact
+Node/npm toolchain and complete `npm run verify` suite. The PR records exact
+commands, transaction fault-matrix counts, platform capability observations,
+and the final CI links.
+
+## Security and privacy review
+
+- Staged content exists only under the project-owned `.brain/transactions/`
+  boundary and is removed after a terminal outcome.
+- Manifests and receipts contain hashes and relative paths, not payload bytes or
+  absolute user paths.
+- Recovery never trusts marker-provided paths before schema, lexical, namespace,
+  and filesystem-boundary validation.
+- Cleanup enumerates only a validated transaction layout and never performs an
+  unconstrained recursive removal.
+- A manifest cannot authorize its own transaction metadata as a managed
+  destination.
+- Universal errors are catalog-backed and sanitized.
+
+## Delivery sequence and dependency handling
+
+Implementation starts only after `RUN-04` is merged or the branch is rebased
+onto its accepted schema registry and canonical serialization boundary. This
+issue reuses those capabilities; it does not ship a parallel validator or JSON
+canonical serializer.
+
+Recommended implementation slices are:
+
+1. versioned transaction schemas and pure model;
+2. mutation-plan normalization and managed-path policy;
+3. pure state and recovery decisions;
+4. durable-filesystem port plus fake contract;
+5. transaction driver and fault campaign;
+6. Node adapter and real-filesystem tests;
+7. process-termination tests, result mapping, receipts, and documentation; and
+8. complete repository verification and PR evidence.
+
+The implementation plan will decompose these slices into test-first tasks after
+this design is accepted.
+
+## Acceptance mapping
+
+| Issue requirement | Design evidence |
+| --- | --- |
+| Staged writes, flush, atomic rename, verification, cleanup | D3, D5, D7, adapter contract |
+| Begin, prepare, commit, abort markers and recovery inspection | D3, D4, D6 |
+| Reject writes outside allowlisted project-owned paths | D2, D8 |
+| Expose a dry-run transaction plan | D2 and public internal API |
+| Old state or diagnosable recoverable transaction at every boundary | D4-D6 and fault campaign |
+| Idempotent repeated recovery | D6 and property tests |
+| Never overwrite a user-owned path without a managed-file contract | `.brain/`-only policy, reserved namespace, D8 |
+| Fault-inject filesystem and termination scenarios | Verification strategy |
+| Real-filesystem integration on supported systems | Real-filesystem and process tests |

--- a/docs/superpowers/specs/2026-08-09-atomic-filesystem-transactions-design.md
+++ b/docs/superpowers/specs/2026-08-09-atomic-filesystem-transactions-design.md
@@ -128,6 +128,15 @@ nothing. Execution re-observes those preconditions, rejects drift, allocates the
 transaction identity, and binds the same canonical plan digest into the durable
 manifest.
 
+Execution also carries a root mode. `existing` is the default and refuses a
+missing or unusable `.brain` directory. The explicitly selected `initialize`
+mode may create only the empty `.brain/` and `.brain/transactions/` directories,
+then synchronize their parents before creating `begun`. Directory creation is a
+single idempotent bootstrap effect, not accepted workflow state. If the process
+stops there, a later initialization sees empty reserved directories and retries;
+no state file exists outside a manifest. No other operation may select this
+mode.
+
 ### D3: Versioned immutable manifest and atomic progress document
 
 Each transaction owns this project-local directory:
@@ -142,6 +151,11 @@ Each transaction owns this project-local directory:
 
 The transaction manager owns `.brain/transactions/**`. A caller cannot target,
 delete, or shadow that namespace through an effect plan.
+
+The empty transaction namespace is bootstrap metadata, not a managed operation
+supplied by the caller. Outside explicit initialization, the transaction manager
+requires both `.brain/` and its reserved namespace to be real, no-follow
+directories before it creates a transaction identifier.
 
 `manifest.json` is written once and becomes immutable before the transaction
 enters `prepared`. Its versioned schema contains:
@@ -206,15 +220,17 @@ The normal sequence is:
    for a mutating operation.
 2. Normalize and render the managed mutation plan.
 3. Inspect every destination and bind its precondition.
-4. Create the transaction directory exclusively and persist `begun`.
-5. Write, hash, and synchronize every payload in staging.
-6. Persist and synchronize the immutable manifest.
-7. Reinspect all preconditions and persist `prepared`.
-8. Persist `publishing` before the first destination mutation.
-9. Apply operations in manifest order. Before each operation, revalidate its
+4. In explicit initialization mode only, create and synchronize the empty
+   managed root and transaction namespace if absent.
+5. Create the transaction directory exclusively and persist `begun`.
+6. Write, hash, and synchronize every payload in staging.
+7. Persist and synchronize the immutable manifest.
+8. Reinspect all preconditions and persist `prepared`.
+9. Persist `publishing` before the first destination mutation.
+10. Apply operations in manifest order. Before each operation, revalidate its
    target and parent. After it, synchronize the affected directory, inspect the
    result, and atomically advance progress.
-10. Reinspect every destination against the manifest, persist `committed`, and
+11. Reinspect every destination against the manifest, persist `committed`, and
     remove staged payload bytes.
 
 Writes use an atomic rename from a staged file on the same `.brain` filesystem.
@@ -382,6 +398,7 @@ planManagedMutation(
 
 executeManagedMutation(
   plan: ManagedMutationPlan,
+  options: { readonly rootMode: "existing" | "initialize" },
   ports: TransactionPorts,
 ): Promise<TransactionReceipt>;
 
@@ -409,6 +426,8 @@ versioned internal contracts until an owning public command exposes them.
   transaction marker.
 - Duplicate, overlapping, contradictory, outside-allowlist, reserved, and
   unsafe paths are rejected.
+- `existing` mode never creates `.brain/`; `initialize` mode creates only the
+  empty managed root and reserved namespace before `begun`.
 - Canonical plan and manifest digests are stable under repeated serialization.
 - Random valid plans plus a crash at every action boundary satisfy the model:
   before publication, destinations remain at preconditions; after explicit

--- a/docs/verification/issue-20-transaction-evidence.md
+++ b/docs/verification/issue-20-transaction-evidence.md
@@ -1,0 +1,130 @@
+# Issue 20 Transaction Verification Evidence
+
+## Result
+
+Issue [#20](https://github.com/thiagocorreanet/mestre-yoda/issues/20)
+(`RUN-05`) is verified as the runtime's internal durable filesystem transaction
+boundary. The implementation provides typed execution, inspection, and explicit
+recovery APIs; it does not add a public recovery command or claim a usable SDD
+trail.
+
+No pull-request URL was available when this local evidence was recorded, so this
+document does not claim one.
+
+## Toolchain and commands
+
+Verification ran on Linux x86-64 with Node.js `24.18.0` and npm `11.16.0`.
+Commands were run from the repository root with the pinned toolchain:
+
+```text
+npm test -- tests/transaction-fault-campaign.test.ts tests/transaction-process-recovery.test.ts tests/node-transaction-security.test.ts
+npm test -- tests/architecture.test.ts tests/runtime-distribution.test.ts tests/package-verifier.test.ts
+npm run build
+npm run package:verify
+npm run verify
+npx prettier --check docs/verification/issue-20-transaction-evidence.md
+npx cspell --no-progress --show-suggestions --no-gitignore docs/verification/issue-20-transaction-evidence.md
+npx --yes markdownlint-cli2@0.23.2 --no-globs docs/verification/issue-20-transaction-evidence.md
+git diff --check
+```
+
+The focused transaction command passed 3 files and 33 tests. The final package
+boundary command passed 3 files and 83 tests. The complete repository command
+passed 77 files and 1,374 tests in both the unit and coverage runs. Measured
+coverage was 100%: 1,743 statements, 1,266 branches, 269 functions, and 1,594
+lines.
+
+The remaining complete-verification gates also passed:
+
+- the Go v3 oracle verified 12 surfaces, 4 PRD anchors, and 3 binaries;
+- parity discovery verified 402 keys and retained honest parity at
+  `0 / 400 (0.00%)`;
+- the result contract verified 76 reasons, 6 exit classes, and 6 examples;
+- contracts verified 10 schemas, 14 legacy profiles, and current generated
+  types;
+- both differential self-test scenarios matched; and
+- formatting, spelling, lint, strict type-checking, build, and package
+  verification exited successfully.
+
+## Fault and termination campaign
+
+The deterministic two-write, one-delete plan enumerated all 13 durable
+operation variants. Twelve variants were reachable during normal execution;
+`read_text` was explicitly observed 0 times. The trace contained 110 durable
+operation occurrences. Injecting both `before` and `after` at every occurrence
+produced exactly 220 fault boundaries.
+
+Every reached boundary records that its selected failure was consumed. A
+durable phase before `publishing` recovers to `aborted`; `publishing` and later
+phases recover to `committed`. Each case checks the exact three managed
+destinations, exact retained receipt entries, and an identical second recovery
+receipt. The named `permission` and `disk_full` probes return only
+catalog-backed public results and exclude internal labels, absolute roots, and
+staged bytes.
+
+The real Node adapter process campaign uses 13 deterministic IPC barriers:
+
+1. durable `begun`;
+2. final staged-directory synchronization;
+3. manifest synchronization;
+4. durable `prepared`;
+5. durable `publishing`;
+6. first destination rename;
+7. first publication-directory synchronization;
+8. second destination rename;
+9. second publication-directory synchronization;
+10. destination delete;
+11. delete-directory synchronization;
+12. durable `committed`; and
+13. terminal cleanup synchronization.
+
+The worker is bundled into a temporary ESM artifact, receives its plan through
+arguments rather than environment variables, and emits no plan or staged bytes
+to stdout, stderr, or IPC. The parent stops the execution process at the exact
+barrier and uses separate fresh processes for inspection, first recovery, and
+idempotent retry.
+
+File synchronization is mandatory. On the verified Linux platform, real and
+fake transaction receipts recorded directory synchronization as `supported`.
+The Node adapter keeps the explicit Windows directory-handle classification as
+`unsupported`; that platform-specific outcome was not simulated or claimed as
+locally executed evidence.
+
+## Bundle and package evidence
+
+The final boundary tests prove that transaction domain and durable port modules
+import no Node.js builtins. Build metadata records both transaction schemas as
+embedded inputs:
+
+- `schemas/state/transaction-manifest.v1.schema.json`;
+- `schemas/state/transaction-progress.v1.schema.json`.
+
+The core also embeds the catalog-backed `runtime.recovery_required` policy and
+contains no checkout-relative schema import. The built manifest remained
+version-coherent: plugin `0.0.0-development`, result contract `1.0.0`, reason
+catalog `1.3.0`, state contract `1.0.0`, and host contract `1.0.0`.
+
+Package verification accepted exactly this three-file inventory:
+
+```text
+runtime/manifest.json
+runtime/yoda.core.mjs
+runtime/yoda.mjs
+```
+
+The core was 237,185 bytes with SHA-256
+`e25ad21c8a1a236fb47f6ad29497a2fde7bbbce93d4fc21a3999b0e94f5070ef`.
+An isolated copy containing only those three files ran `--help`, `help`,
+`--version`, `version`, and `handshake` without a global Yoda installation.
+
+## Explicitly out of scope
+
+- `RUN-06` owns canonical event append and event-chain behavior. This issue does
+  not implement `append_event`.
+- `RUN-07` owns leases, fencing, and concurrent-writer locking. Hash
+  preconditions do not replace that lock contract.
+- Public recovery command routing remains owned by the command-facing workflow.
+  This issue exposes typed internal inspection and recovery only.
+
+No release, public command, event-store, or lock completeness claim is derived
+from this evidence.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -16,6 +16,8 @@ The [`contracts/v1`](contracts/v1) directory contains valid current examples:
 - `evidence.json`;
 - `lock.json`;
 - `migration.json`;
+- `transaction-manifest.json`;
+- `transaction-progress.json`;
 - `adapter-message.json`.
 
 Its `version-cases.json` table covers current, previous, future, malformed,

--- a/fixtures/contracts/v1/transaction-manifest.json
+++ b/fixtures/contracts/v1/transaction-manifest.json
@@ -1,0 +1,21 @@
+{
+  "contractVersion": "1.0.0",
+  "stateContract": "1.0.0",
+  "transactionId": "transaction-01",
+  "planDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "createdAt": "2026-08-09T00:00:00.000Z",
+  "operations": [
+    {
+      "operationId": "operation-0001",
+      "kind": "write_file",
+      "path": ".brain/state.json",
+      "expected": { "kind": "missing" },
+      "result": {
+        "kind": "file",
+        "size": 3,
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "stagedPath": ".brain/transactions/transaction-01/staging/operation-0001.payload"
+    }
+  ]
+}

--- a/fixtures/contracts/v1/transaction-progress.json
+++ b/fixtures/contracts/v1/transaction-progress.json
@@ -1,0 +1,13 @@
+{
+  "contractVersion": "1.0.0",
+  "stateContract": "1.0.0",
+  "transactionId": "transaction-01",
+  "manifestDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "recoveryToken": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "phase": "prepared",
+  "publishedOperationIds": [],
+  "fileSync": "required",
+  "directorySync": "supported",
+  "createdAt": "2026-08-09T00:00:00.000Z",
+  "updatedAt": "2026-08-09T00:00:01.000Z"
+}

--- a/packages/contracts/catalogs/contract-families.v1.json
+++ b/packages/contracts/catalogs/contract-families.v1.json
@@ -76,6 +76,22 @@
       "path": "schemas/state/snapshot.v1.schema.json",
       "boundary": "persisted",
       "typeName": "SnapshotV1"
+    },
+    {
+      "id": "state.transaction-manifest",
+      "family": "state",
+      "version": "1.0.0",
+      "path": "schemas/state/transaction-manifest.v1.schema.json",
+      "boundary": "persisted",
+      "typeName": "TransactionManifestV1"
+    },
+    {
+      "id": "state.transaction-progress",
+      "family": "state",
+      "version": "1.0.0",
+      "path": "schemas/state/transaction-progress.v1.schema.json",
+      "boundary": "persisted",
+      "typeName": "TransactionProgressV1"
     }
   ],
   "legacyProfiles": [

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -273,23 +273,23 @@ export namespace TransactionManifestV1Contract {
   export type Id = string;
   export type Sha256 = string;
   export type Timestamp = string;
-  export type Operation = {
-    [k: string]: unknown | undefined;
-  } & {
-    operationId: Id;
-    kind: "create_directory" | "write_file" | "delete_file";
-    path: Reference;
-    expected: Fingerprint;
-    result: Fingerprint;
-    stagedPath: Reference | null;
-  } & {
-    operationId: Id;
-    kind: "create_directory" | "write_file" | "delete_file";
-    path: Reference;
-    expected: Fingerprint;
-    result: Fingerprint;
-    stagedPath: Reference | null;
-  };
+  export type Operation =
+    | {
+        operationId: Id;
+        kind: "write_file";
+        path: Reference;
+        expected: Fingerprint;
+        result: Fingerprint;
+        stagedPath: Reference;
+      }
+    | {
+        operationId: Id;
+        kind: "create_directory" | "delete_file";
+        path: Reference;
+        expected: Fingerprint;
+        result: Fingerprint;
+        stagedPath: null;
+      };
   export type Reference = string;
   export type Fingerprint =
     | {
@@ -320,21 +320,46 @@ export namespace TransactionManifestV1Contract {
 export type TransactionManifestV1 =
   TransactionManifestV1Contract.TransactionManifestV1;
 export namespace TransactionProgressV1Contract {
-  export type TransactionProgressV1 = {
-    [k: string]: unknown | undefined;
-  } & {
-    contractVersion: "1.0.0";
-    stateContract: "1.0.0";
-    transactionId: Id;
-    manifestDigest: Sha256 | null;
-    recoveryToken: Sha256;
-    phase: "begun" | "prepared" | "publishing" | "committed" | "aborted";
-    publishedOperationIds: Id[];
-    fileSync: "required";
-    directorySync: "not_attempted" | "supported" | "unsupported";
-    createdAt: Timestamp;
-    updatedAt: Timestamp;
-  };
+  export type TransactionProgressV1 =
+    | {
+        contractVersion: "1.0.0";
+        stateContract: "1.0.0";
+        transactionId: Id;
+        manifestDigest: null;
+        recoveryToken: Sha256;
+        phase: "begun";
+        publishedOperationIds: Id[];
+        fileSync: "required";
+        directorySync: "not_attempted" | "supported" | "unsupported";
+        createdAt: Timestamp;
+        updatedAt: Timestamp;
+      }
+    | {
+        contractVersion: "1.0.0";
+        stateContract: "1.0.0";
+        transactionId: Id;
+        manifestDigest: Sha256;
+        recoveryToken: Sha256;
+        phase: "prepared" | "publishing" | "committed";
+        publishedOperationIds: Id[];
+        fileSync: "required";
+        directorySync: "not_attempted" | "supported" | "unsupported";
+        createdAt: Timestamp;
+        updatedAt: Timestamp;
+      }
+    | {
+        contractVersion: "1.0.0";
+        stateContract: "1.0.0";
+        transactionId: Id;
+        manifestDigest: Sha256 | null;
+        recoveryToken: Sha256;
+        phase: "aborted";
+        publishedOperationIds: Id[];
+        fileSync: "required";
+        directorySync: "not_attempted" | "supported" | "unsupported";
+        createdAt: Timestamp;
+        updatedAt: Timestamp;
+      };
   export type Id = string;
   export type Sha256 = string;
   export type Timestamp = string;

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -8,6 +8,8 @@
 // source: https://mestre-yoda.dev/schemas/state/migration/v1 sha256:5b1082202fcc83a9a3c2af6c4894eb3d3774ed1b2e6d43871a98bda1c9c409ef
 // source: https://mestre-yoda.dev/schemas/state/project-config/v1 sha256:78fc5822e1cbf79b0185ceb8d40b64394acfcbb2fc2050526c702c3dc62efebb
 // source: https://mestre-yoda.dev/schemas/state/snapshot/v1 sha256:bb600b0d7d311bda1e150ee9121388b68567a4806f55aca1e77b501faace02fb
+// source: https://mestre-yoda.dev/schemas/state/transaction-manifest/v1 sha256:ca241c654b9edd2c75e3c8b3ce39f17ef9200f5c191786fd7d63d741944f3ec7
+// source: https://mestre-yoda.dev/schemas/state/transaction-progress/v1 sha256:3309c461745781087e4f9595089d8fe8fb739cbf9eaf3676fea211f289c1bdd9
 
 export namespace AdapterMessageV1Contract {
   export type AdapterMessageV1 = RequestMessage | ResponseMessage;
@@ -267,3 +269,75 @@ export namespace SnapshotV1Contract {
   }
 }
 export type SnapshotV1 = SnapshotV1Contract.SnapshotV1;
+export namespace TransactionManifestV1Contract {
+  export type Id = string;
+  export type Sha256 = string;
+  export type Timestamp = string;
+  export type Operation = {
+    [k: string]: unknown | undefined;
+  } & {
+    operationId: Id;
+    kind: "create_directory" | "write_file" | "delete_file";
+    path: Reference;
+    expected: Fingerprint;
+    result: Fingerprint;
+    stagedPath: Reference | null;
+  } & {
+    operationId: Id;
+    kind: "create_directory" | "write_file" | "delete_file";
+    path: Reference;
+    expected: Fingerprint;
+    result: Fingerprint;
+    stagedPath: Reference | null;
+  };
+  export type Reference = string;
+  export type Fingerprint =
+    | {
+        kind: "missing";
+      }
+    | {
+        kind: "directory";
+      }
+    | {
+        kind: "file";
+        size: SafeInteger;
+        sha256: Sha256;
+      };
+  export type SafeInteger = number;
+
+  export interface TransactionManifestV1 {
+    contractVersion: "1.0.0";
+    stateContract: "1.0.0";
+    transactionId: Id;
+    planDigest: Sha256;
+    createdAt: Timestamp;
+    /**
+     * @minItems 1
+     */
+    operations: [Operation, ...Operation[]];
+  }
+}
+export type TransactionManifestV1 =
+  TransactionManifestV1Contract.TransactionManifestV1;
+export namespace TransactionProgressV1Contract {
+  export type TransactionProgressV1 = {
+    [k: string]: unknown | undefined;
+  } & {
+    contractVersion: "1.0.0";
+    stateContract: "1.0.0";
+    transactionId: Id;
+    manifestDigest: Sha256 | null;
+    recoveryToken: Sha256;
+    phase: "begun" | "prepared" | "publishing" | "committed" | "aborted";
+    publishedOperationIds: Id[];
+    fileSync: "required";
+    directorySync: "not_attempted" | "supported" | "unsupported";
+    createdAt: Timestamp;
+    updatedAt: Timestamp;
+  };
+  export type Id = string;
+  export type Sha256 = string;
+  export type Timestamp = string;
+}
+export type TransactionProgressV1 =
+  TransactionProgressV1Contract.TransactionProgressV1;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -21,4 +21,6 @@ export type {
   MigrationV1,
   ProjectConfigV1,
   SnapshotV1,
+  TransactionManifestV1,
+  TransactionProgressV1,
 } from "./generated/contracts.js";

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -12,6 +12,7 @@
     "./domain/project": "./src/domain/project/index.ts",
     "./domain/result": "./src/domain/result/index.ts",
     "./domain/schema": "./src/domain/schema/index.ts",
+    "./domain/transactions": "./src/domain/transactions/index.ts",
     "./infra/fake": "./src/infra/fake/index.ts",
     "./infra/node": "./src/infra/node/index.ts",
     "./infra/schema": "./src/infra/schema/index.ts",

--- a/packages/runtime/src/composition/cli.ts
+++ b/packages/runtime/src/composition/cli.ts
@@ -49,7 +49,7 @@ function validatePlan(
   if (plan.effects.some(({ kind }) => kind === "emit")) {
     throw new Error("A command decision cannot own output effects");
   }
-  if ((plan.effects.length !== 0) !== result.stateChanged) {
+  if (plan.effects.length !== 0 && !result.stateChanged) {
     throw new Error("A command effect plan conflicts with its result");
   }
 }
@@ -91,21 +91,27 @@ export async function runCommandLine(
       return publish(decision.result, json, ports);
     }
 
-    let stdout: string;
+    let preparedOutput: string | undefined;
     if (parsed.invocation.command.jsonContract === "adapter-message@1.0.0") {
       if (decision.payload === undefined) {
         throw new Error("Command payload is absent");
       }
-      stdout = prepareAdapterPayload(decision.payload, schemaRegistry);
-    } else if (json) {
-      stdout = renderResultJson(decision.result).stdout;
-    } else {
-      stdout = decision.humanStdout ?? `${decision.result.summary}\n`;
-      validatePublicText(stdout);
+      preparedOutput = prepareAdapterPayload(decision.payload, schemaRegistry);
+    } else if (!json) {
+      preparedOutput = decision.humanStdout ?? `${decision.result.summary}\n`;
+      validatePublicText(preparedOutput);
     }
-    await applyPlan(decision.plan, ports);
+    const outcome = await applyPlan(decision.plan, ports);
+    const result =
+      outcome.kind === "noop" && decision.result.stateChanged
+        ? { ...decision.result, stateChanged: false }
+        : decision.result;
+    validateResult(result);
+    // A result-contract command prepares human output above; the only absent
+    // value here is therefore result-contract JSON, rendered after outcome.
+    const stdout = preparedOutput ?? renderResultJson(result).stdout;
     write(stdout, "stdout", ports);
-    return decision.result.exitCode;
+    return result.exitCode;
   } catch (error) {
     if (error instanceof TransactionFailure) {
       return publish(transactionFailureResult(error), json, ports);

--- a/packages/runtime/src/composition/cli.ts
+++ b/packages/runtime/src/composition/cli.ts
@@ -10,6 +10,7 @@ import {
   internalFailure,
   renderResultHuman,
   renderResultJson,
+  transactionFailureResult,
   validatePublicText,
   validateResult,
   type Result,
@@ -22,6 +23,7 @@ import type { RuntimePorts } from "../ports/index.js";
 
 import { applyPlan } from "./index.js";
 import { createSchemaRegistry } from "./schema.js";
+import { TransactionFailure } from "./transactions.js";
 
 function write(
   text: string,
@@ -104,7 +106,10 @@ export async function runCommandLine(
     await applyPlan(decision.plan, ports);
     write(stdout, "stdout", ports);
     return decision.result.exitCode;
-  } catch {
+  } catch (error) {
+    if (error instanceof TransactionFailure) {
+      return publish(transactionFailureResult(error), json, ports);
+    }
     return publish(internalFailure(), json, ports);
   }
 }

--- a/packages/runtime/src/composition/index.ts
+++ b/packages/runtime/src/composition/index.ts
@@ -11,6 +11,15 @@ import {
 import type { RuntimePorts } from "../ports/index.js";
 
 export { configurationValidator, createSchemaRegistry } from "./schema.js";
+export {
+  executeManagedMutation,
+  inspectManagedTransactions,
+  recoverManagedMutation,
+  TransactionFailure,
+  type TransactionReceipt,
+  type TransactionServices,
+  type TransactionSummary,
+} from "./transactions.js";
 
 /**
  * The one place effect implementations are chosen.

--- a/packages/runtime/src/composition/index.ts
+++ b/packages/runtime/src/composition/index.ts
@@ -21,6 +21,7 @@ import { configurationValidator, createSchemaRegistry } from "./schema.js";
 import {
   executeManagedMutation,
   inspectManagedTransactions,
+  preflightManagedTransactions,
   recoverManagedMutation,
   TransactionFailure,
   type TransactionReceipt,
@@ -33,6 +34,7 @@ export {
   createSchemaRegistry,
   executeManagedMutation,
   inspectManagedTransactions,
+  preflightManagedTransactions,
   recoverManagedMutation,
   TransactionFailure,
 };
@@ -75,8 +77,14 @@ export function createRuntimeAt(
 /** Reserved destination for the future canonical append operation. */
 const eventLogPath = ".brain/events.jsonl";
 
+export type ApplyPlanOutcome =
+  { readonly kind: "committed" } | { readonly kind: "noop" };
+
 /**
  * Commit every managed effect through one durable transaction, then emit.
+ *
+ * The outcome lets orchestration report the concrete mutation fact: a command
+ * may be allowed to mutate state while its already-satisfied plan is a no-op.
  */
 export async function applyPlan(
   plan: EffectPlan,
@@ -84,14 +92,11 @@ export async function applyPlan(
   options: { readonly rootMode: "existing" | "initialize" } = {
     rootMode: "existing",
   },
-): Promise<void> {
-  const emits = selectEmitEffects(plan);
-  const append = plan.effects.find(({ kind }) => kind === "append_event");
-  if (append !== undefined) {
-    throw new TransactionFailure("runtime.state_corrupt", [
-      { kind: "artifact", ref: eventLogPath },
-    ]);
-  }
+): Promise<ApplyPlanOutcome> {
+  const input = snapshotApplyInput(plan, options);
+  const frozenPlan = input.plan;
+  const frozenOptions = { rootMode: input.rootMode };
+  const emits = selectEmitEffects(frozenPlan);
 
   const services: TransactionServices = {
     clock: ports.clock,
@@ -100,11 +105,22 @@ export async function applyPlan(
     durableFileSystem: ports.durableFileSystem,
     schemaRegistry: createSchemaRegistry(),
   };
-  const observations = await observeManagedPaths(plan, ports);
+  if (hasManagedEffects(frozenPlan)) {
+    await preflightManagedTransactions(frozenOptions, services);
+  }
+  const append = frozenPlan.effects.find(({ kind }) => kind === "append_event");
+  if (append !== undefined) {
+    throw new TransactionFailure("runtime.state_corrupt", [
+      { kind: "artifact", ref: eventLogPath },
+    ]);
+  }
+  const observations = await observeManagedPaths(frozenPlan, ports);
   let normalized: ReturnType<typeof normalizeManagedMutationPlan>;
   try {
-    normalized = normalizeManagedMutationPlan(plan, observations, (text) =>
-      ports.digests.sha256(text),
+    normalized = normalizeManagedMutationPlan(
+      frozenPlan,
+      observations,
+      (text) => ports.digests.sha256(text),
     );
   } catch (error) {
     if (error instanceof TransactionPolicyError) {
@@ -118,15 +134,13 @@ export async function applyPlan(
     throw new TransactionFailure("runtime.internal_failure", []);
   }
 
+  let outcome: ApplyPlanOutcome;
   if (normalized.kind === "noop") {
-    if (hasManagedEffects(plan)) {
-      await assertNoopRoot(options.rootMode, services);
-      await rejectIncompleteMarker(services);
-    }
+    outcome = { kind: "noop" };
   } else {
     const receipt = await executeManagedMutation(
       normalized.plan,
-      options,
+      frozenOptions,
       services,
     );
     /* v8 ignore start -- normal execution returns committed or throws; aborted
@@ -140,39 +154,80 @@ export async function applyPlan(
       ]);
     }
     /* v8 ignore stop */
+    outcome = { kind: "committed" };
   }
 
   for (const effect of emits) {
     if (effect.channel === "structured") ports.output.structured(effect.text);
     else ports.output.human(effect.text);
   }
+  return outcome;
 }
 
-async function assertNoopRoot(
-  rootMode: "existing" | "initialize",
-  services: TransactionServices,
-): Promise<void> {
-  if (rootMode === "initialize") return;
+function snapshotApplyInput(
+  plan: unknown,
+  options: unknown,
+): {
+  readonly plan: EffectPlan;
+  readonly rootMode: "existing" | "initialize";
+} {
   try {
-    if (
-      (await services.durableFileSystem.inspect(".brain")).kind !== "directory"
-    ) {
-      throw new TransactionFailure("runtime.state_corrupt", [
-        { kind: "artifact", ref: ".brain" },
-      ]);
+    if (!isRecord(plan) || !Array.isArray(plan.effects)) {
+      throw invalidApplyInput();
     }
-    if (
-      (await services.durableFileSystem.inspect(".brain/transactions")).kind !==
-      "directory"
-    ) {
-      throw new TransactionFailure("runtime.state_corrupt", [
-        { kind: "artifact", ref: ".brain/transactions" },
-      ]);
+    if (!isRecord(options)) throw invalidApplyInput();
+    const rootMode = options.rootMode;
+    if (rootMode !== "existing" && rootMode !== "initialize") {
+      throw invalidApplyInput();
     }
+    return {
+      plan: { effects: plan.effects.map(snapshotEffect) },
+      rootMode,
+    };
   } catch (error) {
     if (error instanceof TransactionFailure) throw error;
     throw new TransactionFailure("runtime.internal_failure", []);
   }
+}
+
+function snapshotEffect(value: unknown): EffectPlan["effects"][number] {
+  if (!isRecord(value) || typeof value.kind !== "string") {
+    throw invalidApplyInput();
+  }
+  switch (value.kind) {
+    case "write_file":
+      if (typeof value.path !== "string" || typeof value.content !== "string") {
+        throw invalidApplyInput();
+      }
+      return { kind: value.kind, path: value.path, content: value.content };
+    case "delete_file":
+    case "create_directory":
+      if (typeof value.path !== "string") throw invalidApplyInput();
+      return { kind: value.kind, path: value.path };
+    case "append_event":
+      if (typeof value.event !== "string") throw invalidApplyInput();
+      return { kind: value.kind, event: value.event };
+    case "emit":
+      if (
+        (value.channel !== "structured" && value.channel !== "human") ||
+        typeof value.text !== "string"
+      ) {
+        throw invalidApplyInput();
+      }
+      return { kind: value.kind, channel: value.channel, text: value.text };
+    default:
+      throw invalidApplyInput();
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidApplyInput(): TransactionFailure {
+  return new TransactionFailure("runtime.state_corrupt", [
+    { kind: "artifact", ref: ".brain" },
+  ]);
 }
 
 function selectEmitEffects(
@@ -213,25 +268,6 @@ function hasManagedEffects(plan: EffectPlan): boolean {
       kind === "delete_file" ||
       kind === "write_file",
   );
-}
-
-async function rejectIncompleteMarker(
-  services: TransactionServices,
-): Promise<void> {
-  try {
-    const summaries = await inspectManagedTransactions(services);
-    const incomplete = summaries.find(
-      ({ phase }) => phase !== "committed" && phase !== "aborted",
-    );
-    if (incomplete !== undefined) {
-      throw new TransactionFailure("runtime.recovery_required", [
-        { kind: "artifact", ref: incomplete.evidenceRef },
-      ]);
-    }
-  } catch (error) {
-    if (error instanceof TransactionFailure) throw error;
-    throw new TransactionFailure("runtime.internal_failure", []);
-  }
 }
 
 async function observeManagedPaths(

--- a/packages/runtime/src/composition/index.ts
+++ b/packages/runtime/src/composition/index.ts
@@ -1,12 +1,14 @@
 import type { EffectPlan } from "../domain/effects.js";
 import {
   nodeClock,
+  nodeDurableFileSystem,
   nodeEnvironment,
   nodeFileSystem,
   nodeGit,
   nodeIds,
   nodeLocks,
   nodeOutput,
+  sha256Digests,
 } from "../infra/node/index.js";
 import type { RuntimePorts } from "../ports/index.js";
 
@@ -44,6 +46,8 @@ export function createRuntimeAt(
   return {
     clock: nodeClock(),
     ids: nodeIds(),
+    digests: sha256Digests(),
+    durableFileSystem: nodeDurableFileSystem(root),
     fileSystem: nodeFileSystem(root),
     git: nodeGit(root),
     locks: nodeLocks(root),

--- a/packages/runtime/src/composition/index.ts
+++ b/packages/runtime/src/composition/index.ts
@@ -1,5 +1,10 @@
 import type { EffectPlan } from "../domain/effects.js";
 import {
+  normalizeManagedMutationPlan,
+  TransactionPolicyError,
+  type PathFingerprint,
+} from "../domain/transactions/index.js";
+import {
   nodeClock,
   nodeDurableFileSystem,
   nodeEnvironment,
@@ -10,10 +15,10 @@ import {
   nodeOutput,
   sha256Digests,
 } from "../infra/node/index.js";
-import type { RuntimePorts } from "../ports/index.js";
+import type { DurableEntry, RuntimePorts } from "../ports/index.js";
 
-export { configurationValidator, createSchemaRegistry } from "./schema.js";
-export {
+import { configurationValidator, createSchemaRegistry } from "./schema.js";
+import {
   executeManagedMutation,
   inspectManagedTransactions,
   recoverManagedMutation,
@@ -22,6 +27,16 @@ export {
   type TransactionServices,
   type TransactionSummary,
 } from "./transactions.js";
+
+export {
+  configurationValidator,
+  createSchemaRegistry,
+  executeManagedMutation,
+  inspectManagedTransactions,
+  recoverManagedMutation,
+  TransactionFailure,
+};
+export type { TransactionReceipt, TransactionServices, TransactionSummary };
 
 /**
  * The one place effect implementations are chosen.
@@ -57,66 +72,248 @@ export function createRuntimeAt(
   };
 }
 
-/** Where `append_event` effects are recorded, relative to the project root. */
+/** Reserved destination for the future canonical append operation. */
 const eventLogPath = ".brain/events.jsonl";
 
 /**
- * Perform an effect plan in declared order.
- *
- * The switch is exhaustive, so adding an effect variant without handling it
- * fails the type check rather than being silently skipped. A failing effect
- * stops the run instead of being stepped over; making the already-applied
- * prefix roll back is `RUN-05`'s transaction boundary, not this function's.
+ * Commit every managed effect through one durable transaction, then emit.
  */
 export async function applyPlan(
   plan: EffectPlan,
   ports: RuntimePorts,
+  options: { readonly rootMode: "existing" | "initialize" } = {
+    rootMode: "existing",
+  },
 ): Promise<void> {
+  const emits = selectEmitEffects(plan);
+  const append = plan.effects.find(({ kind }) => kind === "append_event");
+  if (append !== undefined) {
+    throw new TransactionFailure("runtime.state_corrupt", [
+      { kind: "artifact", ref: eventLogPath },
+    ]);
+  }
+
+  const services: TransactionServices = {
+    clock: ports.clock,
+    ids: ports.ids,
+    digests: ports.digests,
+    durableFileSystem: ports.durableFileSystem,
+    schemaRegistry: createSchemaRegistry(),
+  };
+  const observations = await observeManagedPaths(plan, ports);
+  let normalized: ReturnType<typeof normalizeManagedMutationPlan>;
+  try {
+    normalized = normalizeManagedMutationPlan(plan, observations, (text) =>
+      ports.digests.sha256(text),
+    );
+  } catch (error) {
+    if (error instanceof TransactionPolicyError) {
+      throw new TransactionFailure(
+        error.reasonCode,
+        error.reasonCode === "runtime.state_corrupt"
+          ? [{ kind: "artifact", ref: ".brain" }]
+          : [],
+      );
+    }
+    throw new TransactionFailure("runtime.internal_failure", []);
+  }
+
+  if (normalized.kind === "noop") {
+    if (hasManagedEffects(plan)) {
+      await assertNoopRoot(options.rootMode, services);
+      await rejectIncompleteMarker(services);
+    }
+  } else {
+    const receipt = await executeManagedMutation(
+      normalized.plan,
+      options,
+      services,
+    );
+    /* v8 ignore start -- normal execution returns committed or throws; aborted
+     * is returned only by the separate explicit-recovery operation. */
+    if (receipt.phase !== "committed") {
+      throw new TransactionFailure("runtime.state_corrupt", [
+        {
+          kind: "artifact",
+          ref: `.brain/transactions/${receipt.transactionId}/progress.json`,
+        },
+      ]);
+    }
+    /* v8 ignore stop */
+  }
+
+  for (const effect of emits) {
+    if (effect.channel === "structured") ports.output.structured(effect.text);
+    else ports.output.human(effect.text);
+  }
+}
+
+async function assertNoopRoot(
+  rootMode: "existing" | "initialize",
+  services: TransactionServices,
+): Promise<void> {
+  if (rootMode === "initialize") return;
+  try {
+    if (
+      (await services.durableFileSystem.inspect(".brain")).kind !== "directory"
+    ) {
+      throw new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain" },
+      ]);
+    }
+    if (
+      (await services.durableFileSystem.inspect(".brain/transactions")).kind !==
+      "directory"
+    ) {
+      throw new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain/transactions" },
+      ]);
+    }
+  } catch (error) {
+    if (error instanceof TransactionFailure) throw error;
+    throw new TransactionFailure("runtime.internal_failure", []);
+  }
+}
+
+function selectEmitEffects(
+  plan: EffectPlan,
+): readonly Extract<
+  EffectPlan["effects"][number],
+  { readonly kind: "emit" }
+>[] {
+  const emits: Extract<
+    EffectPlan["effects"][number],
+    { readonly kind: "emit" }
+  >[] = [];
   for (const effect of plan.effects) {
     switch (effect.kind) {
-      case "write_file":
-        await ports.fileSystem.write(effect.path, effect.content);
-        break;
-      case "delete_file":
-        await ports.fileSystem.remove(effect.path);
-        break;
+      case "append_event":
       case "create_directory":
-        await ports.fileSystem.makeDirectory(effect.path);
+      case "delete_file":
+      case "write_file":
         break;
-      case "append_event": {
-        // Distinguish "no log yet" from "the log could not be read". Catching
-        // every failure and writing an empty prefix would replace an existing
-        // log with a single line on any transient error -- silent,
-        // unrecoverable data loss in the precursor to the event store.
-        const present = (await ports.fileSystem.stat(eventLogPath)) !== null;
-        const existing = present
-          ? await ports.fileSystem.read(eventLogPath)
-          : "";
-        await ports.fileSystem.write(
-          eventLogPath,
-          `${existing}${effect.event}\n`,
-        );
-        break;
-      }
       case "emit":
-        if (effect.channel === "structured")
-          ports.output.structured(effect.text);
-        else ports.output.human(effect.text);
+        emits.push(effect);
         break;
-      /* v8 ignore start -- unreachable by construction; see below */
+      /* v8 ignore start -- the compile-time exhaustiveness assertion */
       default: {
-        // Without this the switch carries no exhaustiveness obligation, because
-        // the function returns void. A new effect kind would then be silently
-        // no-op'd, which is the worst possible failure for an effect applier.
-        //
-        // It is unreachable while `Effect` is fully handled, so it is excluded
-        // from coverage rather than kept alive by a test that would have to
-        // defeat the type system to reach it. Its real assertion is at compile
-        // time: adding a variant makes `never` fail to accept it.
         const unhandled: never = effect;
         throw new Error(`Unhandled effect kind: ${JSON.stringify(unhandled)}`);
       }
       /* v8 ignore stop */
     }
+  }
+  return emits;
+}
+
+function hasManagedEffects(plan: EffectPlan): boolean {
+  return plan.effects.some(
+    ({ kind }) =>
+      kind === "create_directory" ||
+      kind === "delete_file" ||
+      kind === "write_file",
+  );
+}
+
+async function rejectIncompleteMarker(
+  services: TransactionServices,
+): Promise<void> {
+  try {
+    const summaries = await inspectManagedTransactions(services);
+    const incomplete = summaries.find(
+      ({ phase }) => phase !== "committed" && phase !== "aborted",
+    );
+    if (incomplete !== undefined) {
+      throw new TransactionFailure("runtime.recovery_required", [
+        { kind: "artifact", ref: incomplete.evidenceRef },
+      ]);
+    }
+  } catch (error) {
+    if (error instanceof TransactionFailure) throw error;
+    throw new TransactionFailure("runtime.internal_failure", []);
+  }
+}
+
+async function observeManagedPaths(
+  plan: EffectPlan,
+  ports: RuntimePorts,
+): Promise<ReadonlyMap<string, PathFingerprint>> {
+  const observations = new Map<string, PathFingerprint>();
+  try {
+    for (const path of managedObservationPaths(plan)) {
+      const entry = await ports.durableFileSystem.inspect(path);
+      if (path === ".brain" && entry.kind === "file") {
+        throw new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: path },
+        ]);
+      }
+      observations.set(path, durableEntryFingerprint(entry, path));
+    }
+  } catch (error) {
+    if (error instanceof TransactionFailure) throw error;
+    throw new TransactionFailure("runtime.internal_failure", []);
+  }
+  return observations;
+}
+
+function managedObservationPaths(plan: EffectPlan): readonly string[] {
+  const paths = new Set<string>();
+  for (const effect of plan.effects) {
+    if (
+      effect.kind === "emit" ||
+      effect.kind === "append_event" ||
+      !isObservationCandidate(effect.path)
+    ) {
+      continue;
+    }
+    // The root is observed first so an unsafe root cannot be hidden behind a
+    // descendant scan failure. This is a read boundary, not authorization;
+    // normalization below remains the authoritative managed-path policy.
+    paths.add(".brain");
+    const segments = effect.path.split("/");
+    for (let length = 2; length <= segments.length; length += 1) {
+      paths.add(segments.slice(0, length).join("/"));
+    }
+  }
+  return [...paths];
+}
+
+function isObservationCandidate(path: string): boolean {
+  if (path === "" || path.includes("\\") || /^[A-Za-z]:/u.test(path)) {
+    return false;
+  }
+  for (const character of path) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return false;
+    }
+  }
+  const segments = path.split("/");
+  return (
+    segments.length >= 2 &&
+    segments[0] === ".brain" &&
+    !segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    ) &&
+    segments[1]?.toLowerCase() !== "transactions"
+  );
+}
+
+function durableEntryFingerprint(
+  entry: DurableEntry,
+  path: string,
+): PathFingerprint {
+  switch (entry.kind) {
+    case "missing":
+      return entry;
+    case "directory":
+      return { kind: "directory" };
+    case "file":
+      return { kind: "file", size: entry.size, sha256: entry.sha256 };
+    case "special":
+    case "symlink":
+      throw new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: path },
+      ]);
   }
 }

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -616,9 +616,12 @@ async function driveRecovery(
   const manifestEntry = await services.durableFileSystem.inspect(
     `${root}/manifest.json`,
   );
-  if (manifestEntry.kind === "missing") {
+  if (progress.manifestDigest === null) {
     return recoverWithoutManifest(progress, services);
   }
+  /* v8 ignore next -- validated inspection already rejects a bound progress
+   * document whose required manifest is absent. */
+  if (manifestEntry.kind === "missing") throw corrupt(`${root}/manifest.json`);
   /* v8 ignore next -- inspection validated this entry before recovery */
   if (manifestEntry.kind !== "file") throw corrupt(`${root}/manifest.json`);
   const manifest = await readRequiredManifest(root, progress, services);
@@ -745,7 +748,13 @@ async function driveRecovery(
         break;
       }
       case "complete": {
-        if (await hasCleanupEntries(root, services)) {
+        if (
+          await hasCleanupEntries(
+            root,
+            services,
+            progress.manifestDigest === null,
+          )
+        ) {
           const directorySync = await cleanupTransaction(
             manifest,
             progress.directorySync,
@@ -828,7 +837,17 @@ async function firstIncompleteSummary(
     const next = await services.durableFileSystem.inspect(
       `${root}/progress.next`,
     );
-    if (staging.kind !== "missing" || next.kind !== "missing") return summary;
+    const unboundManifest =
+      summary.manifestDigest === null
+        ? await services.durableFileSystem.inspect(`${root}/manifest.json`)
+        : { kind: "missing" as const };
+    if (
+      staging.kind !== "missing" ||
+      next.kind !== "missing" ||
+      unboundManifest.kind !== "missing"
+    ) {
+      return summary;
+    }
   }
   return undefined;
 }
@@ -867,7 +886,13 @@ async function classifyDriverFailure(
       }
       if (current.phase === "committed" || current.phase === "aborted") {
         const root = transactionRoot(current.transactionId);
-        if (await hasCleanupEntries(root, services)) {
+        if (
+          await hasCleanupEntries(
+            root,
+            services,
+            current.manifestDigest === null,
+          )
+        ) {
           throw recoveryRequired(current);
         }
         const progress = await readProgress(`${root}/progress.json`, services);
@@ -1122,9 +1147,9 @@ async function validatePersistedIdentity(
 
   const manifestPath = `${root}/manifest.json`;
   const manifestEntry = await services.durableFileSystem.inspect(manifestPath);
+  if (progress.manifestDigest === null) return;
   if (manifestEntry.kind === "missing") {
-    if (progress.manifestDigest !== null) throw corrupt(manifestPath);
-    return;
+    throw corrupt(manifestPath);
   }
   /* v8 ignore next -- validateTransactionLayout already proved file kind */
   if (manifestEntry.kind !== "file") throw corrupt(manifestPath);
@@ -1136,8 +1161,7 @@ async function validatePersistedIdentity(
   if (
     manifest.transactionId !== progress.transactionId ||
     manifest.createdAt !== progress.createdAt ||
-    (progress.manifestDigest !== null &&
-      services.digests.sha256(canonical) !== progress.manifestDigest)
+    services.digests.sha256(canonical) !== progress.manifestDigest
   ) {
     throw corrupt(manifestPath);
   }
@@ -1610,6 +1634,16 @@ async function recoverWithoutManifest(
   if ((await services.durableFileSystem.inspect(nextPath)).kind === "file") {
     await services.durableFileSystem.removeFile(nextPath);
   }
+  const manifestPath = `${root}/manifest.json`;
+  const manifest = await services.durableFileSystem.inspect(manifestPath);
+  if (manifest.kind === "file") {
+    await services.durableFileSystem.removeFile(manifestPath);
+    /* v8 ignore start -- the initial validated transaction layout permits only
+     * a regular manifest or absence before this bounded cleanup. */
+  } else if (manifest.kind !== "missing") {
+    throw corrupt(manifestPath);
+  }
+  /* v8 ignore stop */
   const directorySync = mergeDirectorySync(
     progress.directorySync,
     await services.durableFileSystem.syncDirectory(root),
@@ -1625,12 +1659,16 @@ async function recoverWithoutManifest(
 async function hasCleanupEntries(
   root: string,
   services: TransactionServices,
+  removeUnboundManifest: boolean,
 ): Promise<boolean> {
   return (
     (await services.durableFileSystem.inspect(`${root}/staging`)).kind !==
       "missing" ||
     (await services.durableFileSystem.inspect(`${root}/progress.next`)).kind !==
-      "missing"
+      "missing" ||
+    (removeUnboundManifest &&
+      (await services.durableFileSystem.inspect(`${root}/manifest.json`))
+        .kind !== "missing")
   );
 }
 

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -125,7 +125,10 @@ async function assertPreflightRoot(
   if (brain.kind !== "directory") throw corrupt(".brain");
   const transactions =
     await services.durableFileSystem.inspect(transactionsRoot);
-  if (transactions.kind === "missing" && rootMode === "initialize") return;
+  if (transactions.kind === "missing" && rootMode === "initialize") {
+    await assertInitializeNamespaceAvailable(false, services);
+    return;
+  }
   if (transactions.kind !== "directory") throw corrupt(transactionsRoot);
 }
 
@@ -1045,12 +1048,7 @@ async function assertExistingRoot(
 
   let transactions = await services.durableFileSystem.inspect(transactionsRoot);
   if (rootMode === "initialize" && transactions.kind === "missing") {
-    if (
-      !createdBrain &&
-      (await services.durableFileSystem.list(".brain")).length !== 0
-    ) {
-      throw new TransactionFailure("runtime.state_corrupt", evidence(".brain"));
-    }
+    await assertInitializeNamespaceAvailable(createdBrain, services);
     await services.durableFileSystem.createDirectory(transactionsRoot);
     await services.durableFileSystem.syncDirectory(".brain");
     transactions = { kind: "directory" };
@@ -1060,6 +1058,18 @@ async function assertExistingRoot(
       "runtime.state_corrupt",
       evidence(transactionsRoot),
     );
+  }
+}
+
+async function assertInitializeNamespaceAvailable(
+  createdBrain: boolean,
+  services: TransactionServices,
+): Promise<void> {
+  if (
+    !createdBrain &&
+    (await services.durableFileSystem.list(".brain")).length !== 0
+  ) {
+    throw corrupt(".brain");
   }
 }
 

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -258,7 +258,12 @@ function validateManagedRelationships(
       const rightPath = right.path.toLowerCase();
       if (leftPath === rightPath) throw invalidPlan();
       if (rightPath.startsWith(`${leftPath}/`)) {
-        if (left.kind !== "create_directory") throw invalidPlan();
+        if (
+          left.kind !== "create_directory" ||
+          right.expected.kind !== "missing"
+        ) {
+          throw invalidPlan();
+        }
       } else if (leftPath.startsWith(`${rightPath}/`)) {
         throw invalidPlan();
       }
@@ -809,7 +814,12 @@ async function classifyDriverFailure(
         );
       }
       if (current.phase === "publishing") {
-        await classifyPublishingState(current, services);
+        try {
+          await classifyPublishingState(current, services);
+        } catch (freshError) {
+          if (freshError instanceof TransactionFailure) throw freshError;
+          throw recoveryRequired(current);
+        }
       }
       if (typedFailure !== undefined) throw typedFailure;
       throw recoveryRequired(current);

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -1,0 +1,1252 @@
+import {
+  CONTRACT_IDENTITIES,
+  type TransactionManifestV1,
+  type TransactionProgressV1,
+} from "@mestre-yoda/contracts";
+
+import type { EvidenceRef } from "../domain/result/index.js";
+import {
+  canonicalizeJson,
+  type SchemaRegistry,
+} from "../domain/schema/index.js";
+import {
+  assertPhaseTransition,
+  decideRecovery,
+  toPersistedManagedOperation,
+  type ManagedMutationPlan,
+  type ManagedOperation,
+  type PathFingerprint,
+} from "../domain/transactions/index.js";
+import type {
+  Clock,
+  Digests,
+  DurableEntry,
+  DurableFileSystem,
+  Ids,
+} from "../ports/index.js";
+
+const contractVersion = "1.0.0" as const;
+const stateContract = "1.0.0" as const;
+const transactionsRoot = ".brain/transactions";
+
+export interface TransactionReceipt {
+  readonly transactionId: string;
+  readonly manifestDigest: string | null;
+  readonly recoveryToken: string;
+  readonly phase: "committed" | "aborted";
+  readonly directorySync: "not_attempted" | "supported" | "unsupported";
+}
+
+export interface TransactionSummary {
+  readonly transactionId: string;
+  readonly manifestDigest: string | null;
+  readonly recoveryToken: string;
+  readonly phase: TransactionProgressV1["phase"];
+  readonly evidenceRef: string;
+}
+
+export interface TransactionServices {
+  readonly clock: Clock;
+  readonly ids: Ids;
+  readonly digests: Digests;
+  readonly durableFileSystem: DurableFileSystem;
+  readonly schemaRegistry: SchemaRegistry;
+}
+
+export class TransactionFailure extends Error {
+  public constructor(
+    public readonly reasonCode:
+      | "guard.outside_allow"
+      | "runtime.internal_failure"
+      | "runtime.recovery_required"
+      | "runtime.revision_conflict"
+      | "runtime.state_corrupt",
+    public readonly evidence: readonly EvidenceRef[],
+  ) {
+    super("Managed transaction failed");
+    this.name = "TransactionFailure";
+  }
+}
+
+export async function executeManagedMutation(
+  plan: ManagedMutationPlan,
+  options: { readonly rootMode: "existing" | "initialize" },
+  services: TransactionServices,
+): Promise<TransactionReceipt> {
+  try {
+    await rejectIncompleteTransactions(services);
+    return await driveExecution(plan, options, services);
+  } catch (error) {
+    return classifyDriverFailure(error, services);
+  }
+}
+
+async function driveExecution(
+  plan: ManagedMutationPlan,
+  options: { readonly rootMode: "existing" | "initialize" },
+  services: TransactionServices,
+): Promise<TransactionReceipt> {
+  await assertExistingRoot(options.rootMode, services);
+
+  const transactionId = services.ids.next();
+  const createdAt = services.clock.now().toISOString();
+  const root = transactionRoot(transactionId);
+  const stagingRoot = `${root}/staging`;
+  const begunToken = services.digests.sha256(
+    canonicalizeJson({
+      contractVersion,
+      stateContract,
+      transactionId,
+      createdAt,
+    }),
+  );
+  let directorySync: TransactionProgressV1["directorySync"] = "not_attempted";
+
+  const begun = validateProgress(
+    {
+      contractVersion,
+      stateContract,
+      transactionId,
+      manifestDigest: null,
+      recoveryToken: begunToken,
+      phase: "begun",
+      publishedOperationIds: [],
+      fileSync: "required",
+      directorySync,
+      createdAt,
+      updatedAt: services.clock.now().toISOString(),
+    },
+    services,
+  );
+
+  await services.durableFileSystem.createDirectoryExclusive(root);
+  directorySync = mergeDirectorySync(
+    directorySync,
+    await services.durableFileSystem.syncDirectory(transactionsRoot),
+  );
+  directorySync = await persistProgress({ ...begun, directorySync }, services);
+
+  await services.durableFileSystem.createDirectory(stagingRoot);
+  directorySync = mergeDirectorySync(
+    directorySync,
+    await services.durableFileSystem.syncDirectory(root),
+  );
+
+  for (const operation of plan.operations) {
+    if (operation.kind !== "write_file") continue;
+    await services.durableFileSystem.writeSynced(
+      stagedPayloadPath(root, operation),
+      operation.content,
+    );
+    directorySync = mergeDirectorySync(
+      directorySync,
+      await services.durableFileSystem.syncDirectory(stagingRoot),
+    );
+  }
+
+  const manifest = createManifest(
+    plan,
+    transactionId,
+    createdAt,
+    root,
+    services,
+  );
+  const manifestEncoded = canonicalizeJson(manifest);
+  const manifestDigest = services.digests.sha256(manifestEncoded);
+  await services.durableFileSystem.writeSynced(
+    `${root}/manifest.json`,
+    `${manifestEncoded}\n`,
+  );
+  directorySync = mergeDirectorySync(
+    directorySync,
+    await services.durableFileSystem.syncDirectory(root),
+  );
+
+  await assertPreconditions(manifest, services);
+  let progress = validateProgress(
+    {
+      ...begun,
+      manifestDigest,
+      recoveryToken: manifestDigest,
+      phase: "prepared",
+      directorySync,
+      updatedAt: services.clock.now().toISOString(),
+    },
+    services,
+  );
+  directorySync = await persistProgress(progress, services);
+
+  progress = validateProgress(
+    {
+      ...progress,
+      phase: "publishing",
+      directorySync,
+      updatedAt: services.clock.now().toISOString(),
+    },
+    services,
+  );
+  directorySync = await persistProgress(progress, services);
+
+  const publishedOperationIds: string[] = [];
+  for (const operation of plan.operations) {
+    await assertPublishable(operation, services);
+    await publishOperation(operation, root, services);
+    directorySync = mergeDirectorySync(
+      directorySync,
+      await services.durableFileSystem.syncDirectory(parentOf(operation.path)),
+    );
+    await assertResult(operation, services);
+    publishedOperationIds.push(operation.operationId);
+    progress = validateProgress(
+      {
+        ...progress,
+        publishedOperationIds: [...publishedOperationIds],
+        directorySync,
+        updatedAt: services.clock.now().toISOString(),
+      },
+      services,
+    );
+    directorySync = await persistProgress(progress, services);
+  }
+
+  await assertResults(manifest, services);
+  progress = validateProgress(
+    {
+      ...progress,
+      phase: "committed",
+      publishedOperationIds: manifest.operations.map(
+        (operation) => operation.operationId,
+      ),
+      directorySync,
+      updatedAt: services.clock.now().toISOString(),
+    },
+    services,
+  );
+  directorySync = await persistProgress(progress, services);
+
+  await services.durableFileSystem.removeEmptyDirectory(stagingRoot);
+  directorySync = mergeDirectorySync(
+    directorySync,
+    await services.durableFileSystem.syncDirectory(root),
+  );
+
+  return {
+    transactionId,
+    manifestDigest,
+    recoveryToken: manifestDigest,
+    phase: "committed",
+    directorySync,
+  };
+}
+
+export async function inspectManagedTransactions(
+  services: TransactionServices,
+): Promise<readonly TransactionSummary[]> {
+  const brain = await services.durableFileSystem.inspect(".brain");
+  if (brain.kind === "missing") return [];
+  if (brain.kind !== "directory") {
+    throw corrupt(".brain");
+  }
+  const transactions =
+    await services.durableFileSystem.inspect(transactionsRoot);
+  if (transactions.kind === "missing") return [];
+  if (transactions.kind !== "directory") {
+    throw corrupt(transactionsRoot);
+  }
+
+  const transactionIds = [
+    ...(await services.durableFileSystem.list(transactionsRoot)),
+  ].sort((left, right) => left.localeCompare(right, "en-US"));
+  const summaries: TransactionSummary[] = [];
+  for (const transactionId of transactionIds) {
+    const root = transactionRoot(transactionId);
+    if ((await services.durableFileSystem.inspect(root)).kind !== "directory") {
+      throw corrupt(root);
+    }
+    await validateTransactionLayout(root, services);
+    const progressPath = `${root}/progress.json`;
+    const progress = await readProgress(progressPath, services);
+    if (progress.transactionId !== transactionId) {
+      throw corrupt(progressPath);
+    }
+    await validatePersistedIdentity(progress, root, services);
+    summaries.push({
+      transactionId,
+      manifestDigest: progress.manifestDigest,
+      recoveryToken: progress.recoveryToken,
+      phase: progress.phase,
+      evidenceRef: progressPath,
+    });
+  }
+  return summaries;
+}
+
+export async function recoverManagedMutation(
+  request: { readonly transactionId: string; readonly recoveryToken: string },
+  services: TransactionServices,
+): Promise<TransactionReceipt> {
+  try {
+    const summaries = await inspectManagedTransactions(services);
+    const summary = summaries.find(
+      (candidate) => candidate.transactionId === request.transactionId,
+    );
+    if (summary === undefined) {
+      const incomplete = await firstIncompleteSummary(summaries, services);
+      if (incomplete !== undefined) throw recoveryRequired(incomplete);
+      throw corrupt(transactionRoot(request.transactionId));
+    }
+    if (summary.recoveryToken !== request.recoveryToken) {
+      throw recoveryRequired(summary);
+    }
+    return await driveRecovery(summary, services);
+  } catch (error) {
+    return classifyDriverFailure(error, services);
+  }
+}
+
+async function driveRecovery(
+  summary: TransactionSummary,
+  services: TransactionServices,
+): Promise<TransactionReceipt> {
+  const root = transactionRoot(summary.transactionId);
+  const progressPath = `${root}/progress.json`;
+  let progress = await readProgress(progressPath, services);
+  const manifestEntry = await services.durableFileSystem.inspect(
+    `${root}/manifest.json`,
+  );
+  if (manifestEntry.kind === "missing") {
+    return recoverWithoutManifest(progress, services);
+  }
+  /* v8 ignore next -- inspection validated this entry before recovery */
+  if (manifestEntry.kind !== "file") throw corrupt(`${root}/manifest.json`);
+  const manifest = await readRequiredManifest(root, progress, services);
+
+  for (;;) {
+    const observation = await observeTransaction(manifest, services);
+    const decision = decideRecovery(manifest, progress, observation);
+    switch (decision.kind) {
+      case "abort": {
+        assertPhaseTransition(progress.phase, "aborted");
+        progress = validateProgress(
+          {
+            ...progress,
+            phase: "aborted",
+            publishedOperationIds: [],
+            updatedAt: services.clock.now().toISOString(),
+          },
+          services,
+        );
+        const directorySync = await persistProgress(progress, services);
+        progress = { ...progress, directorySync };
+        break;
+      }
+      case "record_published": {
+        progress = validateProgress(
+          {
+            ...progress,
+            publishedOperationIds: [
+              ...progress.publishedOperationIds,
+              decision.operationId,
+            ],
+            updatedAt: services.clock.now().toISOString(),
+          },
+          services,
+        );
+        const directorySync = await persistProgress(progress, services);
+        progress = { ...progress, directorySync };
+        break;
+      }
+      case "publish": {
+        const operation = manifest.operations.find(
+          (candidate) => candidate.operationId === decision.operationId,
+        );
+        /* v8 ignore next -- decideRecovery returns an ID from this manifest */
+        if (operation === undefined) throw corrupt(`${root}/manifest.json`);
+        const parent = parentOf(operation.path);
+        if (
+          (await services.durableFileSystem.inspect(parent)).kind !==
+          "directory"
+        ) {
+          throw corrupt(operation.path);
+        }
+        await publishPersistedOperation(operation, services);
+        let directorySync = mergeDirectorySync(
+          progress.directorySync,
+          await services.durableFileSystem.syncDirectory(parent),
+        );
+        const result = await observeFingerprint(operation.path, services);
+        if (!sameFingerprint(result, operation.result)) {
+          throw corrupt(operation.path);
+        }
+        progress = validateProgress(
+          {
+            ...progress,
+            publishedOperationIds: [
+              ...progress.publishedOperationIds,
+              operation.operationId,
+            ],
+            directorySync,
+            updatedAt: services.clock.now().toISOString(),
+          },
+          services,
+        );
+        directorySync = await persistProgress(progress, services);
+        progress = { ...progress, directorySync };
+        break;
+      }
+      case "commit": {
+        assertPhaseTransition(progress.phase, "committed");
+        progress = validateProgress(
+          {
+            ...progress,
+            phase: "committed",
+            publishedOperationIds: manifest.operations.map(
+              (operation) => operation.operationId,
+            ),
+            updatedAt: services.clock.now().toISOString(),
+          },
+          services,
+        );
+        const directorySync = await persistProgress(progress, services);
+        progress = { ...progress, directorySync };
+        break;
+      }
+      case "cleanup": {
+        const directorySync = await cleanupTransaction(
+          manifest,
+          progress.directorySync,
+          services,
+        );
+        progress = { ...progress, directorySync };
+        break;
+      }
+      case "complete": {
+        if (await hasCleanupEntries(root, services)) {
+          const directorySync = await cleanupTransaction(
+            manifest,
+            progress.directorySync,
+            services,
+          );
+          progress = { ...progress, directorySync };
+        }
+        return receiptFromProgress(progress);
+      }
+      case "blocked": {
+        const blockedOperation =
+          decision.operationId === null
+            ? undefined
+            : manifest.operations.find(
+                (operation) => operation.operationId === decision.operationId,
+              );
+        const blockedEvidenceRef =
+          decision.operationId === null ? progressPath : blockedOperation?.path;
+        /* v8 ignore start -- decideRecovery only returns IDs from this manifest */
+        if (blockedEvidenceRef === undefined) {
+          throw corrupt(`${root}/manifest.json`);
+        }
+        /* v8 ignore stop */
+        throw new TransactionFailure(
+          decision.reasonCode,
+          evidence(blockedEvidenceRef),
+        );
+      }
+    }
+  }
+}
+
+function transactionRoot(transactionId: string): string {
+  return `${transactionsRoot}/${transactionId}`;
+}
+
+function evidence(path: string): readonly EvidenceRef[] {
+  return [{ kind: "artifact", ref: path }];
+}
+
+async function rejectIncompleteTransactions(
+  services: TransactionServices,
+): Promise<void> {
+  const summaries = await inspectManagedTransactions(services);
+  const incomplete = await firstIncompleteSummary(summaries, services);
+  if (incomplete !== undefined) throw recoveryRequired(incomplete);
+}
+
+async function firstIncompleteSummary(
+  summaries: readonly TransactionSummary[],
+  services: TransactionServices,
+): Promise<TransactionSummary | undefined> {
+  for (const summary of summaries) {
+    if (summary.phase !== "committed" && summary.phase !== "aborted") {
+      return summary;
+    }
+    const root = transactionRoot(summary.transactionId);
+    const staging = await services.durableFileSystem.inspect(`${root}/staging`);
+    const next = await services.durableFileSystem.inspect(
+      `${root}/progress.next`,
+    );
+    if (staging.kind !== "missing" || next.kind !== "missing") return summary;
+  }
+  return undefined;
+}
+
+function recoveryRequired(summary: TransactionSummary): TransactionFailure {
+  return new TransactionFailure(
+    "runtime.recovery_required",
+    evidence(summary.evidenceRef),
+  );
+}
+
+async function classifyDriverFailure(
+  error: unknown,
+  services: TransactionServices,
+): Promise<never> {
+  if (error instanceof TransactionFailure) throw error;
+  try {
+    await cleanupUnmarkedTransactions(services);
+    const summaries = await inspectManagedTransactions(services);
+    const incomplete = await firstIncompleteSummary(summaries, services);
+    if (incomplete !== undefined) throw recoveryRequired(incomplete);
+  } catch (inspectionError) {
+    if (inspectionError instanceof TransactionFailure) throw inspectionError;
+  }
+  throw new TransactionFailure("runtime.internal_failure", []);
+}
+
+async function cleanupUnmarkedTransactions(
+  services: TransactionServices,
+): Promise<void> {
+  if (
+    (await services.durableFileSystem.inspect(".brain")).kind !== "directory" ||
+    (await services.durableFileSystem.inspect(transactionsRoot)).kind !==
+      "directory"
+  ) {
+    return;
+  }
+  for (const transactionId of await services.durableFileSystem.list(
+    transactionsRoot,
+  )) {
+    const root = transactionRoot(transactionId);
+    /* v8 ignore next -- only the driver creates an unmarked transaction ID */
+    if ((await services.durableFileSystem.inspect(root)).kind !== "directory") {
+      continue;
+    }
+    const progress = await services.durableFileSystem.inspect(
+      `${root}/progress.json`,
+    );
+    if (progress.kind !== "missing") continue;
+    const entries = await services.durableFileSystem.list(root);
+    /* v8 ignore next -- a pre-marker driver writes only progress.next */
+    if (entries.some((entry) => entry !== "progress.next")) continue;
+    const nextPath = `${root}/progress.next`;
+    const next = await services.durableFileSystem.inspect(nextPath);
+    if (next.kind === "file") {
+      await services.durableFileSystem.removeFile(nextPath);
+      /* v8 ignore start -- the validated scratch entry is missing or a file */
+    } else if (next.kind !== "missing") {
+      continue;
+    }
+    /* v8 ignore stop */
+    /* v8 ignore next -- progress.next was the only possible entry */
+    if ((await services.durableFileSystem.list(root)).length !== 0) continue;
+    await services.durableFileSystem.removeEmptyDirectory(root);
+    await services.durableFileSystem.syncDirectory(transactionsRoot);
+  }
+}
+
+async function assertExistingRoot(
+  rootMode: "existing" | "initialize",
+  services: TransactionServices,
+): Promise<void> {
+  let brain = await services.durableFileSystem.inspect(".brain");
+  let createdBrain = false;
+  if (rootMode === "initialize" && brain.kind === "missing") {
+    await services.durableFileSystem.createDirectory(".brain");
+    await services.durableFileSystem.syncDirectory(".");
+    brain = { kind: "directory" };
+    createdBrain = true;
+  }
+  if (brain.kind !== "directory") {
+    throw new TransactionFailure("runtime.state_corrupt", evidence(".brain"));
+  }
+
+  let transactions = await services.durableFileSystem.inspect(transactionsRoot);
+  if (rootMode === "initialize" && transactions.kind === "missing") {
+    if (
+      !createdBrain &&
+      (await services.durableFileSystem.list(".brain")).length !== 0
+    ) {
+      throw new TransactionFailure("runtime.state_corrupt", evidence(".brain"));
+    }
+    await services.durableFileSystem.createDirectory(transactionsRoot);
+    await services.durableFileSystem.syncDirectory(".brain");
+    transactions = { kind: "directory" };
+  }
+  if (transactions.kind !== "directory") {
+    throw new TransactionFailure(
+      "runtime.state_corrupt",
+      evidence(transactionsRoot),
+    );
+  }
+}
+
+async function validateTransactionLayout(
+  root: string,
+  services: TransactionServices,
+): Promise<void> {
+  const allowed = new Set([
+    "manifest.json",
+    "progress.json",
+    "progress.next",
+    "staging",
+  ]);
+  const entries = await services.durableFileSystem.list(root);
+  if (entries.some((entry) => !allowed.has(entry))) throw corrupt(root);
+
+  for (const file of ["manifest.json", "progress.json", "progress.next"]) {
+    const observed = await services.durableFileSystem.inspect(
+      `${root}/${file}`,
+    );
+    if (observed.kind !== "missing" && observed.kind !== "file") {
+      throw corrupt(`${root}/${file}`);
+    }
+  }
+  const staging = await services.durableFileSystem.inspect(`${root}/staging`);
+  if (staging.kind !== "missing" && staging.kind !== "directory") {
+    throw corrupt(`${root}/staging`);
+  }
+}
+
+async function validatePersistedIdentity(
+  progress: TransactionProgressV1,
+  root: string,
+  services: TransactionServices,
+): Promise<void> {
+  const progressPath = `${root}/progress.json`;
+  if (progress.manifestDigest === null) {
+    const identityToken = services.digests.sha256(
+      canonicalizeJson({
+        contractVersion: progress.contractVersion,
+        stateContract: progress.stateContract,
+        transactionId: progress.transactionId,
+        createdAt: progress.createdAt,
+      }),
+    );
+    if (progress.recoveryToken !== identityToken) throw corrupt(progressPath);
+  } else if (progress.recoveryToken !== progress.manifestDigest) {
+    throw corrupt(progressPath);
+  }
+
+  const manifestPath = `${root}/manifest.json`;
+  const manifestEntry = await services.durableFileSystem.inspect(manifestPath);
+  if (manifestEntry.kind === "missing") {
+    if (progress.manifestDigest !== null) throw corrupt(manifestPath);
+    return;
+  }
+  /* v8 ignore next -- validateTransactionLayout already proved file kind */
+  if (manifestEntry.kind !== "file") throw corrupt(manifestPath);
+  const { value: manifest, canonical } = await readManifest(
+    manifestPath,
+    services,
+  );
+  assertManifestSemantics(manifest, root, services);
+  if (
+    manifest.transactionId !== progress.transactionId ||
+    manifest.createdAt !== progress.createdAt ||
+    (progress.manifestDigest !== null &&
+      services.digests.sha256(canonical) !== progress.manifestDigest)
+  ) {
+    throw corrupt(manifestPath);
+  }
+}
+
+async function readRequiredManifest(
+  root: string,
+  progress: TransactionProgressV1,
+  services: TransactionServices,
+): Promise<TransactionManifestV1> {
+  const manifestPath = `${root}/manifest.json`;
+  const { value, canonical } = await readManifest(manifestPath, services);
+  assertManifestSemantics(value, root, services);
+  if (
+    value.transactionId !== progress.transactionId ||
+    value.createdAt !== progress.createdAt ||
+    (progress.manifestDigest !== null &&
+      services.digests.sha256(canonical) !== progress.manifestDigest)
+  ) {
+    throw corrupt(manifestPath);
+  }
+  return value;
+}
+
+function assertManifestSemantics(
+  manifest: TransactionManifestV1,
+  root: string,
+  services: TransactionServices,
+): void {
+  for (const [index, operation] of manifest.operations.entries()) {
+    const operationId = `operation-${String(index + 1).padStart(4, "0")}`;
+    if (
+      operation.operationId !== operationId ||
+      !isManagedDestination(operation.path)
+    ) {
+      throw corrupt(`${root}/manifest.json`);
+    }
+    switch (operation.kind) {
+      case "create_directory":
+        if (
+          operation.expected.kind !== "missing" ||
+          operation.result.kind !== "directory"
+        ) {
+          throw corrupt(`${root}/manifest.json`);
+        }
+        break;
+      case "write_file":
+        if (
+          operation.stagedPath !== `${root}/staging/${operationId}.payload` ||
+          operation.expected.kind === "directory" ||
+          operation.result.kind !== "file"
+        ) {
+          throw corrupt(`${root}/manifest.json`);
+        }
+        break;
+      case "delete_file":
+        if (
+          operation.expected.kind !== "file" ||
+          operation.result.kind !== "missing"
+        ) {
+          throw corrupt(`${root}/manifest.json`);
+        }
+        break;
+    }
+  }
+
+  const relativeOperations = manifest.operations.map((operation) =>
+    operation.stagedPath === null
+      ? operation
+      : {
+          ...operation,
+          stagedPath: `staging/${operation.operationId}.payload`,
+        },
+  );
+  const planDigest = services.digests.sha256(
+    canonicalizeJson({ operations: relativeOperations }),
+  );
+  if (manifest.planDigest !== planDigest) {
+    throw corrupt(`${root}/manifest.json`);
+  }
+}
+
+function isManagedDestination(path: string): boolean {
+  const segments = path.split("/");
+  return (
+    segments.length >= 2 &&
+    segments[0] === ".brain" &&
+    segments[1]?.toLowerCase() !== "transactions" &&
+    segments.every(
+      (segment) => segment !== "" && segment !== "." && segment !== "..",
+    ) &&
+    segments.join("/") === path
+  );
+}
+
+async function observeTransaction(
+  manifest: TransactionManifestV1,
+  services: TransactionServices,
+): Promise<{
+  readonly destinations: ReadonlyMap<string, PathFingerprint>;
+  readonly stagedPayloads: ReadonlyMap<string, PathFingerprint>;
+}> {
+  const destinations = new Map<string, PathFingerprint>();
+  const stagedPayloads = new Map<string, PathFingerprint>();
+  for (const operation of manifest.operations) {
+    destinations.set(
+      operation.path,
+      await observeFingerprint(operation.path, services),
+    );
+    if (operation.stagedPath !== null) {
+      stagedPayloads.set(
+        operation.stagedPath,
+        await observeFingerprint(operation.stagedPath, services),
+      );
+    }
+  }
+
+  const root = transactionRoot(manifest.transactionId);
+  const stagingRoot = `${root}/staging`;
+  const staging = await services.durableFileSystem.inspect(stagingRoot);
+  if (staging.kind === "directory") {
+    const known = new Set(
+      manifest.operations.flatMap((operation) =>
+        operation.stagedPath === null ? [] : [operation.stagedPath],
+      ),
+    );
+    for (const name of await services.durableFileSystem.list(stagingRoot)) {
+      const path = `${stagingRoot}/${name}`;
+      if (!known.has(path)) {
+        stagedPayloads.set(path, await observeFingerprint(path, services));
+      }
+    }
+    /* v8 ignore start -- transaction layout was validated immediately above */
+  } else if (staging.kind !== "missing") {
+    throw corrupt(stagingRoot);
+  }
+  /* v8 ignore stop */
+  return { destinations, stagedPayloads };
+}
+
+async function readProgress(
+  path: string,
+  services: TransactionServices,
+): Promise<TransactionProgressV1> {
+  const text = await readRegularText(path, services);
+  const parsed = parseCanonicalJson(text, path);
+  try {
+    return validateProgress(parsed, services);
+  } catch (error) {
+    if (error instanceof TransactionFailure) throw corrupt(path);
+    throw new TransactionFailure("runtime.internal_failure", []);
+  }
+}
+
+async function readManifest(
+  path: string,
+  services: TransactionServices,
+): Promise<{
+  readonly value: TransactionManifestV1;
+  readonly canonical: string;
+}> {
+  const text = await readRegularText(path, services);
+  const parsed = parseCanonicalJson(text, path);
+  try {
+    return {
+      value: validateManifest(parsed, services),
+      canonical: text.slice(0, -1),
+    };
+  } catch (error) {
+    if (error instanceof TransactionFailure) throw corrupt(path);
+    throw new TransactionFailure("runtime.internal_failure", []);
+  }
+}
+
+async function readRegularText(
+  path: string,
+  services: TransactionServices,
+): Promise<string> {
+  /* v8 ignore start -- callers validate the transaction layout before reading */
+  if ((await services.durableFileSystem.inspect(path)).kind !== "file") {
+    throw corrupt(path);
+  }
+  /* v8 ignore stop */
+  return services.durableFileSystem.readText(path);
+}
+
+function parseCanonicalJson(text: string, path: string): unknown {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (text !== `${canonicalizeJson(parsed)}\n`) throw corrupt(path);
+    return parsed;
+  } catch (error) {
+    if (error instanceof TransactionFailure) throw error;
+    throw corrupt(path);
+  }
+}
+
+function corrupt(path: string): TransactionFailure {
+  return new TransactionFailure("runtime.state_corrupt", evidence(path));
+}
+
+function createManifest(
+  plan: ManagedMutationPlan,
+  transactionId: string,
+  createdAt: string,
+  root: string,
+  services: TransactionServices,
+): TransactionManifestV1 {
+  const persisted = plan.operations.map((operation) => {
+    const value = toPersistedManagedOperation(operation);
+    return value.stagedPath === null
+      ? value
+      : { ...value, stagedPath: `${root}/${value.stagedPath}` };
+  });
+  const first = persisted[0];
+  if (first === undefined) {
+    throw new TransactionFailure("runtime.state_corrupt", []);
+  }
+  const manifest: TransactionManifestV1 = {
+    contractVersion,
+    stateContract,
+    transactionId,
+    planDigest: services.digests.sha256(
+      canonicalizeJson({
+        operations: plan.operations.map(toPersistedManagedOperation),
+      }),
+    ),
+    createdAt,
+    operations: [first, ...persisted.slice(1)],
+  };
+  return validateManifest(manifest, services);
+}
+
+function validateManifest(
+  value: unknown,
+  services: TransactionServices,
+): TransactionManifestV1 {
+  const result = services.schemaRegistry.validate({
+    id: "state.transaction-manifest",
+    version: CONTRACT_IDENTITIES.state,
+    value,
+    structuralReasonCode: "runtime.state_corrupt",
+  });
+  if (result.kind === "invalid") {
+    throw new TransactionFailure("runtime.state_corrupt", []);
+  }
+  return result.value;
+}
+
+function validateProgress(
+  value: unknown,
+  services: TransactionServices,
+): TransactionProgressV1 {
+  const result = services.schemaRegistry.validate({
+    id: "state.transaction-progress",
+    version: CONTRACT_IDENTITIES.state,
+    value,
+    structuralReasonCode: "runtime.state_corrupt",
+  });
+  if (result.kind === "invalid") {
+    throw new TransactionFailure("runtime.state_corrupt", []);
+  }
+  return result.value;
+}
+
+async function persistProgress(
+  progress: TransactionProgressV1,
+  services: TransactionServices,
+): Promise<TransactionProgressV1["directorySync"]> {
+  const validated = validateProgress(progress, services);
+  const root = transactionRoot(validated.transactionId);
+  const nextPath = `${root}/progress.next`;
+  const next = await services.durableFileSystem.inspect(nextPath);
+  if (next.kind === "file") {
+    await services.durableFileSystem.removeFile(nextPath);
+    await services.durableFileSystem.syncDirectory(root);
+  } else if (next.kind !== "missing") {
+    throw corrupt(nextPath);
+  }
+  await services.durableFileSystem.writeSynced(
+    nextPath,
+    `${canonicalizeJson(validated)}\n`,
+  );
+  await services.durableFileSystem.replaceFile(
+    nextPath,
+    `${root}/progress.json`,
+  );
+  return mergeDirectorySync(
+    validated.directorySync,
+    await services.durableFileSystem.syncDirectory(root),
+  );
+}
+
+async function publishPersistedOperation(
+  operation: TransactionManifestV1["operations"][number],
+  services: TransactionServices,
+): Promise<void> {
+  switch (operation.kind) {
+    case "create_directory":
+      await services.durableFileSystem.createDirectory(operation.path);
+      break;
+    case "write_file":
+      await services.durableFileSystem.replaceFile(
+        operation.stagedPath,
+        operation.path,
+      );
+      break;
+    case "delete_file":
+      await services.durableFileSystem.removeFile(operation.path);
+      break;
+  }
+}
+
+async function cleanupTransaction(
+  manifest: TransactionManifestV1,
+  currentDirectorySync: TransactionProgressV1["directorySync"],
+  services: TransactionServices,
+): Promise<TransactionProgressV1["directorySync"]> {
+  const root = transactionRoot(manifest.transactionId);
+  const stagingRoot = `${root}/staging`;
+  for (const operation of manifest.operations) {
+    if (operation.stagedPath === null) continue;
+    const payload = await services.durableFileSystem.inspect(
+      operation.stagedPath,
+    );
+    if (payload.kind === "file") {
+      await services.durableFileSystem.removeFile(operation.stagedPath);
+      /* v8 ignore start -- decideRecovery validates every known payload first */
+    } else if (payload.kind !== "missing") {
+      throw corrupt(operation.stagedPath);
+    }
+    /* v8 ignore stop */
+  }
+
+  const staging = await services.durableFileSystem.inspect(stagingRoot);
+  if (staging.kind === "directory") {
+    /* v8 ignore next -- decideRecovery blocks unknown staging content */
+    if ((await services.durableFileSystem.list(stagingRoot)).length !== 0) {
+      throw corrupt(stagingRoot);
+    }
+    await services.durableFileSystem.removeEmptyDirectory(stagingRoot);
+    /* v8 ignore start -- validated observation permits only directory or missing */
+  } else if (staging.kind !== "missing") {
+    throw corrupt(stagingRoot);
+  }
+  /* v8 ignore stop */
+
+  const nextPath = `${root}/progress.next`;
+  const next = await services.durableFileSystem.inspect(nextPath);
+  if (next.kind === "file") {
+    await services.durableFileSystem.removeFile(nextPath);
+    /* v8 ignore start -- validateTransactionLayout permits only file or missing */
+  } else if (next.kind !== "missing") {
+    throw corrupt(nextPath);
+  }
+  /* v8 ignore stop */
+  return mergeDirectorySync(
+    currentDirectorySync,
+    await services.durableFileSystem.syncDirectory(root),
+  );
+}
+
+async function recoverWithoutManifest(
+  initial: TransactionProgressV1,
+  services: TransactionServices,
+): Promise<TransactionReceipt> {
+  const root = transactionRoot(initial.transactionId);
+  const progressPath = `${root}/progress.json`;
+  /* v8 ignore next -- persisted identity rejects a digest without a manifest */
+  if (initial.manifestDigest !== null) {
+    throw corrupt(progressPath);
+  }
+
+  const stagingRoot = `${root}/staging`;
+  const staging = await services.durableFileSystem.inspect(stagingRoot);
+  const payloads: string[] = [];
+  if (staging.kind === "directory") {
+    for (const name of await services.durableFileSystem.list(stagingRoot)) {
+      if (!/^operation-[0-9]{4}\.payload$/u.test(name)) {
+        throw corrupt(`${stagingRoot}/${name}`);
+      }
+      const path = `${stagingRoot}/${name}`;
+      if ((await services.durableFileSystem.inspect(path)).kind !== "file") {
+        throw corrupt(path);
+      }
+      payloads.push(path);
+    }
+    /* v8 ignore start -- validateTransactionLayout proved the staging kind */
+  } else if (staging.kind !== "missing") {
+    throw corrupt(stagingRoot);
+  }
+  /* v8 ignore stop */
+
+  const nextPath = `${root}/progress.next`;
+  const next = await services.durableFileSystem.inspect(nextPath);
+  /* v8 ignore next -- validateTransactionLayout proved the scratch kind */
+  if (next.kind !== "file" && next.kind !== "missing") {
+    throw corrupt(nextPath);
+  }
+
+  let progress: TransactionProgressV1 = initial;
+  if (progress.phase === "begun") {
+    assertPhaseTransition(progress.phase, "aborted");
+    progress = validateProgress(
+      {
+        ...progress,
+        phase: "aborted",
+        publishedOperationIds: [],
+        updatedAt: services.clock.now().toISOString(),
+      },
+      services,
+    );
+    const directorySync = await persistProgress(progress, services);
+    progress = { ...progress, directorySync };
+  }
+
+  for (const path of payloads) {
+    await services.durableFileSystem.removeFile(path);
+  }
+  if (staging.kind === "directory") {
+    await services.durableFileSystem.removeEmptyDirectory(stagingRoot);
+  }
+  if ((await services.durableFileSystem.inspect(nextPath)).kind === "file") {
+    await services.durableFileSystem.removeFile(nextPath);
+  }
+  const directorySync = mergeDirectorySync(
+    progress.directorySync,
+    await services.durableFileSystem.syncDirectory(root),
+  );
+  return receiptFromProgress({ ...progress, directorySync });
+}
+
+async function hasCleanupEntries(
+  root: string,
+  services: TransactionServices,
+): Promise<boolean> {
+  return (
+    (await services.durableFileSystem.inspect(`${root}/staging`)).kind !==
+      "missing" ||
+    (await services.durableFileSystem.inspect(`${root}/progress.next`)).kind !==
+      "missing"
+  );
+}
+
+function receiptFromProgress(
+  progress: TransactionProgressV1,
+): TransactionReceipt {
+  /* v8 ignore next -- receipts are constructed only from terminal decisions */
+  if (progress.phase !== "committed" && progress.phase !== "aborted") {
+    throw corrupt(`${transactionRoot(progress.transactionId)}/progress.json`);
+  }
+  return {
+    transactionId: progress.transactionId,
+    manifestDigest: progress.manifestDigest,
+    recoveryToken: progress.recoveryToken,
+    phase: progress.phase,
+    directorySync: progress.directorySync,
+  };
+}
+
+function stagedPayloadPath(
+  root: string,
+  operation: Extract<ManagedOperation, { readonly kind: "write_file" }>,
+): string {
+  return `${root}/${operation.stagedPath}`;
+}
+
+async function assertPreconditions(
+  manifest: TransactionManifestV1,
+  services: TransactionServices,
+): Promise<void> {
+  for (const operation of manifest.operations) {
+    const observed = await observeFingerprint(operation.path, services);
+    if (!sameFingerprint(observed, operation.expected)) {
+      throw new TransactionFailure(
+        "runtime.revision_conflict",
+        evidence(operation.path),
+      );
+    }
+  }
+}
+
+async function assertPublishable(
+  operation: ManagedOperation,
+  services: TransactionServices,
+): Promise<void> {
+  const parent = await services.durableFileSystem.inspect(
+    parentOf(operation.path),
+  );
+  if (parent.kind !== "directory") {
+    throw new TransactionFailure(
+      "runtime.state_corrupt",
+      evidence(operation.path),
+    );
+  }
+  const observed = await observeFingerprint(operation.path, services);
+  if (!sameFingerprint(observed, operation.expected)) {
+    throw new TransactionFailure(
+      "runtime.revision_conflict",
+      evidence(operation.path),
+    );
+  }
+}
+
+async function publishOperation(
+  operation: ManagedOperation,
+  root: string,
+  services: TransactionServices,
+): Promise<void> {
+  switch (operation.kind) {
+    case "create_directory":
+      await services.durableFileSystem.createDirectory(operation.path);
+      break;
+    case "write_file":
+      await services.durableFileSystem.replaceFile(
+        stagedPayloadPath(root, operation),
+        operation.path,
+      );
+      break;
+    case "delete_file":
+      await services.durableFileSystem.removeFile(operation.path);
+      break;
+  }
+}
+
+async function assertResult(
+  operation: ManagedOperation,
+  services: TransactionServices,
+): Promise<void> {
+  const observed = await observeFingerprint(operation.path, services);
+  if (!sameFingerprint(observed, operation.result)) {
+    throw new TransactionFailure(
+      "runtime.state_corrupt",
+      evidence(operation.path),
+    );
+  }
+}
+
+async function assertResults(
+  manifest: TransactionManifestV1,
+  services: TransactionServices,
+): Promise<void> {
+  for (const operation of manifest.operations) {
+    const observed = await observeFingerprint(operation.path, services);
+    if (!sameFingerprint(observed, operation.result)) {
+      throw new TransactionFailure(
+        "runtime.state_corrupt",
+        evidence(operation.path),
+      );
+    }
+  }
+}
+
+async function observeFingerprint(
+  path: string,
+  services: TransactionServices,
+): Promise<PathFingerprint> {
+  return toFingerprint(await services.durableFileSystem.inspect(path), path);
+}
+
+function toFingerprint(entry: DurableEntry, path: string): PathFingerprint {
+  switch (entry.kind) {
+    case "missing":
+      return entry;
+    case "directory":
+      return { kind: "directory" };
+    case "file":
+      return { kind: "file", size: entry.size, sha256: entry.sha256 };
+    case "special":
+    case "symlink":
+      throw new TransactionFailure("runtime.state_corrupt", evidence(path));
+  }
+}
+
+function sameFingerprint(
+  left: PathFingerprint,
+  right: PathFingerprint,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind !== "file" || right.kind !== "file") return true;
+  return left.size === right.size && left.sha256 === right.sha256;
+}
+
+function parentOf(path: string): string {
+  const separator = path.lastIndexOf("/");
+  /* v8 ignore next -- every managed destination begins with .brain/ */
+  return separator === -1 ? "." : path.slice(0, separator);
+}
+
+function mergeDirectorySync(
+  current: TransactionProgressV1["directorySync"],
+  observed: "supported" | "unsupported",
+): TransactionProgressV1["directorySync"] {
+  return current === "unsupported" || observed === "unsupported"
+    ? "unsupported"
+    : "supported";
+}

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -92,12 +92,41 @@ export async function executeManagedMutation(
     publishingAuthorized: false,
   };
   try {
-    await reconcileUnmarkedTransactions(services);
-    await rejectIncompleteTransactions(services);
+    // applyPlan performs this preflight before observing caller destinations;
+    // repeat it here after normalization to close that asynchronous race.
+    await preflightManagedTransactions(options, services);
     return await driveExecution(frozenPlan, options, services, attempt);
   } catch (error) {
     return classifyDriverFailure(error, services, attempt);
   }
+}
+
+/** Reconcile safe orphans and reject every transaction requiring recovery. */
+export async function preflightManagedTransactions(
+  options: { readonly rootMode: "existing" | "initialize" },
+  services: TransactionServices,
+): Promise<void> {
+  try {
+    await reconcileUnmarkedTransactions(services);
+    await assertPreflightRoot(options.rootMode, services);
+    await rejectIncompleteTransactions(services);
+  } catch (error) {
+    if (error instanceof TransactionFailure) throw error;
+    throw new TransactionFailure("runtime.internal_failure", []);
+  }
+}
+
+async function assertPreflightRoot(
+  rootMode: "existing" | "initialize",
+  services: TransactionServices,
+): Promise<void> {
+  const brain = await services.durableFileSystem.inspect(".brain");
+  if (brain.kind === "missing" && rootMode === "initialize") return;
+  if (brain.kind !== "directory") throw corrupt(".brain");
+  const transactions =
+    await services.durableFileSystem.inspect(transactionsRoot);
+  if (transactions.kind === "missing" && rootMode === "initialize") return;
+  if (transactions.kind !== "directory") throw corrupt(transactionsRoot);
 }
 
 function freezeManagedPlan(

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -53,6 +53,12 @@ export interface TransactionServices {
   readonly schemaRegistry: SchemaRegistry;
 }
 
+interface TransactionFailureContext {
+  transactionId?: string;
+  recoveryToken?: string;
+  publishingAuthorized: boolean;
+}
+
 export class TransactionFailure extends Error {
   public constructor(
     public readonly reasonCode:
@@ -80,13 +86,13 @@ export async function executeManagedMutation(
     if (error instanceof TransactionFailure) throw error;
     throw new TransactionFailure("runtime.internal_failure", []);
   }
-  const attempt: { transactionId?: string } = {};
+  const attempt: TransactionFailureContext = { publishingAuthorized: false };
   try {
     await reconcileUnmarkedTransactions(services);
     await rejectIncompleteTransactions(services);
     return await driveExecution(frozenPlan, options, services, attempt);
   } catch (error) {
-    return classifyDriverFailure(error, services, attempt.transactionId);
+    return classifyDriverFailure(error, services, attempt);
   }
 }
 
@@ -269,6 +275,21 @@ function validateManagedRelationships(
       }
     }
   }
+
+  const createdDirectories = new Set<string>();
+  for (const operation of operations) {
+    let beneathCreatedDirectory = false;
+    for (const prefix of managedPathPrefixes(operation.path).slice(0, -1)) {
+      if (createdDirectories.has(prefix.toLowerCase())) {
+        beneathCreatedDirectory = true;
+      } else if (beneathCreatedDirectory) {
+        throw invalidPlan();
+      }
+    }
+    if (operation.kind === "create_directory") {
+      createdDirectories.add(operation.path.toLowerCase());
+    }
+  }
 }
 
 function managedPathPrefixes(path: string): readonly string[] {
@@ -313,7 +334,7 @@ async function driveExecution(
   plan: ManagedMutationPlan,
   options: { readonly rootMode: "existing" | "initialize" },
   services: TransactionServices,
-  attempt: { transactionId?: string },
+  attempt: TransactionFailureContext,
 ): Promise<TransactionReceipt> {
   await assertExistingRoot(options.rootMode, services);
 
@@ -417,6 +438,7 @@ async function driveExecution(
     services,
   );
   directorySync = await persistProgress(progress, services);
+  attempt.publishingAuthorized = true;
 
   const publishedOperationIds: string[] = [];
   for (const operation of plan.operations) {
@@ -513,6 +535,11 @@ export async function recoverManagedMutation(
   request: { readonly transactionId: string; readonly recoveryToken: string },
   services: TransactionServices,
 ): Promise<TransactionReceipt> {
+  const attempt: TransactionFailureContext = {
+    transactionId: request.transactionId,
+    recoveryToken: request.recoveryToken,
+    publishingAuthorized: false,
+  };
   try {
     const summaries = await inspectManagedTransactions(services);
     const summary = summaries.find(
@@ -526,14 +553,11 @@ export async function recoverManagedMutation(
     if (summary.recoveryToken !== request.recoveryToken) {
       throw recoveryRequired(summary);
     }
+    attempt.publishingAuthorized =
+      summary.phase === "publishing" || summary.phase === "committed";
     return await driveRecovery(summary, services);
   } catch (error) {
-    return classifyDriverFailure(
-      error,
-      services,
-      request.transactionId,
-      request.recoveryToken,
-    );
+    return classifyDriverFailure(error, services, attempt);
   }
 }
 
@@ -781,9 +805,9 @@ function recoveryRequired(summary: TransactionSummary): TransactionFailure {
 async function classifyDriverFailure(
   error: unknown,
   services: TransactionServices,
-  transactionId?: string,
-  recoveryToken?: string,
+  context: TransactionFailureContext,
 ): Promise<TransactionReceipt> {
+  const { transactionId, recoveryToken } = context;
   const typedFailure = error instanceof TransactionFailure ? error : undefined;
   if (typedFailure !== undefined && transactionId === undefined) {
     throw typedFailure;
@@ -828,9 +852,21 @@ async function classifyDriverFailure(
     if (incomplete !== undefined) throw recoveryRequired(incomplete);
   } catch (inspectionError) {
     if (inspectionError instanceof TransactionFailure) throw inspectionError;
+    if (context.publishingAuthorized && transactionId !== undefined) {
+      throw recoveryRequiredForTransaction(transactionId);
+    }
   }
   if (typedFailure !== undefined) throw typedFailure;
   throw new TransactionFailure("runtime.internal_failure", []);
+}
+
+function recoveryRequiredForTransaction(
+  transactionId: string,
+): TransactionFailure {
+  return new TransactionFailure(
+    "runtime.recovery_required",
+    evidence(`${transactionRoot(transactionId)}/progress.json`),
+  );
 }
 
 async function classifyPublishingState(

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -56,6 +56,7 @@ export interface TransactionServices {
 interface TransactionFailureContext {
   transactionId?: string;
   recoveryToken?: string;
+  validatedRecovery: boolean;
   publishingAuthorized: boolean;
 }
 
@@ -86,7 +87,10 @@ export async function executeManagedMutation(
     if (error instanceof TransactionFailure) throw error;
     throw new TransactionFailure("runtime.internal_failure", []);
   }
-  const attempt: TransactionFailureContext = { publishingAuthorized: false };
+  const attempt: TransactionFailureContext = {
+    validatedRecovery: false,
+    publishingAuthorized: false,
+  };
   try {
     await reconcileUnmarkedTransactions(services);
     await rejectIncompleteTransactions(services);
@@ -538,6 +542,7 @@ export async function recoverManagedMutation(
   const attempt: TransactionFailureContext = {
     transactionId: request.transactionId,
     recoveryToken: request.recoveryToken,
+    validatedRecovery: false,
     publishingAuthorized: false,
   };
   try {
@@ -553,6 +558,7 @@ export async function recoverManagedMutation(
     if (summary.recoveryToken !== request.recoveryToken) {
       throw recoveryRequired(summary);
     }
+    attempt.validatedRecovery = true;
     attempt.publishingAuthorized =
       summary.phase === "publishing" || summary.phase === "committed";
     return await driveRecovery(summary, services);
@@ -852,7 +858,10 @@ async function classifyDriverFailure(
     if (incomplete !== undefined) throw recoveryRequired(incomplete);
   } catch (inspectionError) {
     if (inspectionError instanceof TransactionFailure) throw inspectionError;
-    if (context.publishingAuthorized && transactionId !== undefined) {
+    if (
+      (context.validatedRecovery || context.publishingAuthorized) &&
+      transactionId !== undefined
+    ) {
       throw recoveryRequiredForTransaction(transactionId);
     }
   }

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -73,22 +73,247 @@ export async function executeManagedMutation(
   options: { readonly rootMode: "existing" | "initialize" },
   services: TransactionServices,
 ): Promise<TransactionReceipt> {
+  let frozenPlan: ManagedMutationPlan;
   try {
-    await rejectIncompleteTransactions(services);
-    return await driveExecution(plan, options, services);
+    frozenPlan = freezeManagedPlan(plan, services);
   } catch (error) {
-    return classifyDriverFailure(error, services);
+    if (error instanceof TransactionFailure) throw error;
+    throw new TransactionFailure("runtime.internal_failure", []);
   }
+  const attempt: { transactionId?: string } = {};
+  try {
+    await reconcileUnmarkedTransactions(services);
+    await rejectIncompleteTransactions(services);
+    return await driveExecution(frozenPlan, options, services, attempt);
+  } catch (error) {
+    return classifyDriverFailure(error, services, attempt.transactionId);
+  }
+}
+
+function freezeManagedPlan(
+  value: unknown,
+  services: TransactionServices,
+): ManagedMutationPlan {
+  if (
+    !isExactRecord(value, ["operations"]) ||
+    !Array.isArray(value.operations)
+  ) {
+    throw invalidPlan();
+  }
+  if (value.operations.length === 0) throw invalidPlan();
+
+  const operations = value.operations.map((operation, index) =>
+    freezeManagedOperation(operation, index, services),
+  );
+  validateManagedRelationships(operations);
+  return { operations };
+}
+
+function freezeManagedOperation(
+  value: unknown,
+  index: number,
+  services: TransactionServices,
+): ManagedOperation {
+  if (!isRecord(value)) throw invalidPlan();
+  const operationId = `operation-${String(index + 1).padStart(4, "0")}`;
+  if (value.operationId !== operationId || typeof value.path !== "string") {
+    throw invalidPlan();
+  }
+  assertCallerManagedDestination(value.path);
+  const expected = freezeFingerprint(value.expected);
+  const result = freezeFingerprint(value.result);
+  if (sameFingerprint(expected, result)) throw invalidPlan();
+
+  switch (value.kind) {
+    case "create_directory":
+      if (
+        !isExactRecord(value, [
+          "expected",
+          "kind",
+          "operationId",
+          "path",
+          "result",
+          "stagedPath",
+        ]) ||
+        value.stagedPath !== null ||
+        expected.kind !== "missing" ||
+        result.kind !== "directory"
+      ) {
+        throw invalidPlan();
+      }
+      return {
+        operationId,
+        kind: value.kind,
+        path: value.path,
+        expected,
+        result,
+        stagedPath: null,
+      };
+    case "write_file": {
+      if (
+        !isExactRecord(value, [
+          "content",
+          "expected",
+          "kind",
+          "operationId",
+          "path",
+          "result",
+          "stagedPath",
+        ]) ||
+        value.stagedPath !== `staging/${operationId}.payload` ||
+        typeof value.content !== "string" ||
+        expected.kind === "directory" ||
+        result.kind !== "file"
+      ) {
+        throw invalidPlan();
+      }
+      const contentSize = new TextEncoder().encode(value.content).byteLength;
+      if (
+        result.size !== contentSize ||
+        result.sha256 !== services.digests.sha256(value.content)
+      ) {
+        throw invalidPlan();
+      }
+      return {
+        operationId,
+        kind: value.kind,
+        path: value.path,
+        expected,
+        result,
+        stagedPath: value.stagedPath,
+        content: value.content,
+      };
+    }
+    case "delete_file":
+      if (
+        !isExactRecord(value, [
+          "expected",
+          "kind",
+          "operationId",
+          "path",
+          "result",
+          "stagedPath",
+        ]) ||
+        value.stagedPath !== null ||
+        expected.kind !== "file" ||
+        result.kind !== "missing"
+      ) {
+        throw invalidPlan();
+      }
+      return {
+        operationId,
+        kind: value.kind,
+        path: value.path,
+        expected,
+        result,
+        stagedPath: null,
+      };
+    default:
+      throw invalidPlan();
+  }
+}
+
+function freezeFingerprint(value: unknown): PathFingerprint {
+  if (!isRecord(value)) throw invalidPlan();
+  switch (value.kind) {
+    case "missing":
+      if (!isExactRecord(value, ["kind"])) throw invalidPlan();
+      return { kind: "missing" };
+    case "directory":
+      if (!isExactRecord(value, ["kind"])) throw invalidPlan();
+      return { kind: "directory" };
+    case "file":
+      if (
+        !isExactRecord(value, ["kind", "sha256", "size"]) ||
+        !Number.isSafeInteger(value.size) ||
+        typeof value.size !== "number" ||
+        value.size < 0 ||
+        typeof value.sha256 !== "string" ||
+        !/^[a-f0-9]{64}$/u.test(value.sha256)
+      ) {
+        throw invalidPlan();
+      }
+      return { kind: "file", size: value.size, sha256: value.sha256 };
+    default:
+      throw invalidPlan();
+  }
+}
+
+function validateManagedRelationships(
+  operations: readonly ManagedOperation[],
+): void {
+  const spellings = new Map<string, string>();
+  for (const operation of operations) {
+    for (const path of managedPathPrefixes(operation.path)) {
+      const key = path.toLowerCase();
+      const prior = spellings.get(key);
+      if (prior !== undefined && prior !== path) throw invalidPlan();
+      spellings.set(key, path);
+    }
+  }
+
+  for (const [leftIndex, left] of operations.entries()) {
+    for (const right of operations.slice(leftIndex + 1)) {
+      const leftPath = left.path.toLowerCase();
+      const rightPath = right.path.toLowerCase();
+      if (leftPath === rightPath) throw invalidPlan();
+      if (rightPath.startsWith(`${leftPath}/`)) {
+        if (left.kind !== "create_directory") throw invalidPlan();
+      } else if (leftPath.startsWith(`${rightPath}/`)) {
+        throw invalidPlan();
+      }
+    }
+  }
+}
+
+function managedPathPrefixes(path: string): readonly string[] {
+  const segments = path.split("/");
+  return segments
+    .slice(1)
+    .map((_segment, index) => segments.slice(0, index + 2).join("/"));
+}
+
+function assertCallerManagedDestination(path: string): void {
+  if (!isManagedDestination(path)) {
+    throw new TransactionFailure("guard.outside_allow", []);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isExactRecord(
+  value: unknown,
+  expectedKeys: readonly string[],
+): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const actual = Object.keys(value).sort((left, right) =>
+    left.localeCompare(right, "en-US"),
+  );
+  const expected = [...expectedKeys].sort((left, right) =>
+    left.localeCompare(right, "en-US"),
+  );
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+}
+
+function invalidPlan(): TransactionFailure {
+  return new TransactionFailure("runtime.state_corrupt", []);
 }
 
 async function driveExecution(
   plan: ManagedMutationPlan,
   options: { readonly rootMode: "existing" | "initialize" },
   services: TransactionServices,
+  attempt: { transactionId?: string },
 ): Promise<TransactionReceipt> {
   await assertExistingRoot(options.rootMode, services);
 
   const transactionId = services.ids.next();
+  attempt.transactionId = transactionId;
   const createdAt = services.clock.now().toISOString();
   const root = transactionRoot(transactionId);
   const stagingRoot = `${root}/staging`;
@@ -138,6 +363,7 @@ async function driveExecution(
       stagedPayloadPath(root, operation),
       operation.content,
     );
+    await assertExecutionPayload(operation, root, services);
     directorySync = mergeDirectorySync(
       directorySync,
       await services.durableFileSystem.syncDirectory(stagingRoot),
@@ -190,6 +416,9 @@ async function driveExecution(
   const publishedOperationIds: string[] = [];
   for (const operation of plan.operations) {
     await assertPublishable(operation, services);
+    if (operation.kind === "write_file") {
+      await assertExecutionPayload(operation, root, services);
+    }
     await publishOperation(operation, root, services);
     directorySync = mergeDirectorySync(
       directorySync,
@@ -224,19 +453,13 @@ async function driveExecution(
   );
   directorySync = await persistProgress(progress, services);
 
-  await services.durableFileSystem.removeEmptyDirectory(stagingRoot);
-  directorySync = mergeDirectorySync(
+  directorySync = await cleanupTransaction(manifest, directorySync, services);
+  progress = await persistTerminalDirectorySync(
+    progress,
     directorySync,
-    await services.durableFileSystem.syncDirectory(root),
+    services,
   );
-
-  return {
-    transactionId,
-    manifestDigest,
-    recoveryToken: manifestDigest,
-    phase: "committed",
-    directorySync,
-  };
+  return receiptFromProgress(progress);
 }
 
 export async function inspectManagedTransactions(
@@ -300,7 +523,12 @@ export async function recoverManagedMutation(
     }
     return await driveRecovery(summary, services);
   } catch (error) {
-    return classifyDriverFailure(error, services);
+    return classifyDriverFailure(
+      error,
+      services,
+      request.transactionId,
+      request.recoveryToken,
+    );
   }
 }
 
@@ -311,6 +539,13 @@ async function driveRecovery(
   const root = transactionRoot(summary.transactionId);
   const progressPath = `${root}/progress.json`;
   let progress = await readProgress(progressPath, services);
+  if (
+    progress.transactionId !== summary.transactionId ||
+    progress.recoveryToken !== summary.recoveryToken ||
+    progress.manifestDigest !== summary.manifestDigest
+  ) {
+    throw recoveryRequired(summary);
+  }
   const manifestEntry = await services.durableFileSystem.inspect(
     `${root}/manifest.json`,
   );
@@ -369,6 +604,24 @@ async function driveRecovery(
         ) {
           throw corrupt(operation.path);
         }
+        const immediateTarget = await observeFingerprint(
+          operation.path,
+          services,
+        );
+        if (sameFingerprint(immediateTarget, operation.result)) {
+          progress = await recordPublishedOperation(
+            progress,
+            operation.operationId,
+            services,
+          );
+          break;
+        }
+        if (!sameFingerprint(immediateTarget, operation.expected)) {
+          throw corrupt(operation.path);
+        }
+        if (operation.kind === "write_file") {
+          await assertPersistedPayload(operation, services);
+        }
         await publishPersistedOperation(operation, services);
         let directorySync = mergeDirectorySync(
           progress.directorySync,
@@ -417,7 +670,11 @@ async function driveRecovery(
           progress.directorySync,
           services,
         );
-        progress = { ...progress, directorySync };
+        progress = await persistTerminalDirectorySync(
+          progress,
+          directorySync,
+          services,
+        );
         break;
       }
       case "complete": {
@@ -427,7 +684,11 @@ async function driveRecovery(
             progress.directorySync,
             services,
           );
-          progress = { ...progress, directorySync };
+          progress = await persistTerminalDirectorySync(
+            progress,
+            directorySync,
+            services,
+          );
         }
         return receiptFromProgress(progress);
       }
@@ -452,6 +713,23 @@ async function driveRecovery(
       }
     }
   }
+}
+
+async function recordPublishedOperation(
+  progress: TransactionProgressV1,
+  operationId: string,
+  services: TransactionServices,
+): Promise<TransactionProgressV1> {
+  const next = validateProgress(
+    {
+      ...progress,
+      publishedOperationIds: [...progress.publishedOperationIds, operationId],
+      updatedAt: services.clock.now().toISOString(),
+    },
+    services,
+  );
+  const directorySync = await persistProgress(next, services);
+  return { ...next, directorySync };
 }
 
 function transactionRoot(transactionId: string): string {
@@ -498,20 +776,104 @@ function recoveryRequired(summary: TransactionSummary): TransactionFailure {
 async function classifyDriverFailure(
   error: unknown,
   services: TransactionServices,
-): Promise<never> {
-  if (error instanceof TransactionFailure) throw error;
+  transactionId?: string,
+  recoveryToken?: string,
+): Promise<TransactionReceipt> {
+  const typedFailure = error instanceof TransactionFailure ? error : undefined;
+  if (typedFailure !== undefined && transactionId === undefined) {
+    throw typedFailure;
+  }
   try {
-    await cleanupUnmarkedTransactions(services);
+    if (typedFailure === undefined && transactionId !== undefined) {
+      await cleanupUnmarkedTransaction(transactionId, services);
+    }
     const summaries = await inspectManagedTransactions(services);
+    const current = summaries.find(
+      (summary) => summary.transactionId === transactionId,
+    );
+    if (current !== undefined) {
+      if (
+        recoveryToken !== undefined &&
+        current.recoveryToken !== recoveryToken
+      ) {
+        throw recoveryRequired(current);
+      }
+      if (current.phase === "committed" || current.phase === "aborted") {
+        const root = transactionRoot(current.transactionId);
+        if (await hasCleanupEntries(root, services)) {
+          throw recoveryRequired(current);
+        }
+        const progress = await readProgress(`${root}/progress.json`, services);
+        return receiptFromProgress(
+          await finalizeTerminalProgress(progress, services),
+        );
+      }
+      if (current.phase === "publishing") {
+        await classifyPublishingState(current, services);
+      }
+      if (typedFailure !== undefined) throw typedFailure;
+      throw recoveryRequired(current);
+    }
     const incomplete = await firstIncompleteSummary(summaries, services);
     if (incomplete !== undefined) throw recoveryRequired(incomplete);
   } catch (inspectionError) {
     if (inspectionError instanceof TransactionFailure) throw inspectionError;
   }
+  if (typedFailure !== undefined) throw typedFailure;
   throw new TransactionFailure("runtime.internal_failure", []);
 }
 
-async function cleanupUnmarkedTransactions(
+async function classifyPublishingState(
+  summary: TransactionSummary,
+  services: TransactionServices,
+): Promise<never> {
+  const root = transactionRoot(summary.transactionId);
+  const progress = await readProgress(`${root}/progress.json`, services);
+  if (
+    progress.transactionId !== summary.transactionId ||
+    progress.recoveryToken !== summary.recoveryToken ||
+    progress.manifestDigest !== summary.manifestDigest
+  ) {
+    throw recoveryRequired(summary);
+  }
+  const manifest = await readRequiredManifest(root, progress, services);
+  const observation = await observeTransaction(manifest, services);
+  const decision = decideRecovery(manifest, progress, observation);
+  if (decision.kind === "blocked") {
+    const operation =
+      decision.operationId === null
+        ? undefined
+        : manifest.operations.find(
+            (candidate) => candidate.operationId === decision.operationId,
+          );
+    if (operation?.kind === "write_file") {
+      const payload = observation.stagedPayloads.get(operation.stagedPath);
+      if (
+        payload === undefined ||
+        !sameFingerprint(payload, operation.result)
+      ) {
+        throw corrupt(operation.stagedPath);
+      }
+    }
+    throw corrupt(operation?.path ?? `${root}/progress.json`);
+  }
+  if (decision.kind === "publish") {
+    const operation = manifest.operations.find(
+      (candidate) => candidate.operationId === decision.operationId,
+    );
+    /* v8 ignore next -- decideRecovery only returns IDs from the manifest */
+    if (operation === undefined) throw corrupt(`${root}/manifest.json`);
+    if (
+      (await services.durableFileSystem.inspect(parentOf(operation.path)))
+        .kind !== "directory"
+    ) {
+      throw corrupt(operation.path);
+    }
+  }
+  throw recoveryRequired(summary);
+}
+
+async function reconcileUnmarkedTransactions(
   services: TransactionServices,
 ): Promise<void> {
   if (
@@ -521,35 +883,64 @@ async function cleanupUnmarkedTransactions(
   ) {
     return;
   }
-  for (const transactionId of await services.durableFileSystem.list(
-    transactionsRoot,
-  )) {
+  const transactionIds = [
+    ...(await services.durableFileSystem.list(transactionsRoot)),
+  ].sort((left, right) => left.localeCompare(right, "en-US"));
+  for (const transactionId of transactionIds) {
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/u.test(transactionId)) {
+      throw corrupt(transactionsRoot);
+    }
     const root = transactionRoot(transactionId);
-    /* v8 ignore next -- only the driver creates an unmarked transaction ID */
     if ((await services.durableFileSystem.inspect(root)).kind !== "directory") {
-      continue;
+      throw corrupt(root);
     }
     const progress = await services.durableFileSystem.inspect(
       `${root}/progress.json`,
     );
     if (progress.kind !== "missing") continue;
-    const entries = await services.durableFileSystem.list(root);
-    /* v8 ignore next -- a pre-marker driver writes only progress.next */
-    if (entries.some((entry) => entry !== "progress.next")) continue;
-    const nextPath = `${root}/progress.next`;
-    const next = await services.durableFileSystem.inspect(nextPath);
-    if (next.kind === "file") {
-      await services.durableFileSystem.removeFile(nextPath);
-      /* v8 ignore start -- the validated scratch entry is missing or a file */
-    } else if (next.kind !== "missing") {
-      continue;
-    }
-    /* v8 ignore stop */
-    /* v8 ignore next -- progress.next was the only possible entry */
-    if ((await services.durableFileSystem.list(root)).length !== 0) continue;
-    await services.durableFileSystem.removeEmptyDirectory(root);
-    await services.durableFileSystem.syncDirectory(transactionsRoot);
+    await removeSafeUnmarkedTransaction(root, services, true);
   }
+}
+
+async function cleanupUnmarkedTransaction(
+  transactionId: string,
+  services: TransactionServices,
+): Promise<void> {
+  const root = transactionRoot(transactionId);
+  if ((await services.durableFileSystem.inspect(root)).kind !== "directory") {
+    return;
+  }
+  const progress = await services.durableFileSystem.inspect(
+    `${root}/progress.json`,
+  );
+  if (progress.kind !== "missing") return;
+  await removeSafeUnmarkedTransaction(root, services, false);
+}
+
+async function removeSafeUnmarkedTransaction(
+  root: string,
+  services: TransactionServices,
+  blockUnknown: boolean,
+): Promise<void> {
+  const entries = await services.durableFileSystem.list(root);
+  if (entries.some((entry) => entry !== "progress.next")) {
+    if (blockUnknown) throw corrupt(root);
+    return;
+  }
+  const nextPath = `${root}/progress.next`;
+  const next = await services.durableFileSystem.inspect(nextPath);
+  if (next.kind === "file") {
+    await services.durableFileSystem.removeFile(nextPath);
+  } else if (next.kind !== "missing") {
+    if (blockUnknown) throw corrupt(nextPath);
+    return;
+  }
+  if ((await services.durableFileSystem.list(root)).length !== 0) {
+    if (blockUnknown) throw corrupt(root);
+    return;
+  }
+  await services.durableFileSystem.removeEmptyDirectory(root);
+  await services.durableFileSystem.syncDirectory(transactionsRoot);
 }
 
 async function assertExistingRoot(
@@ -738,6 +1129,10 @@ function assertManifestSemantics(
 function isManagedDestination(path: string): boolean {
   const segments = path.split("/");
   return (
+    path !== "" &&
+    !path.includes("\\") &&
+    !/^[A-Za-z]:/u.test(path) &&
+    !hasControlCharacter(path) &&
     segments.length >= 2 &&
     segments[0] === ".brain" &&
     segments[1]?.toLowerCase() !== "transactions" &&
@@ -746,6 +1141,16 @@ function isManagedDestination(path: string): boolean {
     ) &&
     segments.join("/") === path
   );
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function observeTransaction(
@@ -868,9 +1273,11 @@ function createManifest(
       : { ...value, stagedPath: `${root}/${value.stagedPath}` };
   });
   const first = persisted[0];
+  /* v8 ignore start -- the synchronous preflight rejects empty plans */
   if (first === undefined) {
     throw new TransactionFailure("runtime.state_corrupt", []);
   }
+  /* v8 ignore stop */
   const manifest: TransactionManifestV1 = {
     contractVersion,
     stateContract,
@@ -921,7 +1328,7 @@ function validateProgress(
 async function persistProgress(
   progress: TransactionProgressV1,
   services: TransactionServices,
-): Promise<TransactionProgressV1["directorySync"]> {
+): Promise<"supported" | "unsupported"> {
   const validated = validateProgress(progress, services);
   const root = transactionRoot(validated.transactionId);
   const nextPath = `${root}/progress.next`;
@@ -970,7 +1377,7 @@ async function cleanupTransaction(
   manifest: TransactionManifestV1,
   currentDirectorySync: TransactionProgressV1["directorySync"],
   services: TransactionServices,
-): Promise<TransactionProgressV1["directorySync"]> {
+): Promise<"supported" | "unsupported"> {
   const root = transactionRoot(manifest.transactionId);
   const stagingRoot = `${root}/staging`;
   for (const operation of manifest.operations) {
@@ -1013,6 +1420,37 @@ async function cleanupTransaction(
     currentDirectorySync,
     await services.durableFileSystem.syncDirectory(root),
   );
+}
+
+async function persistTerminalDirectorySync(
+  progress: TransactionProgressV1,
+  observed: "supported" | "unsupported",
+  services: TransactionServices,
+): Promise<TransactionProgressV1> {
+  const directorySync = mergeDirectorySync(progress.directorySync, observed);
+  if (directorySync === progress.directorySync) {
+    return { ...progress, directorySync };
+  }
+  const next = validateProgress(
+    {
+      ...progress,
+      directorySync,
+      updatedAt: services.clock.now().toISOString(),
+    },
+    services,
+  );
+  const persistedDirectorySync = await persistProgress(next, services);
+  return { ...next, directorySync: persistedDirectorySync };
+}
+
+async function finalizeTerminalProgress(
+  progress: TransactionProgressV1,
+  services: TransactionServices,
+): Promise<TransactionProgressV1> {
+  const observed = await services.durableFileSystem.syncDirectory(
+    transactionRoot(progress.transactionId),
+  );
+  return persistTerminalDirectorySync(progress, observed, services);
 }
 
 async function recoverWithoutManifest(
@@ -1082,7 +1520,12 @@ async function recoverWithoutManifest(
     progress.directorySync,
     await services.durableFileSystem.syncDirectory(root),
   );
-  return receiptFromProgress({ ...progress, directorySync });
+  progress = await persistTerminalDirectorySync(
+    progress,
+    directorySync,
+    services,
+  );
+  return receiptFromProgress(progress);
 }
 
 async function hasCleanupEntries(
@@ -1154,6 +1597,29 @@ async function assertPublishable(
       "runtime.revision_conflict",
       evidence(operation.path),
     );
+  }
+}
+
+async function assertExecutionPayload(
+  operation: Extract<ManagedOperation, { readonly kind: "write_file" }>,
+  root: string,
+  services: TransactionServices,
+): Promise<void> {
+  const path = stagedPayloadPath(root, operation);
+  const observed = await observeFingerprint(path, services);
+  if (!sameFingerprint(observed, operation.result)) throw corrupt(path);
+}
+
+async function assertPersistedPayload(
+  operation: Extract<
+    TransactionManifestV1["operations"][number],
+    { readonly kind: "write_file" }
+  >,
+  services: TransactionServices,
+): Promise<void> {
+  const observed = await observeFingerprint(operation.stagedPath, services);
+  if (!sameFingerprint(observed, operation.result)) {
+    throw corrupt(operation.stagedPath);
   }
 }
 
@@ -1245,7 +1711,7 @@ function parentOf(path: string): string {
 function mergeDirectorySync(
   current: TransactionProgressV1["directorySync"],
   observed: "supported" | "unsupported",
-): TransactionProgressV1["directorySync"] {
+): "supported" | "unsupported" {
   return current === "unsupported" || observed === "unsupported"
     ? "unsupported"
     : "supported";

--- a/packages/runtime/src/domain/result/index.ts
+++ b/packages/runtime/src/domain/result/index.ts
@@ -1,10 +1,16 @@
 export {
   internalFailure,
   resultFor,
+  transactionFailureResult,
   usageFailure,
   USAGE_WHY,
 } from "./result.js";
-export type { EvidenceRef, Result, ResultDetail } from "./result.js";
+export type {
+  EvidenceRef,
+  Result,
+  ResultDetail,
+  TransactionFailureDetail,
+} from "./result.js";
 export {
   ResultContractError,
   validatePublicText,

--- a/packages/runtime/src/domain/result/result.ts
+++ b/packages/runtime/src/domain/result/result.ts
@@ -27,6 +27,16 @@ export interface ResultDetail {
   readonly stateChanged?: boolean;
 }
 
+export interface TransactionFailureDetail {
+  readonly reasonCode:
+    | "guard.outside_allow"
+    | "runtime.internal_failure"
+    | "runtime.recovery_required"
+    | "runtime.revision_conflict"
+    | "runtime.state_corrupt";
+  readonly evidence: readonly EvidenceRef[];
+}
+
 /** Build a result whose policy comes from the reason it reports. */
 export function resultFor(code: string, detail: ResultDetail = {}): Result {
   const policy = reasonPolicy(code);
@@ -62,5 +72,19 @@ export function internalFailure(): Result {
   return resultFor("runtime.internal_failure", {
     summary: "The operation stopped after an unexpected internal failure.",
     why: ["A sanitized runtime boundary caught an unexpected condition."],
+  });
+}
+
+/** Render a typed transaction failure through the universal reason catalog. */
+export function transactionFailureResult(
+  error: TransactionFailureDetail,
+): Result {
+  if (error.reasonCode === "runtime.internal_failure") {
+    return internalFailure();
+  }
+  return resultFor(error.reasonCode, {
+    evidence: error.evidence,
+    summary: "The managed transaction did not reach a committed state.",
+    why: ["The durable transaction boundary reported a blocked condition."],
   });
 }

--- a/packages/runtime/src/domain/result/validate.ts
+++ b/packages/runtime/src/domain/result/validate.ts
@@ -203,12 +203,8 @@ export function validateResult(result: Result): Result {
       );
     }
   }
-  if (result.stateChanged !== policy.stateChanged) {
-    throw new ResultContractError(
-      result.stateChanged
-        ? "result makes a false state mutation claim"
-        : "result state mutation claim conflicts with its reason",
-    );
+  if (result.stateChanged && !policy.stateChanged) {
+    throw new ResultContractError("result makes a false state mutation claim");
   }
   if (policy.evidence === "required" && result.evidence.length === 0) {
     throw new ResultContractError("required evidence is absent");

--- a/packages/runtime/src/domain/schema/contracts.ts
+++ b/packages/runtime/src/domain/schema/contracts.ts
@@ -7,6 +7,8 @@ import type {
   MigrationV1,
   ProjectConfigV1,
   SnapshotV1,
+  TransactionManifestV1,
+  TransactionProgressV1,
 } from "@mestre-yoda/contracts";
 
 export interface ContractValues {
@@ -18,6 +20,8 @@ export interface ContractValues {
   readonly "state.migration": MigrationV1;
   readonly "state.project-config": ProjectConfigV1;
   readonly "state.snapshot": SnapshotV1;
+  readonly "state.transaction-manifest": TransactionManifestV1;
+  readonly "state.transaction-progress": TransactionProgressV1;
 }
 
 export type ContractId = keyof ContractValues;

--- a/packages/runtime/src/domain/transactions/index.ts
+++ b/packages/runtime/src/domain/transactions/index.ts
@@ -8,5 +8,9 @@ export {
   type ManagedWriteFileOperation,
   type PathFingerprint,
   type PersistedManagedOperation,
+  type RecoveryDecision,
+  type TransactionObservation,
 } from "./model.js";
 export { normalizeManagedMutationPlan } from "./normalize.js";
+export { decideRecovery } from "./recovery.js";
+export { assertPhaseTransition } from "./transition.js";

--- a/packages/runtime/src/domain/transactions/index.ts
+++ b/packages/runtime/src/domain/transactions/index.ts
@@ -1,0 +1,12 @@
+export {
+  TransactionPolicyError,
+  toPersistedManagedOperation,
+  type ManagedCreateDirectoryOperation,
+  type ManagedDeleteFileOperation,
+  type ManagedMutationPlan,
+  type ManagedOperation,
+  type ManagedWriteFileOperation,
+  type PathFingerprint,
+  type PersistedManagedOperation,
+} from "./model.js";
+export { normalizeManagedMutationPlan } from "./normalize.js";

--- a/packages/runtime/src/domain/transactions/model.ts
+++ b/packages/runtime/src/domain/transactions/model.ts
@@ -44,6 +44,24 @@ export interface ManagedMutationPlan {
   readonly operations: readonly ManagedOperation[];
 }
 
+export interface TransactionObservation {
+  readonly destinations: ReadonlyMap<string, PathFingerprint>;
+  readonly stagedPayloads: ReadonlyMap<string, PathFingerprint>;
+}
+
+export type RecoveryDecision =
+  | { readonly kind: "abort" }
+  | { readonly kind: "record_published"; readonly operationId: string }
+  | { readonly kind: "publish"; readonly operationId: string }
+  | { readonly kind: "commit" }
+  | { readonly kind: "cleanup"; readonly terminal: "committed" | "aborted" }
+  | { readonly kind: "complete"; readonly terminal: "committed" | "aborted" }
+  | {
+      readonly kind: "blocked";
+      readonly reasonCode: "runtime.state_corrupt";
+      readonly operationId: string | null;
+    };
+
 export class TransactionPolicyError extends Error {
   public constructor(
     public readonly reasonCode: "guard.outside_allow" | "runtime.state_corrupt",

--- a/packages/runtime/src/domain/transactions/model.ts
+++ b/packages/runtime/src/domain/transactions/model.ts
@@ -1,0 +1,68 @@
+export type PathFingerprint =
+  | { readonly kind: "missing" }
+  | { readonly kind: "directory" }
+  | {
+      readonly kind: "file";
+      readonly size: number;
+      readonly sha256: string;
+    };
+
+interface ManagedOperationBase {
+  readonly operationId: string;
+  readonly path: string;
+  readonly expected: PathFingerprint;
+  readonly result: PathFingerprint;
+}
+
+export interface ManagedCreateDirectoryOperation extends ManagedOperationBase {
+  readonly kind: "create_directory";
+  readonly stagedPath: null;
+}
+
+export interface ManagedWriteFileOperation extends ManagedOperationBase {
+  readonly kind: "write_file";
+  readonly stagedPath: string;
+  readonly content: string;
+}
+
+export interface ManagedDeleteFileOperation extends ManagedOperationBase {
+  readonly kind: "delete_file";
+  readonly stagedPath: null;
+}
+
+export type ManagedOperation =
+  | ManagedCreateDirectoryOperation
+  | ManagedWriteFileOperation
+  | ManagedDeleteFileOperation;
+
+export type PersistedManagedOperation =
+  | ManagedCreateDirectoryOperation
+  | Omit<ManagedWriteFileOperation, "content">
+  | ManagedDeleteFileOperation;
+
+export interface ManagedMutationPlan {
+  readonly operations: readonly ManagedOperation[];
+}
+
+export class TransactionPolicyError extends Error {
+  public constructor(
+    public readonly reasonCode: "guard.outside_allow" | "runtime.state_corrupt",
+  ) {
+    super("Managed mutation plan is invalid");
+    this.name = "TransactionPolicyError";
+  }
+}
+
+export function toPersistedManagedOperation(
+  operation: ManagedOperation,
+): PersistedManagedOperation {
+  if (operation.kind !== "write_file") return operation;
+  return {
+    operationId: operation.operationId,
+    kind: operation.kind,
+    path: operation.path,
+    expected: operation.expected,
+    result: operation.result,
+    stagedPath: operation.stagedPath,
+  };
+}

--- a/packages/runtime/src/domain/transactions/normalize.ts
+++ b/packages/runtime/src/domain/transactions/normalize.ts
@@ -50,7 +50,7 @@ export function normalizeManagedMutationPlan(
   const observedState = new Map(observations);
   const drafts: DraftOperation[] = [];
   for (const effect of managedEffects) {
-    if (effect.kind === "write_file") {
+    if (effect.kind === "create_directory" || effect.kind === "write_file") {
       synthesizeMissingParents(effect.path, observedState, drafts);
     }
 

--- a/packages/runtime/src/domain/transactions/normalize.ts
+++ b/packages/runtime/src/domain/transactions/normalize.ts
@@ -1,0 +1,296 @@
+import type { Effect, EffectPlan } from "../effects.js";
+import {
+  TransactionPolicyError,
+  type ManagedMutationPlan,
+  type ManagedOperation,
+  type PathFingerprint,
+} from "./model.js";
+
+type ManagedEffect = Extract<
+  Effect,
+  { readonly kind: "create_directory" | "delete_file" | "write_file" }
+>;
+
+type DraftOperation =
+  | {
+      readonly kind: "create_directory";
+      readonly path: string;
+      readonly expected: PathFingerprint;
+      readonly result: PathFingerprint;
+    }
+  | {
+      readonly kind: "write_file";
+      readonly path: string;
+      readonly expected: PathFingerprint;
+      readonly result: PathFingerprint;
+      readonly content: string;
+    }
+  | {
+      readonly kind: "delete_file";
+      readonly path: string;
+      readonly expected: PathFingerprint;
+      readonly result: PathFingerprint;
+    };
+
+const missing = { kind: "missing" } as const;
+const directory = { kind: "directory" } as const;
+const driveQualified = /^[A-Za-z]:/u;
+const utf8 = new TextEncoder();
+
+export function normalizeManagedMutationPlan(
+  effectPlan: EffectPlan,
+  observations: ReadonlyMap<string, PathFingerprint>,
+  sha256: (text: string) => string,
+):
+  | { readonly kind: "noop" }
+  | { readonly kind: "ready"; readonly plan: ManagedMutationPlan } {
+  const managedEffects = selectManagedEffects(effectPlan);
+  validateRelationships(managedEffects);
+
+  const observedState = new Map(observations);
+  const drafts: DraftOperation[] = [];
+  for (const effect of managedEffects) {
+    if (effect.kind === "write_file") {
+      synthesizeMissingParents(effect.path, observedState, drafts);
+    }
+
+    const expected = observedState.get(effect.path) ?? missing;
+    switch (effect.kind) {
+      case "create_directory":
+        normalizeCreateDirectory(effect.path, expected, observedState, drafts);
+        break;
+      case "write_file":
+        normalizeWriteFile(effect, expected, sha256, observedState, drafts);
+        break;
+      case "delete_file":
+        normalizeDeleteFile(effect.path, expected, observedState, drafts);
+        break;
+    }
+  }
+
+  if (drafts.length === 0) return { kind: "noop" };
+  return {
+    kind: "ready",
+    plan: { operations: drafts.map(finalizeOperation) },
+  };
+}
+
+function selectManagedEffects(effectPlan: EffectPlan): ManagedEffect[] {
+  const effects: ManagedEffect[] = [];
+  for (const effect of effectPlan.effects) {
+    switch (effect.kind) {
+      case "emit":
+        break;
+      case "append_event":
+        throw invalidState();
+      case "create_directory":
+      case "delete_file":
+      case "write_file":
+        assertManagedPath(effect.path);
+        effects.push(effect);
+        break;
+    }
+  }
+  return effects;
+}
+
+function assertManagedPath(path: string): void {
+  if (
+    path === "" ||
+    path.includes("\\") ||
+    hasControlCharacter(path) ||
+    driveQualified.test(path)
+  ) {
+    throw outsideAllowlist();
+  }
+
+  const segments = path.split("/");
+  if (
+    segments.length < 2 ||
+    segments[0] !== ".brain" ||
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    ) ||
+    segments.join("/") !== path ||
+    segments[1]?.toLowerCase() === "transactions"
+  ) {
+    throw outsideAllowlist();
+  }
+}
+
+function validateRelationships(effects: readonly ManagedEffect[]): void {
+  const spellings = new Map<string, string>();
+  for (const effect of effects) {
+    for (const path of managedPathPrefixes(effect.path)) {
+      const key = collisionKey(path);
+      const prior = spellings.get(key);
+      if (prior !== undefined && prior !== path) throw invalidState();
+      spellings.set(key, path);
+    }
+  }
+
+  for (let leftIndex = 0; leftIndex < effects.length; leftIndex += 1) {
+    const left = effects[leftIndex];
+    if (left === undefined) continue;
+    for (
+      let rightIndex = leftIndex + 1;
+      rightIndex < effects.length;
+      rightIndex += 1
+    ) {
+      const right = effects[rightIndex];
+      if (right === undefined) continue;
+      const leftPath = collisionKey(left.path);
+      const rightPath = collisionKey(right.path);
+      if (leftPath === rightPath) throw invalidState();
+
+      if (isParent(leftPath, rightPath)) {
+        if (left.kind !== "create_directory") throw invalidState();
+        continue;
+      }
+      if (isParent(rightPath, leftPath)) {
+        throw invalidState();
+      }
+    }
+  }
+}
+
+function managedPathPrefixes(path: string): string[] {
+  const segments = path.split("/");
+  const prefixes: string[] = [];
+  for (let length = 2; length <= segments.length; length += 1) {
+    prefixes.push(segments.slice(0, length).join("/"));
+  }
+  return prefixes;
+}
+
+function synthesizeMissingParents(
+  path: string,
+  observedState: Map<string, PathFingerprint>,
+  drafts: DraftOperation[],
+): void {
+  const segments = path.split("/");
+  for (let length = 2; length < segments.length; length += 1) {
+    const parent = segments.slice(0, length).join("/");
+    const expected = observedState.get(parent) ?? missing;
+    if (expected.kind === "file") throw invalidState();
+    if (expected.kind === "directory") continue;
+    drafts.push({
+      kind: "create_directory",
+      path: parent,
+      expected,
+      result: directory,
+    });
+    observedState.set(parent, directory);
+  }
+}
+
+function normalizeCreateDirectory(
+  path: string,
+  expected: PathFingerprint,
+  observedState: Map<string, PathFingerprint>,
+  drafts: DraftOperation[],
+): void {
+  if (expected.kind === "file") throw invalidState();
+  if (expected.kind === "missing") {
+    drafts.push({
+      kind: "create_directory",
+      path,
+      expected,
+      result: directory,
+    });
+  }
+  observedState.set(path, directory);
+}
+
+function normalizeWriteFile(
+  effect: Extract<ManagedEffect, { readonly kind: "write_file" }>,
+  expected: PathFingerprint,
+  sha256: (text: string) => string,
+  observedState: Map<string, PathFingerprint>,
+  drafts: DraftOperation[],
+): void {
+  if (expected.kind === "directory") throw invalidState();
+  const result = {
+    kind: "file",
+    size: utf8.encode(effect.content).byteLength,
+    sha256: sha256(effect.content),
+  } as const;
+  if (!sameFingerprint(expected, result)) {
+    drafts.push({
+      kind: "write_file",
+      path: effect.path,
+      expected,
+      result,
+      content: effect.content,
+    });
+  }
+  observedState.set(effect.path, result);
+}
+
+function normalizeDeleteFile(
+  path: string,
+  expected: PathFingerprint,
+  observedState: Map<string, PathFingerprint>,
+  drafts: DraftOperation[],
+): void {
+  if (expected.kind === "directory") throw invalidState();
+  if (expected.kind === "file") {
+    drafts.push({
+      kind: "delete_file",
+      path,
+      expected,
+      result: missing,
+    });
+  }
+  observedState.set(path, missing);
+}
+
+function finalizeOperation(
+  draft: DraftOperation,
+  index: number,
+): ManagedOperation {
+  const operationId = `operation-${String(index + 1).padStart(4, "0")}`;
+  if (draft.kind === "write_file") {
+    return {
+      ...draft,
+      operationId,
+      stagedPath: `staging/${operationId}.payload`,
+    };
+  }
+  return { ...draft, operationId, stagedPath: null };
+}
+
+function sameFingerprint(
+  left: PathFingerprint,
+  right: PathFingerprint,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind !== "file" || right.kind !== "file") return true;
+  return left.size === right.size && left.sha256 === right.sha256;
+}
+
+function collisionKey(path: string): string {
+  return path.toLowerCase();
+}
+
+function hasControlCharacter(path: string): boolean {
+  for (const character of path) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isParent(parent: string, child: string): boolean {
+  return child.startsWith(`${parent}/`);
+}
+
+function outsideAllowlist(): TransactionPolicyError {
+  return new TransactionPolicyError("guard.outside_allow");
+}
+
+function invalidState(): TransactionPolicyError {
+  return new TransactionPolicyError("runtime.state_corrupt");
+}

--- a/packages/runtime/src/domain/transactions/normalize.ts
+++ b/packages/runtime/src/domain/transactions/normalize.ts
@@ -129,16 +129,8 @@ function validateRelationships(effects: readonly ManagedEffect[]): void {
     }
   }
 
-  for (let leftIndex = 0; leftIndex < effects.length; leftIndex += 1) {
-    const left = effects[leftIndex];
-    if (left === undefined) continue;
-    for (
-      let rightIndex = leftIndex + 1;
-      rightIndex < effects.length;
-      rightIndex += 1
-    ) {
-      const right = effects[rightIndex];
-      if (right === undefined) continue;
+  for (const [leftIndex, left] of effects.entries()) {
+    for (const right of effects.slice(leftIndex + 1)) {
       const leftPath = collisionKey(left.path);
       const rightPath = collisionKey(right.path);
       if (leftPath === rightPath) throw invalidState();
@@ -262,11 +254,13 @@ function finalizeOperation(
 
 function sameFingerprint(
   left: PathFingerprint,
-  right: PathFingerprint,
+  right: Extract<PathFingerprint, { readonly kind: "file" }>,
 ): boolean {
-  if (left.kind !== right.kind) return false;
-  if (left.kind !== "file" || right.kind !== "file") return true;
-  return left.size === right.size && left.sha256 === right.sha256;
+  return (
+    left.kind === "file" &&
+    left.size === right.size &&
+    left.sha256 === right.sha256
+  );
 }
 
 function collisionKey(path: string): string {

--- a/packages/runtime/src/domain/transactions/recovery.ts
+++ b/packages/runtime/src/domain/transactions/recovery.ts
@@ -45,7 +45,12 @@ export function decideRecovery(
     );
     if (destinationFailure !== null) return blocked(destinationFailure);
 
-    if (progress.phase === "prepared") {
+    if (progress.phase === "begun") {
+      const payloads = inspectPayloads(manifest, observation);
+      if (payloads.blockedOperationId !== null) {
+        return blocked(payloads.blockedOperationId);
+      }
+    } else {
       const payloadFailure = findUnpublishablePayload(manifest, observation);
       if (payloadFailure !== null) return blocked(payloadFailure);
     }

--- a/packages/runtime/src/domain/transactions/recovery.ts
+++ b/packages/runtime/src/domain/transactions/recovery.ts
@@ -1,0 +1,311 @@
+import type {
+  TransactionManifestV1,
+  TransactionProgressV1,
+} from "@mestre-yoda/contracts";
+import type {
+  PathFingerprint,
+  RecoveryDecision,
+  TransactionObservation,
+} from "./model.js";
+
+const missing = { kind: "missing" } as const;
+
+export function decideRecovery(
+  manifest: TransactionManifestV1,
+  progress: TransactionProgressV1,
+  observation: TransactionObservation,
+): RecoveryDecision {
+  if (!hasValidIdentity(manifest, progress)) return blocked(null);
+
+  const manifestFailure = findManifestFailure(manifest);
+  if (manifestFailure !== undefined) return blocked(manifestFailure);
+
+  const operationIds = manifest.operations.map(
+    (operation) => operation.operationId,
+  );
+  if (!hasValidPublishedPrefix(progress, operationIds)) {
+    return blocked(null);
+  }
+  if (hasUnexpectedStagedContent(manifest, observation)) return blocked(null);
+
+  if (progress.phase === "aborted") {
+    const payloads = inspectPayloads(manifest, observation);
+    if (payloads.blockedOperationId !== null) {
+      return blocked(payloads.blockedOperationId);
+    }
+    return payloads.hasPayload
+      ? { kind: "cleanup", terminal: "aborted" }
+      : { kind: "complete", terminal: "aborted" };
+  }
+
+  if (progress.phase === "begun" || progress.phase === "prepared") {
+    const destinationFailure = findUnexpectedPrepublicationDestination(
+      manifest,
+      observation,
+    );
+    if (destinationFailure !== null) return blocked(destinationFailure);
+
+    if (progress.phase === "prepared") {
+      const payloadFailure = findUnpublishablePayload(manifest, observation);
+      if (payloadFailure !== null) return blocked(payloadFailure);
+    }
+    return { kind: "abort" };
+  }
+
+  if (progress.phase === "committed") {
+    const destinationFailure = findNonResultDestination(manifest, observation);
+    if (destinationFailure !== null) return blocked(destinationFailure);
+
+    const payloads = inspectPayloads(manifest, observation);
+    if (payloads.blockedOperationId !== null) {
+      return blocked(payloads.blockedOperationId);
+    }
+    return payloads.hasPayload
+      ? { kind: "cleanup", terminal: "committed" }
+      : { kind: "complete", terminal: "committed" };
+  }
+
+  return decidePublishing(manifest, progress, observation);
+}
+
+function findManifestFailure(
+  manifest: TransactionManifestV1,
+): string | null | undefined {
+  const operationIds = new Set<string>();
+  const paths = new Set<string>();
+  const stagedPaths = new Set<string>();
+  for (const operation of manifest.operations) {
+    if (
+      operationIds.has(operation.operationId) ||
+      paths.has(operation.path) ||
+      (operation.stagedPath !== null && stagedPaths.has(operation.stagedPath))
+    ) {
+      return null;
+    }
+    operationIds.add(operation.operationId);
+    paths.add(operation.path);
+    if (operation.stagedPath !== null) stagedPaths.add(operation.stagedPath);
+    if (sameFingerprint(operation.expected, operation.result)) {
+      return operation.operationId;
+    }
+  }
+  return undefined;
+}
+
+function hasUnexpectedStagedContent(
+  manifest: TransactionManifestV1,
+  observation: TransactionObservation,
+): boolean {
+  const knownPaths = new Set(
+    manifest.operations.flatMap((operation) =>
+      operation.stagedPath === null ? [] : [operation.stagedPath],
+    ),
+  );
+  for (const [path, fingerprint] of observation.stagedPayloads) {
+    if (!knownPaths.has(path) && fingerprint.kind !== "missing") return true;
+  }
+  return false;
+}
+
+function decidePublishing(
+  manifest: TransactionManifestV1,
+  progress: TransactionProgressV1,
+  observation: TransactionObservation,
+): RecoveryDecision {
+  let observedResultCount = 0;
+  let foundPrecondition = false;
+
+  for (const operation of manifest.operations) {
+    const destination = observation.destinations.get(operation.path);
+    if (destination === undefined) return blocked(operation.operationId);
+
+    if (sameFingerprint(destination, operation.result)) {
+      if (foundPrecondition) return blocked(operation.operationId);
+      observedResultCount += 1;
+      continue;
+    }
+    if (sameFingerprint(destination, operation.expected)) {
+      foundPrecondition = true;
+      continue;
+    }
+    return blocked(operation.operationId);
+  }
+
+  for (const operationId of progress.publishedOperationIds.slice(
+    observedResultCount,
+  )) {
+    return blocked(operationId);
+  }
+
+  const payloadFailure = findPublishingPayloadFailure(
+    manifest,
+    observation,
+    observedResultCount,
+  );
+  if (payloadFailure !== null) return blocked(payloadFailure);
+
+  for (const operation of manifest.operations.slice(
+    progress.publishedOperationIds.length,
+    observedResultCount,
+  )) {
+    return { kind: "record_published", operationId: operation.operationId };
+  }
+
+  const next = manifest.operations[observedResultCount];
+  return next === undefined
+    ? { kind: "commit" }
+    : { kind: "publish", operationId: next.operationId };
+}
+
+function hasValidIdentity(
+  manifest: TransactionManifestV1,
+  progress: TransactionProgressV1,
+): boolean {
+  if (
+    manifest.transactionId !== progress.transactionId ||
+    manifest.createdAt !== progress.createdAt
+  ) {
+    return false;
+  }
+
+  switch (progress.phase) {
+    case "begun":
+      return true;
+    case "aborted":
+      return (
+        progress.manifestDigest === null ||
+        progress.recoveryToken === progress.manifestDigest
+      );
+    case "prepared":
+    case "publishing":
+    case "committed":
+      return progress.recoveryToken === progress.manifestDigest;
+  }
+}
+
+function hasValidPublishedPrefix(
+  progress: TransactionProgressV1,
+  operationIds: readonly string[],
+): boolean {
+  const published = progress.publishedOperationIds;
+  if (new Set(published).size !== published.length) return false;
+  if (
+    published.some((operationId, index) => operationId !== operationIds[index])
+  ) {
+    return false;
+  }
+
+  if (
+    progress.phase === "begun" ||
+    progress.phase === "prepared" ||
+    progress.phase === "aborted"
+  ) {
+    return published.length === 0;
+  }
+  if (progress.phase === "committed") {
+    return published.length === operationIds.length;
+  }
+  return published.length <= operationIds.length;
+}
+
+function findUnexpectedPrepublicationDestination(
+  manifest: TransactionManifestV1,
+  observation: TransactionObservation,
+): string | null {
+  for (const operation of manifest.operations) {
+    const destination = observation.destinations.get(operation.path);
+    if (
+      destination === undefined ||
+      !sameFingerprint(destination, operation.expected)
+    ) {
+      return operation.operationId;
+    }
+  }
+  return null;
+}
+
+function findNonResultDestination(
+  manifest: TransactionManifestV1,
+  observation: TransactionObservation,
+): string | null {
+  for (const operation of manifest.operations) {
+    const destination = observation.destinations.get(operation.path);
+    if (
+      destination === undefined ||
+      !sameFingerprint(destination, operation.result)
+    ) {
+      return operation.operationId;
+    }
+  }
+  return null;
+}
+
+function findUnpublishablePayload(
+  manifest: TransactionManifestV1,
+  observation: TransactionObservation,
+): string | null {
+  for (const operation of manifest.operations) {
+    if (operation.stagedPath === null) continue;
+    const payload = observation.stagedPayloads.get(operation.stagedPath);
+    if (payload === undefined || !sameFingerprint(payload, operation.result)) {
+      return operation.operationId;
+    }
+  }
+  return null;
+}
+
+function findPublishingPayloadFailure(
+  manifest: TransactionManifestV1,
+  observation: TransactionObservation,
+  observedResultCount: number,
+): string | null {
+  for (const [index, operation] of manifest.operations.entries()) {
+    if (operation.stagedPath === null) continue;
+    const payload =
+      observation.stagedPayloads.get(operation.stagedPath) ?? missing;
+    if (index < observedResultCount) {
+      if (payload.kind !== "missing") return operation.operationId;
+    } else if (!sameFingerprint(payload, operation.result)) {
+      return operation.operationId;
+    }
+  }
+  return null;
+}
+
+function inspectPayloads(
+  manifest: TransactionManifestV1,
+  observation: TransactionObservation,
+): {
+  readonly blockedOperationId: string | null;
+  readonly hasPayload: boolean;
+} {
+  let hasPayload = false;
+  for (const operation of manifest.operations) {
+    if (operation.stagedPath === null) continue;
+    const payload =
+      observation.stagedPayloads.get(operation.stagedPath) ?? missing;
+    if (payload.kind === "missing") continue;
+    if (!sameFingerprint(payload, operation.result)) {
+      return { blockedOperationId: operation.operationId, hasPayload: false };
+    }
+    hasPayload = true;
+  }
+  return { blockedOperationId: null, hasPayload };
+}
+
+function sameFingerprint(
+  left: PathFingerprint,
+  right: PathFingerprint,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind !== "file" || right.kind !== "file") return true;
+  return left.size === right.size && left.sha256 === right.sha256;
+}
+
+function blocked(operationId: string | null): RecoveryDecision {
+  return {
+    kind: "blocked",
+    reasonCode: "runtime.state_corrupt",
+    operationId,
+  };
+}

--- a/packages/runtime/src/domain/transactions/transition.ts
+++ b/packages/runtime/src/domain/transactions/transition.ts
@@ -1,0 +1,18 @@
+import type { TransactionProgressV1 } from "@mestre-yoda/contracts";
+
+const legalTransitions = new Set<string>([
+  "begun:prepared",
+  "begun:aborted",
+  "prepared:publishing",
+  "prepared:aborted",
+  "publishing:committed",
+]);
+
+export function assertPhaseTransition(
+  from: TransactionProgressV1["phase"],
+  to: TransactionProgressV1["phase"],
+): void {
+  if (!legalTransitions.has(`${from}:${to}`)) {
+    throw new Error("Illegal transaction phase transition");
+  }
+}

--- a/packages/runtime/src/infra/digests.ts
+++ b/packages/runtime/src/infra/digests.ts
@@ -1,0 +1,10 @@
+import { createHash } from "node:crypto";
+
+import type { Digests } from "../ports/index.js";
+
+/** Production SHA-256 over the exact UTF-8 bytes represented by the text. */
+export function sha256Digests(): Digests {
+  return {
+    sha256: (text) => createHash("sha256").update(text, "utf8").digest("hex"),
+  };
+}

--- a/packages/runtime/src/infra/fake/index.ts
+++ b/packages/runtime/src/infra/fake/index.ts
@@ -19,6 +19,14 @@ import type {
   Workspace,
 } from "../../ports/index.js";
 
+export {
+  memoryTransactionStorage,
+  type DurableOperation,
+  type FailureRule,
+  type MemoryTransactionStorage,
+  type MemoryTransactionStorageSeed,
+} from "./transactions.js";
+
 /**
  * Deterministic in-memory port implementations.
  *

--- a/packages/runtime/src/infra/fake/transactions.ts
+++ b/packages/runtime/src/infra/fake/transactions.ts
@@ -1,0 +1,433 @@
+import type {
+  Digests,
+  DurableEntry,
+  DurableFileSystem,
+  FileStat,
+  FileSystem,
+} from "../../ports/index.js";
+import { sha256Digests } from "../digests.js";
+
+export type DurableOperation =
+  | "inspect"
+  | "list"
+  | "read_text"
+  | "create_directory"
+  | "create_directory_exclusive"
+  | "open_file"
+  | "write_file"
+  | "sync_file"
+  | "close_file"
+  | "replace_file"
+  | "remove_file"
+  | "remove_empty_directory"
+  | "sync_directory";
+
+export interface FailureRule {
+  readonly operation: DurableOperation;
+  readonly timing: "before" | "after";
+  readonly occurrence: number;
+  readonly fault?: "generic" | "permission" | "disk_full";
+}
+
+export interface MemoryTransactionStorageSeed {
+  readonly files?: Readonly<Record<string, string>>;
+  readonly directories?: readonly string[];
+}
+
+export interface MemoryTransactionStorage {
+  readonly fileSystem: FileSystem;
+  readonly durableFileSystem: DurableFileSystem;
+  readonly digests: Digests;
+  readonly fail: (rule: FailureRule) => void;
+  readonly calls: () => readonly DurableOperation[];
+  readonly snapshot: () => {
+    readonly files: Readonly<Record<string, string>>;
+    readonly directories: readonly string[];
+  };
+}
+
+function normalizePath(path: string): string {
+  const reject = (): never => {
+    throw new Error("Runtime path escapes the project");
+  };
+  let hasControlCharacter = false;
+  for (const character of path) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) hasControlCharacter = true;
+  }
+  if (
+    path.length === 0 ||
+    path.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/u.test(path) ||
+    path.includes("\\") ||
+    hasControlCharacter
+  ) {
+    reject();
+  }
+  const segments: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") reject();
+    segments.push(segment);
+  }
+  if (segments.length === 0) reject();
+  return segments.join("/");
+}
+
+function deferred<T>(body: () => T): Promise<T> {
+  return Promise.resolve().then(body);
+}
+
+function parentOf(path: string): string | null {
+  const separator = path.lastIndexOf("/");
+  return separator === -1 ? null : path.slice(0, separator);
+}
+
+function immediateEntries(
+  path: string | null,
+  files: ReadonlyMap<string, string>,
+  directories: ReadonlySet<string>,
+): readonly string[] {
+  const prefix = path === null ? "" : `${path}/`;
+  const names = new Set<string>();
+  for (const candidate of [...files.keys(), ...directories]) {
+    if (!candidate.startsWith(prefix)) continue;
+    const rest = candidate.slice(prefix.length);
+    if (rest.length === 0) continue;
+    names.add(rest.split("/")[0] ?? rest);
+  }
+  return [...names].sort((left, right) => left.localeCompare(right, "en-US"));
+}
+
+/** One deterministic model shared by the ordinary and durable filesystem views. */
+export function memoryTransactionStorage(
+  seed: MemoryTransactionStorageSeed = {},
+): MemoryTransactionStorage {
+  const files = new Map<string, string>();
+  const directories = new Set<string>();
+  const trace: DurableOperation[] = [];
+  const occurrences = new Map<DurableOperation, number>();
+  const rules: FailureRule[] = [];
+  const digests = sha256Digests();
+
+  function addParents(path: string): void {
+    let parent = parentOf(path);
+    const parents: string[] = [];
+    while (parent !== null) {
+      parents.push(parent);
+      parent = parentOf(parent);
+    }
+    for (const candidate of parents.reverse()) directories.add(candidate);
+  }
+
+  for (const path of seed.directories ?? []) {
+    const normalized = normalizePath(path);
+    addParents(normalized);
+    directories.add(normalized);
+  }
+  for (const [path, content] of Object.entries(seed.files ?? {})) {
+    const normalized = normalizePath(path);
+    addParents(normalized);
+    if (directories.has(normalized)) {
+      throw new Error("Memory transaction seed has conflicting entries");
+    }
+    files.set(normalized, content);
+  }
+  for (const path of files.keys()) {
+    let parent = parentOf(path);
+    while (parent !== null) {
+      if (files.has(parent)) {
+        throw new Error("Memory transaction seed has conflicting entries");
+      }
+      parent = parentOf(parent);
+    }
+  }
+
+  function injectedFailure(rule: FailureRule): Error {
+    const fault = rule.fault ?? "generic";
+    const suffix = fault === "generic" ? "" : ` (${fault})`;
+    return new Error(`Injected durable filesystem failure${suffix}`);
+  }
+
+  function matchingRule(
+    operation: DurableOperation,
+    timing: FailureRule["timing"],
+    occurrence: number,
+  ): FailureRule | undefined {
+    return rules.find(
+      (rule) =>
+        rule.operation === operation &&
+        rule.timing === timing &&
+        rule.occurrence === occurrence,
+    );
+  }
+
+  function boundary<T>(operation: DurableOperation, effect: () => T): T {
+    trace.push(operation);
+    const occurrence = (occurrences.get(operation) ?? 0) + 1;
+    occurrences.set(operation, occurrence);
+    const before = matchingRule(operation, "before", occurrence);
+    if (before !== undefined) throw injectedFailure(before);
+    const result = effect();
+    const after = matchingRule(operation, "after", occurrence);
+    if (after !== undefined) throw injectedFailure(after);
+    return result;
+  }
+
+  function requireParentDirectory(path: string): void {
+    const parent = parentOf(path);
+    if (parent !== null && !directories.has(parent)) {
+      throw new Error(`Memory transaction storage has no parent for ${path}`);
+    }
+  }
+
+  function requireDirectory(path: string): void {
+    if (!directories.has(path)) {
+      throw new Error(`Memory transaction storage has no directory at ${path}`);
+    }
+  }
+
+  function requireFile(path: string): string {
+    const content = files.get(path);
+    if (content === undefined) {
+      throw new Error(`Memory transaction storage has no file at ${path}`);
+    }
+    return content;
+  }
+
+  const fileSystem: FileSystem = {
+    read: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        return requireFile(normalized);
+      }),
+    write: (path, content) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        if (directories.has(normalized)) {
+          throw new Error(
+            `Memory transaction storage has a directory at ${normalized}`,
+          );
+        }
+        addParents(normalized);
+        files.set(normalized, content);
+      }),
+    remove: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        files.delete(normalized);
+        directories.delete(normalized);
+        for (const candidate of [...files.keys()]) {
+          if (candidate.startsWith(`${normalized}/`)) files.delete(candidate);
+        }
+        for (const candidate of [...directories]) {
+          if (candidate.startsWith(`${normalized}/`)) {
+            directories.delete(candidate);
+          }
+        }
+      }),
+    makeDirectory: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        if (files.has(normalized)) {
+          throw new Error(
+            `Memory transaction storage has a file at ${normalized}`,
+          );
+        }
+        addParents(normalized);
+        directories.add(normalized);
+      }),
+    list: (path) =>
+      deferred(() => {
+        const normalized = path === "." ? null : normalizePath(path);
+        if (
+          normalized !== null &&
+          !directories.has(normalized) &&
+          !files.has(normalized)
+        ) {
+          return [];
+        }
+        if (normalized !== null && files.has(normalized)) return [];
+        return immediateEntries(normalized, files, directories);
+      }),
+    stat: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        const content = files.get(normalized);
+        if (content !== undefined) {
+          return {
+            kind: "file",
+            size: Buffer.byteLength(content, "utf8"),
+          } satisfies FileStat;
+        }
+        return directories.has(normalized)
+          ? ({ kind: "directory", size: 0 } satisfies FileStat)
+          : null;
+      }),
+  };
+
+  const durableFileSystem: DurableFileSystem = {
+    inspect: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        return boundary("inspect", (): DurableEntry => {
+          const content = files.get(normalized);
+          if (content !== undefined) {
+            return {
+              kind: "file",
+              size: Buffer.byteLength(content, "utf8"),
+              sha256: digests.sha256(content),
+            };
+          }
+          return directories.has(normalized)
+            ? { kind: "directory" }
+            : { kind: "missing" };
+        });
+      }),
+    list: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        return boundary("list", () => {
+          requireDirectory(normalized);
+          return immediateEntries(normalized, files, directories);
+        });
+      }),
+    readText: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        return boundary("read_text", () => requireFile(normalized));
+      }),
+    createDirectory: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        boundary("create_directory", () => {
+          requireParentDirectory(normalized);
+          if (files.has(normalized)) {
+            throw new Error(
+              `Memory transaction storage has a file at ${normalized}`,
+            );
+          }
+          directories.add(normalized);
+        });
+      }),
+    createDirectoryExclusive: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        boundary("create_directory_exclusive", () => {
+          requireParentDirectory(normalized);
+          if (files.has(normalized) || directories.has(normalized)) {
+            throw new Error(
+              `Memory transaction storage already has an entry at ${normalized}`,
+            );
+          }
+          directories.add(normalized);
+        });
+      }),
+    writeSynced: async (path, content) => {
+      const normalized = normalizePath(path);
+      const handle = { opened: false };
+      try {
+        await deferred(() => {
+          boundary("open_file", () => {
+            requireParentDirectory(normalized);
+            if (files.has(normalized) || directories.has(normalized)) {
+              throw new Error(
+                `Memory transaction storage already has an entry at ${normalized}`,
+              );
+            }
+            files.set(normalized, "");
+            handle.opened = true;
+          });
+        });
+        await deferred(() => {
+          boundary("write_file", () => {
+            requireFile(normalized);
+            files.set(normalized, content);
+          });
+        });
+        await deferred(() => {
+          boundary("sync_file", () => {
+            requireFile(normalized);
+          });
+        });
+      } finally {
+        if (handle.opened) {
+          await deferred(() => {
+            boundary("close_file", () => {
+              requireFile(normalized);
+            });
+          });
+        }
+      }
+    },
+    replaceFile: (stagedPath, targetPath) =>
+      deferred(() => {
+        const normalizedStaged = normalizePath(stagedPath);
+        const normalizedTarget = normalizePath(targetPath);
+        boundary("replace_file", () => {
+          requireParentDirectory(normalizedStaged);
+          requireParentDirectory(normalizedTarget);
+          const content = requireFile(normalizedStaged);
+          if (directories.has(normalizedTarget)) {
+            throw new Error(
+              `Memory transaction storage has a directory at ${normalizedTarget}`,
+            );
+          }
+          files.delete(normalizedStaged);
+          files.set(normalizedTarget, content);
+        });
+      }),
+    removeFile: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        boundary("remove_file", () => {
+          requireFile(normalized);
+          files.delete(normalized);
+        });
+      }),
+    removeEmptyDirectory: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        boundary("remove_empty_directory", () => {
+          requireDirectory(normalized);
+          if (immediateEntries(normalized, files, directories).length !== 0) {
+            throw new Error(
+              `Memory transaction storage directory is not empty at ${normalized}`,
+            );
+          }
+          directories.delete(normalized);
+        });
+      }),
+    syncDirectory: (path) =>
+      deferred(() => {
+        const normalized = normalizePath(path);
+        return boundary("sync_directory", () => {
+          requireDirectory(normalized);
+          return "supported" as const;
+        });
+      }),
+  };
+
+  return {
+    fileSystem,
+    durableFileSystem,
+    digests,
+    fail: (rule) => {
+      if (!Number.isInteger(rule.occurrence) || rule.occurrence <= 0) {
+        throw new Error("Failure occurrence must be a positive integer");
+      }
+      rules.push({ ...rule });
+    },
+    calls: () => [...trace],
+    snapshot: () => ({
+      files: Object.fromEntries(
+        [...files.entries()].sort(([left], [right]) =>
+          left.localeCompare(right, "en-US"),
+        ),
+      ),
+      directories: [...directories].sort((left, right) =>
+        left.localeCompare(right, "en-US"),
+      ),
+    }),
+  };
+}

--- a/packages/runtime/src/infra/fake/transactions.ts
+++ b/packages/runtime/src/infra/fake/transactions.ts
@@ -397,9 +397,9 @@ export function memoryTransactionStorage(
       }),
     syncDirectory: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = path === "." ? null : normalizePath(path);
         return boundary("sync_directory", () => {
-          requireDirectory(normalized);
+          if (normalized !== null) requireDirectory(normalized);
           return "supported" as const;
         });
       }),

--- a/packages/runtime/src/infra/fake/transactions.ts
+++ b/packages/runtime/src/infra/fake/transactions.ts
@@ -52,7 +52,7 @@ function normalizePath(path: string): string {
   };
   let hasControlCharacter = false;
   for (const character of path) {
-    const code = character.codePointAt(0) ?? 0;
+    const code = character.charCodeAt(0);
     if (code < 0x20 || code === 0x7f) hasControlCharacter = true;
   }
   if (
@@ -93,8 +93,8 @@ function immediateEntries(
   for (const candidate of [...files.keys(), ...directories]) {
     if (!candidate.startsWith(prefix)) continue;
     const rest = candidate.slice(prefix.length);
-    if (rest.length === 0) continue;
-    names.add(rest.split("/")[0] ?? rest);
+    const separator = rest.indexOf("/");
+    names.add(separator === -1 ? rest : rest.slice(0, separator));
   }
   return [...names].sort((left, right) => left.localeCompare(right, "en-US"));
 }
@@ -117,6 +117,13 @@ export function memoryTransactionStorage(
       parents.push(parent);
       parent = parentOf(parent);
     }
+    for (const candidate of parents) {
+      if (files.has(candidate)) {
+        throw new Error(
+          `Memory transaction storage has a file ancestor at ${candidate}`,
+        );
+      }
+    }
     for (const candidate of parents.reverse()) directories.add(candidate);
   }
 
@@ -133,16 +140,6 @@ export function memoryTransactionStorage(
     }
     files.set(normalized, content);
   }
-  for (const path of files.keys()) {
-    let parent = parentOf(path);
-    while (parent !== null) {
-      if (files.has(parent)) {
-        throw new Error("Memory transaction seed has conflicting entries");
-      }
-      parent = parentOf(parent);
-    }
-  }
-
   function injectedFailure(rule: FailureRule): Error {
     const fault = rule.fault ?? "generic";
     const suffix = fault === "generic" ? "" : ` (${fault})`;

--- a/packages/runtime/src/infra/fake/transactions.ts
+++ b/packages/runtime/src/infra/fake/transactions.ts
@@ -46,10 +46,11 @@ export interface MemoryTransactionStorage {
   };
 }
 
+function rejectPath(): never {
+  throw new Error("Runtime path escapes the project");
+}
+
 function normalizePath(path: string): string {
-  const reject = (): never => {
-    throw new Error("Runtime path escapes the project");
-  };
   let hasControlCharacter = false;
   for (const character of path) {
     const code = character.charCodeAt(0);
@@ -62,16 +63,32 @@ function normalizePath(path: string): string {
     path.includes("\\") ||
     hasControlCharacter
   ) {
-    reject();
+    rejectPath();
   }
   const segments: string[] = [];
   for (const segment of path.split("/")) {
     if (segment === "" || segment === ".") continue;
-    if (segment === "..") reject();
+    if (segment === "..") rejectPath();
     segments.push(segment);
   }
-  if (segments.length === 0) reject();
+  if (segments.length === 0) rejectPath();
   return segments.join("/");
+}
+
+function normalizeDurablePath(path: string): string {
+  const normalized = normalizePath(path);
+  const segments = path.split("/");
+  if (
+    segments[0] !== ".brain" ||
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    ) ||
+    segments.join("/") !== path ||
+    normalized !== path
+  ) {
+    rejectPath();
+  }
+  return normalized;
 }
 
 function deferred<T>(body: () => T): Promise<T> {
@@ -266,7 +283,7 @@ export function memoryTransactionStorage(
   const durableFileSystem: DurableFileSystem = {
     inspect: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = normalizeDurablePath(path);
         return boundary("inspect", (): DurableEntry => {
           const content = files.get(normalized);
           if (content !== undefined) {
@@ -283,7 +300,7 @@ export function memoryTransactionStorage(
       }),
     list: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = normalizeDurablePath(path);
         return boundary("list", () => {
           requireDirectory(normalized);
           return immediateEntries(normalized, files, directories);
@@ -291,12 +308,12 @@ export function memoryTransactionStorage(
       }),
     readText: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = normalizeDurablePath(path);
         return boundary("read_text", () => requireFile(normalized));
       }),
     createDirectory: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = normalizeDurablePath(path);
         boundary("create_directory", () => {
           requireParentDirectory(normalized);
           if (files.has(normalized)) {
@@ -309,7 +326,7 @@ export function memoryTransactionStorage(
       }),
     createDirectoryExclusive: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = normalizeDurablePath(path);
         boundary("create_directory_exclusive", () => {
           requireParentDirectory(normalized);
           if (files.has(normalized) || directories.has(normalized)) {
@@ -321,7 +338,7 @@ export function memoryTransactionStorage(
         });
       }),
     writeSynced: async (path, content) => {
-      const normalized = normalizePath(path);
+      const normalized = normalizeDurablePath(path);
       const handle = { opened: false };
       try {
         await deferred(() => {
@@ -359,8 +376,8 @@ export function memoryTransactionStorage(
     },
     replaceFile: (stagedPath, targetPath) =>
       deferred(() => {
-        const normalizedStaged = normalizePath(stagedPath);
-        const normalizedTarget = normalizePath(targetPath);
+        const normalizedStaged = normalizeDurablePath(stagedPath);
+        const normalizedTarget = normalizeDurablePath(targetPath);
         boundary("replace_file", () => {
           requireParentDirectory(normalizedStaged);
           requireParentDirectory(normalizedTarget);
@@ -376,7 +393,7 @@ export function memoryTransactionStorage(
       }),
     removeFile: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = normalizeDurablePath(path);
         boundary("remove_file", () => {
           requireFile(normalized);
           files.delete(normalized);
@@ -384,7 +401,7 @@ export function memoryTransactionStorage(
       }),
     removeEmptyDirectory: (path) =>
       deferred(() => {
-        const normalized = normalizePath(path);
+        const normalized = normalizeDurablePath(path);
         boundary("remove_empty_directory", () => {
           requireDirectory(normalized);
           if (immediateEntries(normalized, files, directories).length !== 0) {
@@ -397,7 +414,7 @@ export function memoryTransactionStorage(
       }),
     syncDirectory: (path) =>
       deferred(() => {
-        const normalized = path === "." ? null : normalizePath(path);
+        const normalized = path === "." ? null : normalizeDurablePath(path);
         return boundary("sync_directory", () => {
           if (normalized !== null) requireDirectory(normalized);
           return "supported" as const;

--- a/packages/runtime/src/infra/fake/transactions.ts
+++ b/packages/runtime/src/infra/fake/transactions.ts
@@ -39,6 +39,7 @@ export interface MemoryTransactionStorage {
   readonly durableFileSystem: DurableFileSystem;
   readonly digests: Digests;
   readonly fail: (rule: FailureRule) => void;
+  readonly failureHits: () => readonly FailureRule[];
   readonly calls: () => readonly DurableOperation[];
   readonly snapshot: () => {
     readonly files: Readonly<Record<string, string>>;
@@ -125,6 +126,7 @@ export function memoryTransactionStorage(
   const trace: DurableOperation[] = [];
   const occurrences = new Map<DurableOperation, number>();
   const rules: FailureRule[] = [];
+  const failureHits: FailureRule[] = [];
   const digests = sha256Digests();
 
   function addParents(path: string): void {
@@ -181,10 +183,16 @@ export function memoryTransactionStorage(
     const occurrence = (occurrences.get(operation) ?? 0) + 1;
     occurrences.set(operation, occurrence);
     const before = matchingRule(operation, "before", occurrence);
-    if (before !== undefined) throw injectedFailure(before);
+    if (before !== undefined) {
+      failureHits.push({ ...before });
+      throw injectedFailure(before);
+    }
     const result = effect();
     const after = matchingRule(operation, "after", occurrence);
-    if (after !== undefined) throw injectedFailure(after);
+    if (after !== undefined) {
+      failureHits.push({ ...after });
+      throw injectedFailure(after);
+    }
     return result;
   }
 
@@ -432,6 +440,7 @@ export function memoryTransactionStorage(
       }
       rules.push({ ...rule });
     },
+    failureHits: () => failureHits.map((rule) => ({ ...rule })),
     calls: () => [...trace],
     snapshot: () => ({
       files: Object.fromEntries(

--- a/packages/runtime/src/infra/node/index.ts
+++ b/packages/runtime/src/infra/node/index.ts
@@ -27,6 +27,13 @@ import type {
 } from "../../ports/index.js";
 
 export { nodeWorkspace } from "./workspace.js";
+export { sha256Digests } from "../digests.js";
+export {
+  nodeDurableFileSystem,
+  type DurableOperation,
+  type DurableOperationEvent,
+  type DurableOperationObserver,
+} from "./transactions.js";
 
 const run = promisify(execFile);
 

--- a/packages/runtime/src/infra/node/transactions.ts
+++ b/packages/runtime/src/infra/node/transactions.ts
@@ -1,0 +1,380 @@
+import { constants, type Stats } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  realpath,
+  rename,
+  rmdir,
+  stat,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+import type { DurableEntry, DurableFileSystem } from "../../ports/index.js";
+
+export type DurableOperation =
+  | "inspect"
+  | "list"
+  | "read_text"
+  | "create_directory"
+  | "create_directory_exclusive"
+  | "open_file"
+  | "write_file"
+  | "sync_file"
+  | "close_file"
+  | "replace_file"
+  | "remove_file"
+  | "remove_empty_directory"
+  | "sync_directory";
+
+export interface DurableOperationEvent {
+  readonly operation: DurableOperation;
+  readonly timing: "before" | "after";
+}
+
+export type DurableOperationObserver = (
+  event: DurableOperationEvent,
+) => Promise<void>;
+
+interface NormalizedPath {
+  readonly path: string;
+  readonly segments: readonly string[];
+}
+
+interface ScannedPath {
+  readonly absolute: string;
+  readonly details: Stats | null;
+  readonly missingAt: number | null;
+  readonly normalized: NormalizedPath;
+}
+
+function pathRefusal(): never {
+  throw new Error("Runtime path escapes the project");
+}
+
+function normalizeManagedPath(path: string): NormalizedPath {
+  let hasControlCharacter = false;
+  for (const character of path) {
+    const code = character.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f) hasControlCharacter = true;
+  }
+  if (
+    path.length === 0 ||
+    path.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/u.test(path) ||
+    path.includes("\\") ||
+    hasControlCharacter
+  ) {
+    return pathRefusal();
+  }
+
+  const segments: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") return pathRefusal();
+    segments.push(segment);
+  }
+  if (segments.length === 0 || segments[0] !== ".brain") {
+    return pathRefusal();
+  }
+  return { path: segments.join("/"), segments };
+}
+
+function missing(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+async function optionalLstat(path: string): Promise<Stats | null> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (missing(error)) return null;
+    throw error;
+  }
+}
+
+function foldCase(name: string): string {
+  return name.toLocaleLowerCase("en-US");
+}
+
+async function refuseCaseCollision(
+  parent: string,
+  requested: string,
+): Promise<void> {
+  const folded = foldCase(requested);
+  const entries = await readdir(parent);
+  if (
+    entries.some((entry) => entry !== requested && foldCase(entry) === folded)
+  ) {
+    throw new Error("Runtime durable path has a case collision");
+  }
+}
+
+function assertDirectory(details: Stats | null): asserts details is Stats {
+  if (details?.isDirectory() !== true) {
+    throw new Error("Runtime durable path is not a directory");
+  }
+}
+
+function assertRegularFile(details: Stats | null): asserts details is Stats {
+  if (details?.isFile() !== true) {
+    throw new Error("Runtime durable path is not a regular file");
+  }
+}
+
+function durableNonFileEntry(details: Stats | null): DurableEntry {
+  if (details === null) return { kind: "missing" };
+  if (details.isSymbolicLink()) return { kind: "symlink" };
+  if (details.isDirectory()) return { kind: "directory" };
+  return { kind: "special" };
+}
+
+function parentPath(path: NormalizedPath): string {
+  return path.segments.slice(0, -1).join("/");
+}
+
+/**
+ * Directory handles are unsupported on Windows, where Node reports EISDIR.
+ * No other error is downgraded; extending this table requires a contract test.
+ */
+export function isUnsupportedDirectorySyncError(
+  error: unknown,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return (
+    platform === "win32" &&
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === "EISDIR"
+  );
+}
+
+/** Real durable primitives rooted at a canonical project directory. */
+export function nodeDurableFileSystem(
+  root: string,
+  observer?: DurableOperationObserver,
+): DurableFileSystem {
+  const canonicalRoot = realpath(root).then(async (path) => {
+    const details = await stat(path);
+    if (!details.isDirectory()) {
+      throw new Error("Runtime project root is not a directory");
+    }
+    return path;
+  });
+
+  async function notify(
+    operation: DurableOperation,
+    timing: DurableOperationEvent["timing"],
+  ): Promise<void> {
+    await observer?.({ operation, timing });
+  }
+
+  async function boundary<T>(
+    operation: DurableOperation,
+    effect: () => Promise<T>,
+  ): Promise<T> {
+    await notify(operation, "before");
+    const result = await effect();
+    await notify(operation, "after");
+    return result;
+  }
+
+  async function scan(path: string): Promise<ScannedPath> {
+    const normalized = normalizeManagedPath(path);
+    const project = await canonicalRoot;
+    let absolute = project;
+
+    for (const [index, segment] of normalized.segments.entries()) {
+      await refuseCaseCollision(absolute, segment);
+      absolute = join(absolute, segment);
+      const details = await optionalLstat(absolute);
+      if (details === null) {
+        return { absolute, details, missingAt: index, normalized };
+      }
+      const final = index === normalized.segments.length - 1;
+      if (details.isSymbolicLink() && !final) {
+        throw new Error("Runtime durable path contains a symlink");
+      }
+      if (!final && !details.isDirectory()) {
+        throw new Error("Runtime durable path ancestor is not a directory");
+      }
+    }
+
+    return {
+      absolute,
+      details: await optionalLstat(absolute),
+      missingAt: null,
+      normalized,
+    };
+  }
+
+  function requireDeclaredParent(observation: ScannedPath): void {
+    if (
+      observation.missingAt !== null &&
+      observation.missingAt < observation.normalized.segments.length - 1
+    ) {
+      throw new Error("Runtime durable path has no declared parent directory");
+    }
+  }
+
+  async function requireDirectory(path: string): Promise<ScannedPath> {
+    const observation = await scan(path);
+    assertDirectory(observation.details);
+    return observation;
+  }
+
+  async function readRegularBytes(path: string): Promise<Buffer> {
+    const observation = await scan(path);
+    assertRegularFile(observation.details);
+    const handle = await open(
+      observation.absolute,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+    try {
+      const before = await handle.stat();
+      assertRegularFile(before);
+      return await handle.readFile();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async function closeObserved(handle: FileHandle): Promise<void> {
+    await boundary("close_file", async () => handle.close());
+  }
+
+  return {
+    inspect: (path) =>
+      boundary("inspect", async () => {
+        const observation = await scan(path);
+        if (observation.details?.isFile() !== true) {
+          return durableNonFileEntry(observation.details);
+        }
+        const bytes = await readRegularBytes(observation.normalized.path);
+        return {
+          kind: "file",
+          size: bytes.byteLength,
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+        };
+      }),
+    list: (path) =>
+      boundary("list", async () => {
+        const observation = await requireDirectory(path);
+        const entries = await readdir(observation.absolute);
+        return entries.sort((left, right) =>
+          left.localeCompare(right, "en-US"),
+        );
+      }),
+    readText: (path) =>
+      boundary("read_text", async () =>
+        (await readRegularBytes(path)).toString("utf8"),
+      ),
+    createDirectory: (path) =>
+      boundary("create_directory", async () => {
+        const observation = await scan(path);
+        requireDeclaredParent(observation);
+        if (observation.details === null) {
+          await mkdir(observation.absolute);
+          return;
+        }
+        assertDirectory(observation.details);
+      }),
+    createDirectoryExclusive: (path) =>
+      boundary("create_directory_exclusive", async () => {
+        const observation = await scan(path);
+        requireDeclaredParent(observation);
+        if (observation.details !== null) {
+          throw new Error("Runtime durable path already has an entry");
+        }
+        await mkdir(observation.absolute);
+      }),
+    writeSynced: async (path, content) => {
+      const opened: { handle: FileHandle | null } = { handle: null };
+      try {
+        await boundary("open_file", async () => {
+          const observation = await scan(path);
+          requireDeclaredParent(observation);
+          if (observation.details !== null) {
+            throw new Error("Runtime durable path already has an entry");
+          }
+          opened.handle = await open(
+            observation.absolute,
+            constants.O_WRONLY |
+              constants.O_CREAT |
+              constants.O_EXCL |
+              constants.O_NOFOLLOW,
+            0o600,
+          );
+        });
+        await boundary("write_file", async () => {
+          await opened.handle?.writeFile(content, "utf8");
+        });
+        await boundary("sync_file", async () => {
+          await opened.handle?.sync();
+        });
+      } finally {
+        if (opened.handle !== null) await closeObserved(opened.handle);
+      }
+    },
+    replaceFile: (stagedPath, targetPath) =>
+      boundary("replace_file", async () => {
+        const staged = await scan(stagedPath);
+        const target = await scan(targetPath);
+        assertRegularFile(staged.details);
+        requireDeclaredParent(target);
+        if (target.details !== null && !target.details.isFile()) {
+          throw new Error("Runtime durable path is not a regular file");
+        }
+        await requireDirectory(parentPath(staged.normalized));
+        await requireDirectory(parentPath(target.normalized));
+        await rename(staged.absolute, target.absolute);
+      }),
+    removeFile: (path) =>
+      boundary("remove_file", async () => {
+        const observation = await scan(path);
+        assertRegularFile(observation.details);
+        await unlink(observation.absolute);
+      }),
+    removeEmptyDirectory: (path) =>
+      boundary("remove_empty_directory", async () => {
+        const observation = await requireDirectory(path);
+        await rmdir(observation.absolute);
+      }),
+    syncDirectory: (path) =>
+      boundary("sync_directory", async () => {
+        const absolute =
+          path === "."
+            ? await canonicalRoot
+            : (await requireDirectory(path)).absolute;
+        let handle: FileHandle | null = null;
+        try {
+          handle = await open(
+            absolute,
+            constants.O_RDONLY | constants.O_DIRECTORY,
+          );
+          await handle.sync();
+          return "supported" as const;
+        } catch (error) {
+          /* v8 ignore start -- Windows-only syscall outcome; the exact
+           * error/platform classifier is covered independently. */
+          if (isUnsupportedDirectorySyncError(error)) {
+            return "unsupported" as const;
+          }
+          throw error;
+          /* v8 ignore stop */
+        } finally {
+          await handle?.close();
+        }
+      }),
+  };
+}

--- a/packages/runtime/src/infra/node/transactions.ts
+++ b/packages/runtime/src/infra/node/transactions.ts
@@ -7,7 +7,6 @@ import {
   realpath,
   rename,
   rmdir,
-  stat,
   unlink,
   type FileHandle,
 } from "node:fs/promises";
@@ -52,6 +51,12 @@ interface ScannedPath {
   readonly normalized: NormalizedPath;
 }
 
+interface CanonicalRootIdentity {
+  readonly path: string;
+  readonly device: number;
+  readonly inode: number;
+}
+
 function pathRefusal(): never {
   throw new Error("Runtime path escapes the project");
 }
@@ -72,16 +77,18 @@ function normalizeManagedPath(path: string): NormalizedPath {
     return pathRefusal();
   }
 
-  const segments: string[] = [];
-  for (const segment of path.split("/")) {
-    if (segment === "" || segment === ".") continue;
-    if (segment === "..") return pathRefusal();
-    segments.push(segment);
-  }
-  if (segments.length === 0 || segments[0] !== ".brain") {
+  const segments = path.split("/");
+  if (
+    segments.length === 0 ||
+    segments[0] !== ".brain" ||
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    ) ||
+    segments.join("/") !== path
+  ) {
     return pathRefusal();
   }
-  return { path: segments.join("/"), segments };
+  return { path, segments };
 }
 
 function missing(error: unknown): boolean {
@@ -164,13 +171,40 @@ export function nodeDurableFileSystem(
   root: string,
   observer?: DurableOperationObserver,
 ): DurableFileSystem {
-  const canonicalRoot = realpath(root).then(async (path) => {
-    const details = await stat(path);
-    if (!details.isDirectory()) {
-      throw new Error("Runtime project root is not a directory");
+  const canonicalRoot = realpath(root).then(
+    async (path): Promise<CanonicalRootIdentity> => {
+      const details = await lstat(path);
+      if (details.isSymbolicLink() || !details.isDirectory()) {
+        throw new Error("Runtime project root is not a directory");
+      }
+      return { path, device: details.dev, inode: details.ino };
+    },
+  );
+
+  async function validatedRoot(): Promise<string> {
+    const expected = await canonicalRoot;
+    try {
+      const details = await lstat(expected.path);
+      if (
+        details.isSymbolicLink() ||
+        !details.isDirectory() ||
+        details.dev !== expected.device ||
+        details.ino !== expected.inode ||
+        (await realpath(expected.path)) !== expected.path
+      ) {
+        throw new Error("Runtime project root changed");
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === "Runtime project root changed"
+      ) {
+        throw error;
+      }
+      throw new Error("Runtime project root changed", { cause: error });
     }
-    return path;
-  });
+    return expected.path;
+  }
 
   async function notify(
     operation: DurableOperation,
@@ -191,7 +225,7 @@ export function nodeDurableFileSystem(
 
   async function scan(path: string): Promise<ScannedPath> {
     const normalized = normalizeManagedPath(path);
-    const project = await canonicalRoot;
+    const project = await validatedRoot();
     let absolute = project;
 
     for (const [index, segment] of normalized.segments.entries()) {
@@ -354,7 +388,7 @@ export function nodeDurableFileSystem(
       boundary("sync_directory", async () => {
         const absolute =
           path === "."
-            ? await canonicalRoot
+            ? await validatedRoot()
             : (await requireDirectory(path)).absolute;
         let handle: FileHandle | null = null;
         try {

--- a/packages/runtime/src/infra/schema/catalog.ts
+++ b/packages/runtime/src/infra/schema/catalog.ts
@@ -8,6 +8,8 @@ import lockSchema from "../../../../../schemas/state/lock.v1.schema.json" with {
 import migrationSchema from "../../../../../schemas/state/migration.v1.schema.json" with { type: "json" };
 import projectConfigSchema from "../../../../../schemas/state/project-config.v1.schema.json" with { type: "json" };
 import snapshotSchema from "../../../../../schemas/state/snapshot.v1.schema.json" with { type: "json" };
+import transactionManifestSchema from "../../../../../schemas/state/transaction-manifest.v1.schema.json" with { type: "json" };
+import transactionProgressSchema from "../../../../../schemas/state/transaction-progress.v1.schema.json" with { type: "json" };
 
 import type { EmbeddedSchemaEntry } from "./types.js";
 
@@ -82,6 +84,20 @@ export const EMBEDDED_SCHEMA_CATALOG: readonly EmbeddedSchemaEntry[] =
       path: "schemas/state/snapshot.v1.schema.json",
       schema: snapshotSchema,
     },
+    {
+      id: "state.transaction-manifest",
+      family: "state",
+      version: "1.0.0",
+      path: "schemas/state/transaction-manifest.v1.schema.json",
+      schema: transactionManifestSchema,
+    },
+    {
+      id: "state.transaction-progress",
+      family: "state",
+      version: "1.0.0",
+      path: "schemas/state/transaction-progress.v1.schema.json",
+      schema: transactionProgressSchema,
+    },
   ] as const satisfies readonly EmbeddedSchemaEntry[]);
 
 export const EMBEDDED_SCHEMA_DEPENDENCIES = deepFreeze([
@@ -99,6 +115,10 @@ const EXPECTED_SCHEMA_IDS = {
   "state.project-config":
     "https://mestre-yoda.dev/schemas/state/project-config/v1",
   "state.snapshot": "https://mestre-yoda.dev/schemas/state/snapshot/v1",
+  "state.transaction-manifest":
+    "https://mestre-yoda.dev/schemas/state/transaction-manifest/v1",
+  "state.transaction-progress":
+    "https://mestre-yoda.dev/schemas/state/transaction-progress/v1",
 } as const satisfies Readonly<Record<EmbeddedSchemaEntry["id"], string>>;
 
 function failCatalogIntegrity(): never {

--- a/packages/runtime/src/ports/index.ts
+++ b/packages/runtime/src/ports/index.ts
@@ -3,6 +3,12 @@ import type {
   WorktreeLocation,
 } from "../domain/project/observation.js";
 
+export type {
+  Digests,
+  DurableEntry,
+  DurableFileSystem,
+} from "./transactions.js";
+
 /**
  * Injected effect boundaries.
  *

--- a/packages/runtime/src/ports/index.ts
+++ b/packages/runtime/src/ports/index.ts
@@ -2,6 +2,7 @@ import type {
   DirectoryProbe,
   WorktreeLocation,
 } from "../domain/project/observation.js";
+import type { Digests, DurableFileSystem } from "./transactions.js";
 
 export type {
   Digests,
@@ -95,6 +96,8 @@ export interface Workspace {
 export interface RuntimePorts {
   readonly clock: Clock;
   readonly ids: Ids;
+  readonly digests: Digests;
+  readonly durableFileSystem: DurableFileSystem;
   readonly fileSystem: FileSystem;
   readonly git: Git;
   readonly locks: Locks;

--- a/packages/runtime/src/ports/transactions.ts
+++ b/packages/runtime/src/ports/transactions.ts
@@ -1,0 +1,28 @@
+/** No-follow metadata observed for a project-relative durable path. */
+export type DurableEntry =
+  | { readonly kind: "missing" }
+  | { readonly kind: "directory" | "symlink" | "special" }
+  | {
+      readonly kind: "file";
+      readonly size: number;
+      readonly sha256: string;
+    };
+
+/** Narrow durable filesystem primitives driven one boundary at a time. */
+export interface DurableFileSystem {
+  inspect(path: string): Promise<DurableEntry>;
+  list(path: string): Promise<readonly string[]>;
+  readText(path: string): Promise<string>;
+  createDirectory(path: string): Promise<void>;
+  createDirectoryExclusive(path: string): Promise<void>;
+  writeSynced(path: string, content: string): Promise<void>;
+  replaceFile(stagedPath: string, targetPath: string): Promise<void>;
+  removeFile(path: string): Promise<void>;
+  removeEmptyDirectory(path: string): Promise<void>;
+  syncDirectory(path: string): Promise<"supported" | "unsupported">;
+}
+
+/** Injected content digests, so domain code never imports a crypto runtime. */
+export interface Digests {
+  sha256(text: string): string;
+}

--- a/packages/runtime/src/ports/transactions.ts
+++ b/packages/runtime/src/ports/transactions.ts
@@ -19,6 +19,7 @@ export interface DurableFileSystem {
   replaceFile(stagedPath: string, targetPath: string): Promise<void>;
   removeFile(path: string): Promise<void>;
   removeEmptyDirectory(path: string): Promise<void>;
+  /** This method alone accepts the exact `.` project-root sentinel. */
   syncDirectory(path: string): Promise<"supported" | "unsupported">;
 }
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -24,7 +24,9 @@ The state family contains:
 - [`approval.v1.schema.json`](state/approval.v1.schema.json);
 - [`evidence.v1.schema.json`](state/evidence.v1.schema.json);
 - [`lock.v1.schema.json`](state/lock.v1.schema.json);
-- [`migration.v1.schema.json`](state/migration.v1.schema.json).
+- [`migration.v1.schema.json`](state/migration.v1.schema.json);
+- [`transaction-manifest.v1.schema.json`](state/transaction-manifest.v1.schema.json);
+- [`transaction-progress.v1.schema.json`](state/transaction-progress.v1.schema.json).
 
 The host family contains
 [`adapter-message.v1.schema.json`](host/adapter-message.v1.schema.json), and the

--- a/schemas/contracts/contract-manifest.v1.schema.json
+++ b/schemas/contracts/contract-manifest.v1.schema.json
@@ -40,8 +40,8 @@
     },
     "schemas": {
       "type": "array",
-      "minItems": 8,
-      "maxItems": 8,
+      "minItems": 10,
+      "maxItems": 10,
       "uniqueItems": true,
       "items": { "$ref": "#/$defs/schemaEntry" }
     },

--- a/schemas/state/transaction-manifest.v1.schema.json
+++ b/schemas/state/transaction-manifest.v1.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mestre-yoda.dev/schemas/state/transaction-manifest/v1",
+  "title": "Mestre Yoda transaction manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contractVersion",
+    "stateContract",
+    "transactionId",
+    "planDigest",
+    "createdAt",
+    "operations"
+  ],
+  "properties": {
+    "contractVersion": { "const": "1.0.0" },
+    "stateContract": { "const": "1.0.0" },
+    "transactionId": { "$ref": "#/$defs/id" },
+    "planDigest": { "$ref": "#/$defs/sha256" },
+    "createdAt": { "$ref": "#/$defs/timestamp" },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/operation" }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$"
+    },
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$"
+    },
+    "reference": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))(?![a-z][a-z0-9+.-]*://)[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "safeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "fingerprint": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": { "kind": { "const": "missing" } }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": { "kind": { "const": "directory" } }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "size", "sha256"],
+          "properties": {
+            "kind": { "const": "file" },
+            "size": { "$ref": "#/$defs/safeInteger" },
+            "sha256": { "$ref": "#/$defs/sha256" }
+          }
+        }
+      ]
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operationId",
+        "kind",
+        "path",
+        "expected",
+        "result",
+        "stagedPath"
+      ],
+      "properties": {
+        "operationId": { "$ref": "#/$defs/id" },
+        "kind": {
+          "enum": ["create_directory", "write_file", "delete_file"]
+        },
+        "path": { "$ref": "#/$defs/reference" },
+        "expected": { "$ref": "#/$defs/fingerprint" },
+        "result": { "$ref": "#/$defs/fingerprint" },
+        "stagedPath": {
+          "oneOf": [{ "$ref": "#/$defs/reference" }, { "type": "null" }]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "kind": { "const": "write_file" } },
+            "required": ["kind"]
+          },
+          "then": {
+            "properties": {
+              "stagedPath": { "$ref": "#/$defs/reference" }
+            }
+          },
+          "else": {
+            "properties": { "stagedPath": { "type": "null" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/state/transaction-progress.v1.schema.json
+++ b/schemas/state/transaction-progress.v1.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mestre-yoda.dev/schemas/state/transaction-progress/v1",
+  "title": "Mestre Yoda transaction progress v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contractVersion",
+    "stateContract",
+    "transactionId",
+    "manifestDigest",
+    "recoveryToken",
+    "phase",
+    "publishedOperationIds",
+    "fileSync",
+    "directorySync",
+    "createdAt",
+    "updatedAt"
+  ],
+  "properties": {
+    "contractVersion": { "const": "1.0.0" },
+    "stateContract": { "const": "1.0.0" },
+    "transactionId": { "$ref": "#/$defs/id" },
+    "manifestDigest": {
+      "oneOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }]
+    },
+    "recoveryToken": { "$ref": "#/$defs/sha256" },
+    "phase": {
+      "enum": ["begun", "prepared", "publishing", "committed", "aborted"]
+    },
+    "publishedOperationIds": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/id" },
+      "uniqueItems": true
+    },
+    "fileSync": { "const": "required" },
+    "directorySync": {
+      "enum": ["not_attempted", "supported", "unsupported"]
+    },
+    "createdAt": { "$ref": "#/$defs/timestamp" },
+    "updatedAt": { "$ref": "#/$defs/timestamp" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "phase": { "enum": ["prepared", "publishing", "committed"] }
+        },
+        "required": ["phase"]
+      },
+      "then": {
+        "properties": { "manifestDigest": { "$ref": "#/$defs/sha256" } }
+      }
+    },
+    {
+      "if": {
+        "properties": { "phase": { "const": "begun" } },
+        "required": ["phase"]
+      },
+      "then": {
+        "properties": { "manifestDigest": { "type": "null" } }
+      }
+    }
+  ],
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$"
+    },
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?Z$"
+    }
+  }
+}

--- a/scripts/generate-contract-types.mjs
+++ b/scripts/generate-contract-types.mjs
@@ -41,6 +41,26 @@ function mergeConstraint(base, constraint) {
   return { ...base, ...constraint };
 }
 
+function closedObjectVariant(schema, constraints) {
+  if (schema.properties === undefined || !Array.isArray(schema.required)) {
+    throw new Error("closed schema cannot produce a generated union");
+  }
+  const properties = Object.fromEntries(
+    Object.entries(schema.properties).map(([name, definition]) => [
+      name,
+      constraints[name] === undefined
+        ? definition
+        : mergeConstraint(definition, constraints[name]),
+    ]),
+  );
+  return {
+    type: schema.type,
+    additionalProperties: schema.additionalProperties,
+    required: schema.required,
+    properties,
+  };
+}
+
 function conditionalUnion(schema) {
   if (
     !Array.isArray(schema.allOf) ||
@@ -56,21 +76,10 @@ function conditionalUnion(schema) {
     if (exitConstraint === undefined || thenProperties === undefined) {
       throw new Error("conditional schema branch is incomplete");
     }
-    const constraints = { exitCode: exitConstraint, ...thenProperties };
-    const properties = Object.fromEntries(
-      Object.entries(schema.properties).map(([name, definition]) => [
-        name,
-        constraints[name] === undefined
-          ? definition
-          : mergeConstraint(definition, constraints[name]),
-      ]),
-    );
-    return {
-      type: schema.type,
-      additionalProperties: schema.additionalProperties,
-      required: schema.required,
-      properties,
-    };
+    return closedObjectVariant(schema, {
+      exitCode: exitConstraint,
+      ...thenProperties,
+    });
   });
   return {
     $schema: schema.$schema,
@@ -79,6 +88,60 @@ function conditionalUnion(schema) {
     oneOf: variants,
     $defs: schema.$defs,
   };
+}
+
+function transactionManifestTypeSchema(schema) {
+  const operation = schema.$defs?.operation;
+  if (operation === undefined) {
+    throw new Error("transaction manifest operation schema is missing");
+  }
+  const writeOperation = closedObjectVariant(operation, {
+    kind: { const: "write_file" },
+    stagedPath: { $ref: "#/$defs/reference" },
+  });
+  const metadataOnlyOperation = closedObjectVariant(operation, {
+    kind: { enum: ["create_directory", "delete_file"] },
+    stagedPath: { type: "null" },
+  });
+  return {
+    ...schema,
+    $defs: {
+      ...schema.$defs,
+      operation: { oneOf: [writeOperation, metadataOnlyOperation] },
+    },
+  };
+}
+
+function transactionProgressTypeSchema(schema) {
+  return {
+    $schema: schema.$schema,
+    $id: schema.$id,
+    title: schema.title,
+    oneOf: [
+      closedObjectVariant(schema, {
+        phase: { const: "begun" },
+        manifestDigest: { type: "null" },
+      }),
+      closedObjectVariant(schema, {
+        phase: { enum: ["prepared", "publishing", "committed"] },
+        manifestDigest: { $ref: "#/$defs/sha256" },
+      }),
+      closedObjectVariant(schema, {
+        phase: { const: "aborted" },
+      }),
+    ],
+    $defs: schema.$defs,
+  };
+}
+
+function schemaForTypeGeneration(id, schema) {
+  if (id === "state.transaction-manifest") {
+    return transactionManifestTypeSchema(schema);
+  }
+  if (id === "state.transaction-progress") {
+    return transactionProgressTypeSchema(schema);
+  }
+  return schema;
 }
 
 export async function generateContractTypes({
@@ -106,23 +169,27 @@ export async function generateContractTypes({
       `// source: ${schema.$id} sha256:${createHash("sha256").update(schemaText).digest("hex")}`,
     );
     schema.title = entry.typeName;
-    const compiled = await compile(schema, entry.typeName, {
-      bannerComment: "",
-      cwd: repositoryRoot,
-      format: false,
-      ignoreMinAndMaxItems: false,
-      strictIndexSignatures: true,
-      $refOptions: {
-        resolve: {
-          http: false,
-          universalResult: {
-            order: 1,
-            canRead: /^https:\/\/mestre-yoda\.dev\/schemas\/result\/v1$/u,
-            read: generatedResultSchemaText,
+    const compiled = await compile(
+      schemaForTypeGeneration(entry.id, schema),
+      entry.typeName,
+      {
+        bannerComment: "",
+        cwd: repositoryRoot,
+        format: false,
+        ignoreMinAndMaxItems: false,
+        strictIndexSignatures: true,
+        $refOptions: {
+          resolve: {
+            http: false,
+            universalResult: {
+              order: 1,
+              canRead: /^https:\/\/mestre-yoda\.dev\/schemas\/result\/v1$/u,
+              read: generatedResultSchemaText,
+            },
           },
         },
       },
-    });
+    );
     const namespace = `${entry.typeName}Contract`;
     declarations.push(
       `export namespace ${namespace} {\n${indent(compiled)}\n}\nexport type ${entry.typeName} = ${namespace}.${entry.typeName};`,

--- a/scripts/lib/result-contract.mjs
+++ b/scripts/lib/result-contract.mjs
@@ -207,12 +207,8 @@ function validateResultAgainstReason(result, reason, validateResult) {
       throw validationFailure(`result ${property} conflicts with its reason`);
     }
   }
-  if (result.stateChanged !== reason.stateChanged) {
-    throw validationFailure(
-      result.stateChanged
-        ? "result makes a false state mutation claim"
-        : "result state mutation claim conflicts with its reason",
-    );
+  if (result.stateChanged && !reason.stateChanged) {
+    throw validationFailure("result makes a false state mutation claim");
   }
   if (reason.evidence === "required" && result.evidence.length === 0) {
     throw validationFailure("required evidence is absent");

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -319,6 +319,26 @@ describe("runtime boundary documentation", () => {
 });
 
 describe("the repository obeys its own rules", () => {
+  it("keeps transaction domain and durable ports free of Node.js builtins", async () => {
+    const paths = [
+      "packages/runtime/src/domain/transactions/index.ts",
+      "packages/runtime/src/domain/transactions/model.ts",
+      "packages/runtime/src/domain/transactions/normalize.ts",
+      "packages/runtime/src/domain/transactions/recovery.ts",
+      "packages/runtime/src/domain/transactions/transition.ts",
+      "packages/runtime/src/ports/transactions.ts",
+    ] as const;
+    const modules = await Promise.all(
+      paths.map(async (path) => ({
+        path,
+        imports: await collectImports(join(repositoryRoot, path)),
+      })),
+    );
+
+    expect(modules.map(({ path }) => path)).toEqual(paths);
+    expect(violations(modules)).toEqual([]);
+  });
+
   it("has no dependency-direction violation", async () => {
     const modules = await sourceModules();
     // Prove the sweep actually looked at the layered source, so an empty glob

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -107,6 +107,7 @@ describe("import extraction", () => {
       "../infra/node/index.js",
       "../ports/index.js",
       "./schema.js",
+      "./transactions.js",
     ]);
   });
 });

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -95,6 +95,7 @@ describe("import extraction", () => {
       "node:path",
       "../../domain/project/index.js",
       "../../ports/index.js",
+      "./transactions.js",
     ]);
 
     expect(

--- a/tests/architecture.test.ts
+++ b/tests/architecture.test.ts
@@ -104,6 +104,7 @@ describe("import extraction", () => {
       ),
     ).toEqual([
       "../domain/effects.js",
+      "../domain/transactions/index.js",
       "../infra/node/index.js",
       "../ports/index.js",
       "./schema.js",

--- a/tests/cli-composition.test.ts
+++ b/tests/cli-composition.test.ts
@@ -593,6 +593,104 @@ describe("composed command line", () => {
     expect(output.structured_.join("")).toBe("Summary fallback.\n");
   });
 
+  it("reports the concrete managed-state outcome for successful commands", async () => {
+    const runTrailPlan = async (
+      plan: ReturnType<typeof planOf>,
+      seed: Parameters<typeof memoryTransactionStorage>[0],
+      json: boolean,
+    ) => {
+      const storage = memoryTransactionStorage(seed);
+      const output = recordingOutput();
+      const registry = [
+        {
+          path: ["state-outcome"],
+          summary: "Report a concrete state outcome.",
+          flags: [],
+          positionals: { min: 0, max: 0 },
+          jsonContract: "result@1.0.0" as const,
+          handler: () => ({
+            result: resultFor("trail.ok", {
+              summary: "State outcome recorded.",
+              evidence: [
+                { kind: "event" as const, ref: ".brain/events.jsonl" },
+              ],
+            }),
+            plan,
+            humanStdout: null,
+            payload: null,
+          }),
+        },
+      ];
+      const exitCode = await runCommandLine(
+        json ? ["--json", "state-outcome"] : ["state-outcome"],
+        createRuntime({
+          clock: fixedClock("2026-08-09T00:00:00.000Z"),
+          ids: sequentialIds("transaction"),
+          fileSystem: storage.fileSystem,
+          durableFileSystem: storage.durableFileSystem,
+          digests: storage.digests,
+          output,
+        }),
+        registry,
+      );
+      return { exitCode, output, storage };
+    };
+
+    const satisfiedPlan = planOf({
+      kind: "write_file",
+      path: ".brain/state.json",
+      content: "same",
+    });
+    const satisfied = await runTrailPlan(
+      satisfiedPlan,
+      {
+        directories: [".brain", ".brain/transactions"],
+        files: { ".brain/state.json": "same" },
+      },
+      true,
+    );
+    expect(satisfied.exitCode).toBe(0);
+    expect(JSON.parse(satisfied.output.structured_.join(""))).toMatchObject({
+      reasonCode: "trail.ok",
+      stateChanged: false,
+    });
+    expect(satisfied.storage.calls()).not.toContain(
+      "create_directory_exclusive",
+    );
+
+    const committed = await runTrailPlan(
+      satisfiedPlan,
+      { directories: [".brain", ".brain/transactions"] },
+      true,
+    );
+    expect(JSON.parse(committed.output.structured_.join(""))).toMatchObject({
+      reasonCode: "trail.ok",
+      stateChanged: true,
+    });
+
+    const unmanaged = await runTrailPlan(
+      planOf(),
+      { directories: [".brain", ".brain/transactions"] },
+      true,
+    );
+    expect(JSON.parse(unmanaged.output.structured_.join(""))).toMatchObject({
+      reasonCode: "trail.ok",
+      stateChanged: false,
+    });
+
+    const human = await runTrailPlan(
+      satisfiedPlan,
+      {
+        directories: [".brain", ".brain/transactions"],
+        files: { ".brain/state.json": "same" },
+      },
+      false,
+    );
+    expect(human).toMatchObject({ exitCode: 0 });
+    expect(human.output.structured_.join("")).toBe("State outcome recorded.\n");
+    expect(human.output.human_).toEqual([]);
+  });
+
   it("rejects an invalid adapter payload before effects or output", async () => {
     const output = recordingOutput();
     const fileSystem = memoryFileSystem();

--- a/tests/cli-composition.test.ts
+++ b/tests/cli-composition.test.ts
@@ -6,6 +6,7 @@ import { runCli } from "@mestre-yoda/runtime";
 import {
   createRuntime,
   createSchemaRegistry,
+  TransactionFailure,
 } from "@mestre-yoda/runtime/composition";
 import { runCommandLine } from "@mestre-yoda/runtime/composition/cli";
 import { planOf } from "@mestre-yoda/runtime/domain/effects";
@@ -16,9 +17,14 @@ import {
 } from "@mestre-yoda/runtime/domain/result";
 import type { SchemaRegistry } from "@mestre-yoda/runtime/domain/schema";
 import {
+  fixedClock,
   memoryFileSystem,
+  memoryTransactionStorage,
   recordingOutput,
+  sequentialIds,
 } from "@mestre-yoda/runtime/infra/fake";
+import type { EvidenceRef } from "@mestre-yoda/runtime/domain/result";
+import type { DurableFileSystem } from "@mestre-yoda/runtime/ports";
 
 async function run(argv: readonly string[]) {
   const output = recordingOutput();
@@ -29,6 +35,67 @@ async function run(argv: readonly string[]) {
     stderr: output.human_.join(""),
   };
 }
+
+const transactionReasons = [
+  {
+    reasonCode: "guard.outside_allow" as const,
+    status: "failure",
+    exitCode: 2,
+    retryable: true,
+    recovery:
+      "Move the change inside an allowed scope or obtain an explicit reviewed scope update.",
+    evidence: [
+      { kind: "artifact", ref: ".brain/request.json" },
+    ] satisfies readonly EvidenceRef[],
+  },
+  {
+    reasonCode: "runtime.internal_failure" as const,
+    status: "failure",
+    exitCode: 2,
+    retryable: false,
+    recovery:
+      "Capture an authorized redacted diagnostic bundle and report the stable reason without blindly retrying.",
+    evidence: [
+      { kind: "artifact", ref: ".brain/private-payload.json" },
+    ] satisfies readonly EvidenceRef[],
+  },
+  {
+    reasonCode: "runtime.recovery_required" as const,
+    status: "blocked",
+    exitCode: 4,
+    retryable: true,
+    recovery:
+      "Run the explicit transaction recovery operation, verify its event evidence, and then repeat the original request.",
+    evidence: [
+      {
+        kind: "artifact",
+        ref: ".brain/transactions/transaction-1/progress.json",
+      },
+    ] satisfies readonly EvidenceRef[],
+  },
+  {
+    reasonCode: "runtime.revision_conflict" as const,
+    status: "blocked",
+    exitCode: 5,
+    retryable: true,
+    recovery:
+      "Reload canonical state, recompute the decision from the new revision, and submit a fresh mutation.",
+    evidence: [
+      { kind: "artifact", ref: ".brain/state.json" },
+    ] satisfies readonly EvidenceRef[],
+  },
+  {
+    reasonCode: "runtime.state_corrupt" as const,
+    status: "blocked",
+    exitCode: 4,
+    retryable: true,
+    recovery:
+      "Preserve the rejected state, run the explicit integrity audit, and retry only after verified repair or rebuild.",
+    evidence: [
+      { kind: "artifact", ref: ".brain/events.jsonl" },
+    ] satisfies readonly EvidenceRef[],
+  },
+] as const;
 
 describe("composed command line", () => {
   it("delegates the process entry to the composed pipeline", async () => {
@@ -161,6 +228,143 @@ describe("composed command line", () => {
     );
     expect(output.human_.join("")).not.toContain("secret-token");
     expect(output.structured_.join("")).toBe("");
+  });
+
+  it.each(transactionReasons)(
+    "maps $reasonCode through the catalog in human and JSON modes",
+    async ({ reasonCode, status, exitCode, retryable, recovery, evidence }) => {
+      const registry = [
+        {
+          path: ["transaction-failure"],
+          summary: "Raise a typed transaction failure.",
+          flags: [],
+          positionals: { min: 0, max: 0 },
+          jsonContract: "result@1.0.0" as const,
+          handler: () => {
+            const failure = new TransactionFailure(reasonCode, evidence);
+            failure.message =
+              "/home/someone/project/.brain private-payload-content";
+            throw failure;
+          },
+        },
+      ];
+
+      const humanOutput = recordingOutput();
+      const humanExit = await runCommandLine(
+        ["transaction-failure"],
+        createRuntime({ output: humanOutput }),
+        registry,
+      );
+      const human = humanOutput.human_.join("");
+      expect(humanExit).toBe(exitCode);
+      expect(humanOutput.structured_.join("")).toBe("");
+      expect(human).toContain(`Reason: ${reasonCode}`);
+      expect(human).toContain(`Retryable: ${String(retryable)}`);
+      expect(human).toContain(`Recovery: ${recovery}`);
+      const expectedEvidence =
+        reasonCode === "runtime.internal_failure" ? [] : evidence;
+      for (const item of expectedEvidence) {
+        expect(human).toContain(`Evidence: ${item.kind} ${item.ref}`);
+      }
+      if (reasonCode === "runtime.internal_failure") {
+        expect(human).not.toContain("Evidence:");
+      }
+      expect(human).not.toContain("/home/someone");
+      expect(human).not.toContain("private-payload-content");
+
+      const jsonOutput = recordingOutput();
+      const jsonExit = await runCommandLine(
+        ["--json", "transaction-failure"],
+        createRuntime({ output: jsonOutput }),
+        registry,
+      );
+      const jsonText = jsonOutput.structured_.join("");
+      expect(jsonExit).toBe(exitCode);
+      expect(jsonOutput.human_.join("")).toBe("");
+      expect(JSON.parse(jsonText)).toMatchObject({
+        status,
+        exitCode,
+        reasonCode,
+        evidence: expectedEvidence,
+        stateChanged: false,
+        retryable,
+        recovery,
+      });
+      expect(jsonText).not.toContain("/home/someone");
+      expect(jsonText).not.toContain("private-payload-content");
+    },
+  );
+
+  it("does not classify an error by its name or message", async () => {
+    const output = recordingOutput();
+    const lookalike = [
+      {
+        path: ["lookalike"],
+        summary: "Raise an untyped lookalike.",
+        flags: [],
+        positionals: { min: 0, max: 0 },
+        jsonContract: "result@1.0.0" as const,
+        handler: () => {
+          const error = new Error("Managed transaction failed");
+          error.name = "TransactionFailure";
+          throw error;
+        },
+      },
+    ];
+
+    expect(
+      await runCommandLine(
+        ["--json", "lookalike"],
+        createRuntime({ output }),
+        lookalike,
+      ),
+    ).toBe(2);
+    expect(JSON.parse(output.structured_.join(""))).toMatchObject({
+      reasonCode: "runtime.internal_failure",
+      evidence: [],
+    });
+  });
+
+  it("renders the append_event refusal without exposing its payload", async () => {
+    const output = recordingOutput();
+    const append = [
+      {
+        path: ["append"],
+        summary: "Attempt an event append.",
+        flags: [],
+        positionals: { min: 0, max: 0 },
+        jsonContract: "result@1.0.0" as const,
+        handler: () => ({
+          result: resultFor("trail.ok", {
+            evidence: [{ kind: "event" as const, ref: ".brain/events.jsonl" }],
+          }),
+          plan: planOf({
+            kind: "append_event" as const,
+            event: "private-event-payload",
+          }),
+          humanStdout: null,
+          payload: null,
+        }),
+      },
+    ];
+
+    expect(
+      await runCommandLine(
+        ["--json", "append"],
+        createRuntime({ output }),
+        append,
+      ),
+    ).toBe(4);
+    const rendered = output.structured_.join("");
+    expect(JSON.parse(rendered)).toMatchObject({
+      status: "blocked",
+      exitCode: 4,
+      reasonCode: "runtime.state_corrupt",
+      evidence: [{ kind: "artifact", ref: ".brain/events.jsonl" }],
+      stateChanged: false,
+      retryable: true,
+    });
+    expect(rendered).not.toContain("private-event-payload");
   });
 
   it("validates a decision before applying its effect plan", async () => {
@@ -431,7 +635,9 @@ describe("composed command line", () => {
   it("prepares adapter output before applying effects and publishing", async () => {
     const events: string[] = [];
     const output = recordingOutput();
-    const fileSystem = memoryFileSystem();
+    const storage = memoryTransactionStorage({
+      directories: [".brain", ".brain/transactions"],
+    });
     const productionRegistry = createSchemaRegistry();
     const schemaRegistry: SchemaRegistry = {
       validate(request) {
@@ -452,7 +658,7 @@ describe("composed command line", () => {
           }),
           plan: planOf({
             kind: "write_file" as const,
-            path: "changed.txt",
+            path: ".brain/changed.json",
             content: "written",
           }),
           humanStdout: null,
@@ -461,16 +667,22 @@ describe("composed command line", () => {
       },
     ];
 
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      async replaceFile(stagedPath, targetPath) {
+        await storage.durableFileSystem.replaceFile(stagedPath, targetPath);
+        if (targetPath === ".brain/changed.json") events.push("effect");
+      },
+    };
+
     const exitCode = await runCommandLine(
       ["--json", "ordered-adapter"],
       createRuntime({
-        fileSystem: {
-          ...fileSystem,
-          async write(path, content) {
-            events.push("effect");
-            await fileSystem.write(path, content);
-          },
-        },
+        clock: fixedClock("2026-08-09T00:00:00.000Z"),
+        ids: sequentialIds("transaction"),
+        fileSystem: storage.fileSystem,
+        durableFileSystem,
+        digests: storage.digests,
         output: {
           structured(text) {
             events.push("output");
@@ -487,7 +699,7 @@ describe("composed command line", () => {
 
     expect(exitCode).toBe(0);
     expect(events).toEqual(["validate", "effect", "output"]);
-    expect(await fileSystem.read("changed.txt")).toBe("written");
+    expect(storage.snapshot().files[".brain/changed.json"]).toBe("written");
   });
 
   it("fails closed when a non-result command has no payload", async () => {

--- a/tests/cli-contracts.test.ts
+++ b/tests/cli-contracts.test.ts
@@ -5,9 +5,13 @@ import { fileURLToPath } from "node:url";
 import { Ajv2020 } from "ajv/dist/2020.js";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { createRuntime } from "@mestre-yoda/runtime/composition";
+import {
+  createRuntime,
+  TransactionFailure,
+} from "@mestre-yoda/runtime/composition";
 import { runCommandLine } from "@mestre-yoda/runtime/composition/cli";
 import { DEFAULT_REGISTRY } from "@mestre-yoda/runtime/domain/cli";
+import { transactionFailureResult } from "@mestre-yoda/runtime/domain/result";
 import { canonicalizeJson } from "@mestre-yoda/runtime/domain/schema";
 import {
   memoryFileSystem,
@@ -87,6 +91,37 @@ describe("output safety", () => {
       }
     }
   });
+});
+
+describe("transaction failure result contract", () => {
+  it.each([
+    ["guard.outside_allow", "failure", 2, true],
+    ["runtime.internal_failure", "failure", 2, false],
+    ["runtime.recovery_required", "blocked", 4, true],
+    ["runtime.revision_conflict", "blocked", 5, true],
+    ["runtime.state_corrupt", "blocked", 4, true],
+  ] as const)(
+    "maps %s to catalog policy and schema-valid evidence",
+    (reasonCode, status, exitCode, retryable) => {
+      const result = transactionFailureResult(
+        new TransactionFailure(reasonCode, [
+          { kind: "artifact", ref: ".brain/events.jsonl" },
+        ]),
+      );
+      expect(result).toMatchObject({
+        status,
+        exitCode,
+        reasonCode,
+        stateChanged: false,
+        retryable,
+        evidence:
+          reasonCode === "runtime.internal_failure"
+            ? []
+            : [{ kind: "artifact", ref: ".brain/events.jsonl" }],
+      });
+      expect(validators.get("result@1.0.0")?.(result)).toBe(true);
+    },
+  );
 });
 
 describe("determinism", () => {

--- a/tests/contract-documentation.test.ts
+++ b/tests/contract-documentation.test.ts
@@ -118,6 +118,8 @@ describe("contract versioning documentation", () => {
       "evidence.v1.schema.json",
       "lock.v1.schema.json",
       "migration.v1.schema.json",
+      "transaction-manifest.v1.schema.json",
+      "transaction-progress.v1.schema.json",
       "adapter-message.v1.schema.json",
       "contract-manifest.v1.schema.json",
       "npm run contracts:generate",

--- a/tests/contract-documentation.test.ts
+++ b/tests/contract-documentation.test.ts
@@ -135,6 +135,8 @@ describe("contract versioning documentation", () => {
       "evidence.json",
       "lock.json",
       "migration.json",
+      "transaction-manifest.json",
+      "transaction-progress.json",
       "adapter-message.json",
       "version-cases.json",
     ]) {

--- a/tests/contract-manifest.test.ts
+++ b/tests/contract-manifest.test.ts
@@ -123,7 +123,7 @@ describe("contract family manifest", () => {
   });
 
   it("registers every current payload schema once with safe paths", async () => {
-    expect(manifest.schemas).toHaveLength(8);
+    expect(manifest.schemas).toHaveLength(10);
     const ids = manifest.schemas.map(({ id }) => id);
     const paths = manifest.schemas.map(({ path }) => path);
     expect(ids).toEqual([...ids].sort());

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -16,6 +16,16 @@ const artifacts = [
   ["state/evidence.v1.schema.json", "evidence.json", "state"],
   ["state/lock.v1.schema.json", "lock.json", "state"],
   ["state/migration.v1.schema.json", "migration.json", "state"],
+  [
+    "state/transaction-manifest.v1.schema.json",
+    "transaction-manifest.json",
+    "state",
+  ],
+  [
+    "state/transaction-progress.v1.schema.json",
+    "transaction-progress.json",
+    "state",
+  ],
   ["host/adapter-message.v1.schema.json", "adapter-message.json", "host"],
 ] as const;
 
@@ -186,7 +196,103 @@ describe("versioned state and host schemas", () => {
     }
   });
 
-  it("ships eight payload fixtures plus the version-case table", async () => {
+  it("enforces closed transaction operation fingerprints and staging", () => {
+    const artifact = loaded.find(
+      ({ fixtureName }) => fixtureName === "transaction-manifest.json",
+    );
+    if (artifact === undefined) throw new Error("missing transaction manifest");
+    const validate = new Ajv2020({ allErrors: true, strict: true }).compile(
+      artifact.schema,
+    );
+    const operation = (artifact.fixture.operations as JsonObject[])[0];
+    if (operation === undefined)
+      throw new Error("missing transaction operation");
+
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [{ ...operation, stagedPath: null }],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [
+          {
+            ...operation,
+            kind: "delete_file",
+            result: { kind: "missing" },
+            stagedPath: operation.stagedPath,
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [
+          {
+            ...operation,
+            kind: "create_directory",
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [
+          {
+            ...operation,
+            result: {
+              kind: "file",
+              size: Number.MAX_SAFE_INTEGER + 1,
+              sha256: "a".repeat(64),
+            },
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("requires manifest digests after transaction preparation", () => {
+    const artifact = loaded.find(
+      ({ fixtureName }) => fixtureName === "transaction-progress.json",
+    );
+    if (artifact === undefined) throw new Error("missing transaction progress");
+    const validate = new Ajv2020({ allErrors: true, strict: true }).compile(
+      artifact.schema,
+    );
+
+    for (const phase of ["prepared", "publishing", "committed"]) {
+      expect(
+        validate({
+          ...structuredClone(artifact.fixture),
+          phase,
+          manifestDigest: null,
+        }),
+        phase,
+      ).toBe(false);
+    }
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        phase: "begun",
+        manifestDigest: null,
+      }),
+    ).toBe(true);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        phase: "aborted",
+        manifestDigest: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("ships ten payload fixtures plus the version-case table", async () => {
     expect((await readdir(fixtureRoot)).sort()).toEqual(
       [
         ...artifacts.map(([, fixtureName]) => fixtureName),

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -255,6 +255,76 @@ describe("versioned state and host schemas", () => {
         ],
       }),
     ).toBe(false);
+    expect(
+      validate({ ...structuredClone(artifact.fixture), operations: [] }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [{ ...operation, unexpected: true }],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [
+          {
+            ...operation,
+            expected: {
+              ...(operation.expected as JsonObject),
+              unexpected: true,
+            },
+          },
+        ],
+      }),
+    ).toBe(false);
+    for (const unsafeReference of [
+      "/absolute",
+      "../traversal",
+      "backslash\\path",
+      "https://example.test/payload",
+    ]) {
+      expect(
+        validate({
+          ...structuredClone(artifact.fixture),
+          operations: [{ ...operation, path: unsafeReference }],
+        }),
+        `path: ${unsafeReference}`,
+      ).toBe(false);
+      expect(
+        validate({
+          ...structuredClone(artifact.fixture),
+          operations: [{ ...operation, stagedPath: unsafeReference }],
+        }),
+        `stagedPath: ${unsafeReference}`,
+      ).toBe(false);
+    }
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        planDigest: "not-a-sha256",
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [
+          {
+            ...operation,
+            result: {
+              ...(operation.result as JsonObject),
+              sha256: "not-a-sha256",
+            },
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        operations: [{ ...operation, kind: "replace_file" }],
+      }),
+    ).toBe(false);
   });
 
   it("requires manifest digests after transaction preparation", () => {
@@ -286,10 +356,37 @@ describe("versioned state and host schemas", () => {
     expect(
       validate({
         ...structuredClone(artifact.fixture),
+        phase: "begun",
+        manifestDigest: "a".repeat(64),
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
         phase: "aborted",
         manifestDigest: null,
       }),
     ).toBe(true);
+    expect(
+      validate({
+        ...structuredClone(artifact.fixture),
+        phase: "aborted",
+        manifestDigest: "a".repeat(64),
+      }),
+    ).toBe(true);
+    for (const candidate of [
+      { recoveryToken: "not-a-sha256" },
+      { manifestDigest: "not-a-sha256" },
+      { phase: "recovering" },
+      { fileSync: "optional" },
+      { directorySync: "unknown" },
+      { publishedOperationIds: ["operation-0001", "operation-0001"] },
+    ]) {
+      expect(
+        validate({ ...structuredClone(artifact.fixture), ...candidate }),
+        JSON.stringify(candidate),
+      ).toBe(false);
+    }
   });
 
   it("ships ten payload fixtures plus the version-case table", async () => {

--- a/tests/contract-type-generation.test.ts
+++ b/tests/contract-type-generation.test.ts
@@ -29,12 +29,14 @@ describe("schema-derived contract declarations", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe(
-      "contract families v1.0.0: verified (8 schemas; 14 legacy profiles; generated types current)\n",
+      "contract families v1.0.0: verified (10 schemas; 14 legacy profiles; generated types current)\n",
     );
     expect(after).toBe(before);
     expect(after).toContain("Generated from registered JSON Schemas.");
     expect(after).toContain("export type AdapterMessageV1");
     expect(after).toContain("export interface ProjectConfigV1");
+    expect(after).toContain("export interface TransactionManifestV1");
+    expect(after).toContain("export type TransactionProgressV1");
   });
 
   it("detects drift through an alternate generated path", async () => {

--- a/tests/contract-type-generation.test.ts
+++ b/tests/contract-type-generation.test.ts
@@ -37,6 +37,10 @@ describe("schema-derived contract declarations", () => {
     expect(after).toContain("export interface ProjectConfigV1");
     expect(after).toContain("export interface TransactionManifestV1");
     expect(after).toContain("export type TransactionProgressV1");
+    const transactionDeclarations = after.slice(
+      after.indexOf("export namespace TransactionManifestV1Contract"),
+    );
+    expect(transactionDeclarations).not.toContain("[k: string]");
   });
 
   it("detects drift through an alternate generated path", async () => {
@@ -152,6 +156,217 @@ describe("schema-derived contract declarations", () => {
       expect(result.stdout).toContain(
         "'unexpected' does not exist in type '{ contractVersion:",
       );
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it.each([
+    [
+      "a write operation without a staged payload",
+      `
+        ({
+          contractVersion: "1.0.0",
+          stateContract: "1.0.0",
+          transactionId: "transaction-01",
+          planDigest: "${"a".repeat(64)}",
+          createdAt: "2026-08-09T00:00:00.000Z",
+          operations: [{
+            operationId: "operation-0001",
+            kind: "write_file",
+            path: ".brain/state.json",
+            expected: { kind: "missing" },
+            result: { kind: "file", size: 3, sha256: "${"a".repeat(64)}" },
+            stagedPath: null,
+          }],
+        }) satisfies TransactionManifestV1;
+      `,
+    ],
+    [
+      "an additional operation property",
+      `
+        ({
+          contractVersion: "1.0.0",
+          stateContract: "1.0.0",
+          transactionId: "transaction-01",
+          planDigest: "${"a".repeat(64)}",
+          createdAt: "2026-08-09T00:00:00.000Z",
+          operations: [{
+            operationId: "operation-0001",
+            kind: "write_file",
+            path: ".brain/state.json",
+            expected: { kind: "missing" },
+            result: { kind: "file", size: 3, sha256: "${"a".repeat(64)}" },
+            stagedPath: ".brain/transactions/transaction-01/staging/operation-0001.payload",
+            unexpected: true,
+          }],
+        }) satisfies TransactionManifestV1;
+      `,
+    ],
+    [
+      "prepared progress without a manifest digest",
+      `
+        ({
+          contractVersion: "1.0.0",
+          stateContract: "1.0.0",
+          transactionId: "transaction-01",
+          manifestDigest: null,
+          recoveryToken: "${"a".repeat(64)}",
+          phase: "prepared",
+          publishedOperationIds: [],
+          fileSync: "required",
+          directorySync: "supported",
+          createdAt: "2026-08-09T00:00:00.000Z",
+          updatedAt: "2026-08-09T00:00:01.000Z",
+        }) satisfies TransactionProgressV1;
+      `,
+    ],
+    [
+      "an additional progress property",
+      `
+        ({
+          contractVersion: "1.0.0",
+          stateContract: "1.0.0",
+          transactionId: "transaction-01",
+          manifestDigest: "${"a".repeat(64)}",
+          recoveryToken: "${"a".repeat(64)}",
+          phase: "prepared",
+          publishedOperationIds: [],
+          fileSync: "required",
+          directorySync: "supported",
+          createdAt: "2026-08-09T00:00:00.000Z",
+          updatedAt: "2026-08-09T00:00:01.000Z",
+          unexpected: true,
+        }) satisfies TransactionProgressV1;
+      `,
+    ],
+  ])("rejects %s in generated transaction types", async (_name, candidate) => {
+    const directory = await mkdtemp(
+      join(repositoryRoot, ".contract-type-test-"),
+    );
+    try {
+      const source = join(directory, "invalid-transaction.mts");
+      await writeFile(
+        source,
+        `
+          import type {
+            TransactionManifestV1,
+            TransactionProgressV1,
+          } from "../packages/contracts/src/generated/contracts.js";
+          ${candidate}
+        `,
+        "utf8",
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          join(repositoryRoot, "node_modules/typescript/lib/tsc.js"),
+          "--ignoreConfig",
+          "--noEmit",
+          "--strict",
+          "--module",
+          "NodeNext",
+          "--moduleResolution",
+          "NodeNext",
+          "--target",
+          "ES2024",
+          source,
+        ],
+        { cwd: repositoryRoot, encoding: "utf8" },
+      );
+      expect(result.status, result.stdout).not.toBe(0);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts every valid generated transaction variant", async () => {
+    const directory = await mkdtemp(
+      join(repositoryRoot, ".contract-type-test-"),
+    );
+    try {
+      const source = join(directory, "valid-transactions.mts");
+      await writeFile(
+        source,
+        `
+          import type {
+            TransactionManifestV1,
+            TransactionProgressV1,
+          } from "../packages/contracts/src/generated/contracts.js";
+
+          const digest = "${"a".repeat(64)}";
+          ({
+            contractVersion: "1.0.0",
+            stateContract: "1.0.0",
+            transactionId: "transaction-01",
+            planDigest: digest,
+            createdAt: "2026-08-09T00:00:00.000Z",
+            operations: [
+              {
+                operationId: "operation-0001",
+                kind: "write_file",
+                path: ".brain/state.json",
+                expected: { kind: "missing" },
+                result: { kind: "file", size: 3, sha256: digest },
+                stagedPath: ".brain/transactions/transaction-01/staging/operation-0001.payload",
+              },
+              {
+                operationId: "operation-0002",
+                kind: "create_directory",
+                path: ".brain/runs",
+                expected: { kind: "missing" },
+                result: { kind: "directory" },
+                stagedPath: null,
+              },
+              {
+                operationId: "operation-0003",
+                kind: "delete_file",
+                path: ".brain/old.json",
+                expected: { kind: "file", size: 3, sha256: digest },
+                result: { kind: "missing" },
+                stagedPath: null,
+              },
+            ],
+          }) satisfies TransactionManifestV1;
+
+          const common = {
+            contractVersion: "1.0.0" as const,
+            stateContract: "1.0.0" as const,
+            transactionId: "transaction-01",
+            recoveryToken: digest,
+            publishedOperationIds: [] as string[],
+            fileSync: "required" as const,
+            directorySync: "supported" as const,
+            createdAt: "2026-08-09T00:00:00.000Z",
+            updatedAt: "2026-08-09T00:00:01.000Z",
+          };
+          ({ ...common, phase: "begun", manifestDigest: null }) satisfies TransactionProgressV1;
+          ({ ...common, phase: "prepared", manifestDigest: digest }) satisfies TransactionProgressV1;
+          ({ ...common, phase: "publishing", manifestDigest: digest }) satisfies TransactionProgressV1;
+          ({ ...common, phase: "committed", manifestDigest: digest }) satisfies TransactionProgressV1;
+          ({ ...common, phase: "aborted", manifestDigest: null }) satisfies TransactionProgressV1;
+          ({ ...common, phase: "aborted", manifestDigest: digest }) satisfies TransactionProgressV1;
+        `,
+        "utf8",
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          join(repositoryRoot, "node_modules/typescript/lib/tsc.js"),
+          "--ignoreConfig",
+          "--noEmit",
+          "--strict",
+          "--module",
+          "NodeNext",
+          "--moduleResolution",
+          "NodeNext",
+          "--target",
+          "ES2024",
+          source,
+        ],
+        { cwd: repositoryRoot, encoding: "utf8" },
+      );
+      expect(result.status, result.stdout).toBe(0);
     } finally {
       await rm(directory, { force: true, recursive: true });
     }

--- a/tests/fake-transactions.test.ts
+++ b/tests/fake-transactions.test.ts
@@ -1,0 +1,331 @@
+import {
+  type DurableOperation,
+  type MemoryTransactionStorage,
+  memoryTransactionStorage,
+} from "@mestre-yoda/runtime/infra/fake";
+import { describe, expect, it } from "vitest";
+
+interface StorageSnapshot {
+  readonly files: Readonly<Record<string, string>>;
+  readonly directories: readonly string[];
+}
+
+interface OperationCase {
+  readonly operation: DurableOperation;
+  readonly seed?: Parameters<typeof memoryTransactionStorage>[0];
+  readonly run: (storage: MemoryTransactionStorage) => Promise<unknown>;
+  readonly before: StorageSnapshot;
+  readonly after: StorageSnapshot;
+}
+
+const empty: StorageSnapshot = { files: {}, directories: [] };
+const brain: StorageSnapshot = { files: {}, directories: [".brain"] };
+const written: StorageSnapshot = {
+  files: { ".brain/state.json": "new" },
+  directories: [".brain"],
+};
+
+const cases: readonly OperationCase[] = [
+  {
+    operation: "inspect",
+    seed: { files: { ".brain/state.json": "old" } },
+    run: (storage) => storage.durableFileSystem.inspect(".brain/state.json"),
+    before: {
+      files: { ".brain/state.json": "old" },
+      directories: [".brain"],
+    },
+    after: {
+      files: { ".brain/state.json": "old" },
+      directories: [".brain"],
+    },
+  },
+  {
+    operation: "list",
+    seed: { files: { ".brain/state.json": "old" } },
+    run: (storage) => storage.durableFileSystem.list(".brain"),
+    before: {
+      files: { ".brain/state.json": "old" },
+      directories: [".brain"],
+    },
+    after: {
+      files: { ".brain/state.json": "old" },
+      directories: [".brain"],
+    },
+  },
+  {
+    operation: "read_text",
+    seed: { files: { ".brain/state.json": "old" } },
+    run: (storage) => storage.durableFileSystem.readText(".brain/state.json"),
+    before: {
+      files: { ".brain/state.json": "old" },
+      directories: [".brain"],
+    },
+    after: {
+      files: { ".brain/state.json": "old" },
+      directories: [".brain"],
+    },
+  },
+  {
+    operation: "create_directory",
+    run: (storage) => storage.durableFileSystem.createDirectory(".brain"),
+    before: empty,
+    after: brain,
+  },
+  {
+    operation: "create_directory_exclusive",
+    run: (storage) =>
+      storage.durableFileSystem.createDirectoryExclusive(".brain"),
+    before: empty,
+    after: brain,
+  },
+  {
+    operation: "open_file",
+    seed: { directories: [".brain"] },
+    run: (storage) =>
+      storage.durableFileSystem.writeSynced(".brain/state.json", "new"),
+    before: brain,
+    after: {
+      files: { ".brain/state.json": "" },
+      directories: [".brain"],
+    },
+  },
+  {
+    operation: "write_file",
+    seed: { directories: [".brain"] },
+    run: (storage) =>
+      storage.durableFileSystem.writeSynced(".brain/state.json", "new"),
+    before: {
+      files: { ".brain/state.json": "" },
+      directories: [".brain"],
+    },
+    after: written,
+  },
+  {
+    operation: "sync_file",
+    seed: { directories: [".brain"] },
+    run: (storage) =>
+      storage.durableFileSystem.writeSynced(".brain/state.json", "new"),
+    before: written,
+    after: written,
+  },
+  {
+    operation: "close_file",
+    seed: { directories: [".brain"] },
+    run: (storage) =>
+      storage.durableFileSystem.writeSynced(".brain/state.json", "new"),
+    before: written,
+    after: written,
+  },
+  {
+    operation: "replace_file",
+    seed: {
+      files: {
+        ".brain/staged": "new",
+        ".brain/state.json": "old",
+      },
+    },
+    run: (storage) =>
+      storage.durableFileSystem.replaceFile(
+        ".brain/staged",
+        ".brain/state.json",
+      ),
+    before: {
+      files: {
+        ".brain/staged": "new",
+        ".brain/state.json": "old",
+      },
+      directories: [".brain"],
+    },
+    after: written,
+  },
+  {
+    operation: "remove_file",
+    seed: { files: { ".brain/state.json": "old" } },
+    run: (storage) => storage.durableFileSystem.removeFile(".brain/state.json"),
+    before: {
+      files: { ".brain/state.json": "old" },
+      directories: [".brain"],
+    },
+    after: brain,
+  },
+  {
+    operation: "remove_empty_directory",
+    seed: { directories: [".brain", ".brain/empty"] },
+    run: (storage) =>
+      storage.durableFileSystem.removeEmptyDirectory(".brain/empty"),
+    before: {
+      files: {},
+      directories: [".brain", ".brain/empty"],
+    },
+    after: brain,
+  },
+  {
+    operation: "sync_directory",
+    seed: { directories: [".brain"] },
+    run: (storage) => storage.durableFileSystem.syncDirectory(".brain"),
+    before: brain,
+    after: brain,
+  },
+];
+
+describe("memory transaction storage", () => {
+  it("shares seeded files and directories between simple and durable views", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "seeded" },
+    });
+
+    expect(await storage.fileSystem.read(".brain/state.json")).toBe("seeded");
+    await storage.fileSystem.write(".brain/simple.json", "simple");
+    expect(await storage.durableFileSystem.readText(".brain/simple.json")).toBe(
+      "simple",
+    );
+    await storage.durableFileSystem.writeSynced(
+      ".brain/durable.json",
+      "durable",
+    );
+    expect(await storage.fileSystem.read(".brain/durable.json")).toBe(
+      "durable",
+    );
+    expect(storage.snapshot().directories).toEqual([
+      ".brain",
+      ".brain/transactions",
+    ]);
+  });
+
+  it("returns detached snapshots and call traces", async () => {
+    const storage = memoryTransactionStorage({ directories: [".brain"] });
+    const snapshot = storage.snapshot();
+    const calls = storage.calls();
+
+    await storage.durableFileSystem.writeSynced(".brain/state.json", "new");
+
+    expect(snapshot).toEqual(brain);
+    expect(calls).toEqual([]);
+    expect(storage.snapshot()).toEqual(written);
+    expect(storage.calls()).toEqual([
+      "open_file",
+      "write_file",
+      "sync_file",
+      "close_file",
+    ]);
+  });
+
+  it("provides the same deterministic SHA-256 capability as production", () => {
+    expect(memoryTransactionStorage().digests.sha256("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  it("models an ambiguous failure after atomic replacement", async () => {
+    const storage = memoryTransactionStorage({ directories: [".brain"] });
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 1,
+    });
+    await storage.durableFileSystem.writeSynced(".brain/staged", "new");
+
+    await expect(
+      storage.durableFileSystem.replaceFile(
+        ".brain/staged",
+        ".brain/state.json",
+      ),
+    ).rejects.toThrow("Injected durable filesystem failure");
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/staged");
+  });
+
+  it.each(cases)(
+    "$operation fails before its effect at the selected boundary",
+    async ({ operation, seed, run, before }) => {
+      const storage = memoryTransactionStorage(seed);
+      storage.fail({ operation, timing: "before", occurrence: 1 });
+
+      await expect(run(storage)).rejects.toThrow(
+        "Injected durable filesystem failure",
+      );
+
+      expect(storage.snapshot()).toEqual(before);
+      expect(storage.calls()).toContain(operation);
+    },
+  );
+
+  it.each(cases)(
+    "$operation fails after exposing its completed effect",
+    async ({ operation, seed, run, after }) => {
+      const storage = memoryTransactionStorage(seed);
+      storage.fail({ operation, timing: "after", occurrence: 1 });
+
+      await expect(run(storage)).rejects.toThrow(
+        "Injected durable filesystem failure",
+      );
+
+      expect(storage.snapshot()).toEqual(after);
+      expect(storage.calls()).toContain(operation);
+    },
+  );
+
+  it("targets an exact occurrence once", async () => {
+    const storage = memoryTransactionStorage({ directories: [".brain"] });
+    storage.fail({ operation: "inspect", timing: "before", occurrence: 2 });
+
+    await expect(
+      storage.durableFileSystem.inspect(".brain/missing"),
+    ).resolves.toEqual({ kind: "missing" });
+    await expect(
+      storage.durableFileSystem.inspect(".brain/missing"),
+    ).rejects.toThrow("Injected durable filesystem failure");
+    await expect(
+      storage.durableFileSystem.inspect(".brain/missing"),
+    ).resolves.toEqual({ kind: "missing" });
+  });
+
+  it.each(["permission", "disk_full"] as const)(
+    "retains the sanitized %s fault label",
+    async (fault) => {
+      const storage = memoryTransactionStorage();
+      storage.fail({
+        operation: "inspect",
+        timing: "before",
+        occurrence: 1,
+        fault,
+      });
+
+      await expect(
+        storage.durableFileSystem.inspect(".brain/state.json"),
+      ).rejects.toThrow(fault);
+    },
+  );
+
+  it("rejects a non-positive occurrence", () => {
+    const storage = memoryTransactionStorage();
+    expect(() => {
+      storage.fail({
+        operation: "inspect",
+        timing: "before",
+        occurrence: 0,
+      });
+    }).toThrow("positive integer");
+  });
+
+  it("records operation names without paths or content", async () => {
+    const storage = memoryTransactionStorage({ directories: [".brain"] });
+    const secret = "never-record-this-content";
+    const path = ".brain/never-record-this-path.json";
+
+    await storage.durableFileSystem.writeSynced(path, secret);
+    await storage.durableFileSystem.inspect(path);
+
+    const trace = JSON.stringify(storage.calls());
+    expect(trace).not.toContain(secret);
+    expect(trace).not.toContain(path);
+    expect(storage.calls()).toEqual([
+      "open_file",
+      "write_file",
+      "sync_file",
+      "close_file",
+      "inspect",
+    ]);
+  });
+});

--- a/tests/fake-transactions.test.ts
+++ b/tests/fake-transactions.test.ts
@@ -211,6 +211,212 @@ describe("memory transaction storage", () => {
     ]);
   });
 
+  it.each([
+    {
+      label: "write",
+      mutate: (storage: MemoryTransactionStorage) =>
+        storage.fileSystem.write(".brain/blocker/child.json", "child"),
+    },
+    {
+      label: "makeDirectory",
+      mutate: (storage: MemoryTransactionStorage) =>
+        storage.fileSystem.makeDirectory(".brain/blocker/child"),
+    },
+  ])(
+    "$label refuses a file ancestor without changing the shared model",
+    async ({ mutate }) => {
+      const storage = memoryTransactionStorage({
+        files: { ".brain/blocker": "unchanged" },
+      });
+      const before = storage.snapshot();
+      const encodedBefore = JSON.stringify(before);
+
+      await expect(mutate(storage)).rejects.toThrow("file ancestor");
+
+      expect(storage.snapshot()).toEqual(before);
+      expect(JSON.stringify(storage.snapshot())).toBe(encodedBefore);
+      await expect(
+        storage.durableFileSystem.inspect(".brain/blocker"),
+      ).resolves.toMatchObject({ kind: "file" });
+      await expect(storage.durableFileSystem.list(".brain")).resolves.toEqual([
+        "blocker",
+      ]);
+      await expect(
+        storage.durableFileSystem.inspect(".brain/blocker/child"),
+      ).resolves.toEqual({ kind: "missing" });
+    },
+  );
+
+  it.each([
+    {
+      label: "unsafe directory",
+      seed: { directories: ["../outside"] },
+      message: "escapes the project",
+    },
+    {
+      label: "unsafe file",
+      seed: { files: { "/outside": "content" } },
+      message: "escapes the project",
+    },
+    {
+      label: "file and directory at the same path",
+      seed: {
+        directories: [".brain/conflict"],
+        files: { ".brain/conflict": "content" },
+      },
+      message: "conflicting entries",
+    },
+    {
+      label: "file below a file",
+      seed: {
+        files: {
+          ".brain/file": "parent",
+          ".brain/file/child": "child",
+        },
+      },
+      message: "file ancestor",
+    },
+  ])("rejects a $label seed", ({ seed, message }) => {
+    expect(() => memoryTransactionStorage(seed)).toThrow(message);
+  });
+
+  it("normalizes harmless separators without creating duplicate entries", async () => {
+    const storage = memoryTransactionStorage();
+
+    await storage.fileSystem.write(".brain//./state.json", "state");
+
+    expect(storage.snapshot()).toEqual({
+      files: { ".brain/state.json": "state" },
+      directories: [".brain"],
+    });
+  });
+
+  it.each([
+    {
+      label: "write over a directory",
+      seed: { directories: [".brain/entry"] },
+      mutate: (storage: MemoryTransactionStorage) =>
+        storage.fileSystem.write(".brain/entry", "content"),
+      message: "directory",
+    },
+    {
+      label: "makeDirectory over a file",
+      seed: { files: { ".brain/entry": "content" } },
+      mutate: (storage: MemoryTransactionStorage) =>
+        storage.fileSystem.makeDirectory(".brain/entry"),
+      message: "file",
+    },
+  ])(
+    "refuses $label without changing storage",
+    async ({ seed, mutate, message }) => {
+      const storage = memoryTransactionStorage(seed);
+      const before = storage.snapshot();
+
+      await expect(mutate(storage)).rejects.toThrow(message);
+
+      expect(storage.snapshot()).toEqual(before);
+    },
+  );
+
+  it("removes a complete subtree through the simple view", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/remove/deep", ".brain/keep"],
+      files: {
+        ".brain/remove/a.json": "a",
+        ".brain/remove/deep/b.json": "b",
+        ".brain/keep/state.json": "keep",
+      },
+    });
+
+    await storage.fileSystem.remove(".brain/remove");
+
+    expect(storage.snapshot()).toEqual({
+      files: { ".brain/keep/state.json": "keep" },
+      directories: [".brain", ".brain/keep"],
+    });
+  });
+
+  it.each([
+    {
+      label: "file",
+      seed: { files: { ".brain/entry": "old" } },
+    },
+    {
+      label: "directory",
+      seed: { directories: [".brain/entry"] },
+    },
+  ])("writeSynced refuses an existing $label", async ({ seed }) => {
+    const storage = memoryTransactionStorage(seed);
+    const before = storage.snapshot();
+
+    await expect(
+      storage.durableFileSystem.writeSynced(".brain/entry", "new"),
+    ).rejects.toThrow("already has an entry");
+
+    expect(storage.snapshot()).toEqual(before);
+    expect(storage.calls()).toEqual(["open_file"]);
+  });
+
+  it("createDirectory refuses to replace a file", async () => {
+    const storage = memoryTransactionStorage({
+      files: { ".brain/entry": "content" },
+    });
+    const before = storage.snapshot();
+
+    await expect(
+      storage.durableFileSystem.createDirectory(".brain/entry"),
+    ).rejects.toThrow("has a file");
+
+    expect(storage.snapshot()).toEqual(before);
+  });
+
+  it("createDirectoryExclusive refuses to replace a file", async () => {
+    const storage = memoryTransactionStorage({
+      files: { ".brain/entry": "content" },
+    });
+    const before = storage.snapshot();
+
+    await expect(
+      storage.durableFileSystem.createDirectoryExclusive(".brain/entry"),
+    ).rejects.toThrow("already has an entry");
+
+    expect(storage.snapshot()).toEqual(before);
+  });
+
+  it.each([
+    {
+      label: "staged path is a directory",
+      seed: {
+        directories: [".brain/staged"],
+        files: { ".brain/target": "old" },
+      },
+      message: "no file",
+    },
+    {
+      label: "target path is a directory",
+      seed: {
+        directories: [".brain/target"],
+        files: { ".brain/staged": "new" },
+      },
+      message: "has a directory",
+    },
+  ])("replaceFile refuses when the $label", async ({ seed, message }) => {
+    const storage = memoryTransactionStorage(seed);
+    const before = storage.snapshot();
+
+    await expect(
+      storage.durableFileSystem.replaceFile(".brain/staged", ".brain/target"),
+    ).rejects.toThrow(message);
+
+    expect(storage.snapshot()).toEqual(before);
+  });
+
+  it("rejects the project root as a durable entry path", async () => {
+    await expect(
+      memoryTransactionStorage().durableFileSystem.inspect("."),
+    ).rejects.toThrow("escapes the project");
+  });
+
   it("provides the same deterministic SHA-256 capability as production", () => {
     expect(memoryTransactionStorage().digests.sha256("abc")).toBe(
       "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
@@ -305,6 +511,17 @@ describe("memory transaction storage", () => {
         operation: "inspect",
         timing: "before",
         occurrence: 0,
+      });
+    }).toThrow("positive integer");
+  });
+
+  it("rejects a fractional occurrence", () => {
+    const storage = memoryTransactionStorage();
+    expect(() => {
+      storage.fail({
+        operation: "inspect",
+        timing: "before",
+        occurrence: 1.5,
       });
     }).toThrow("positive integer");
   });

--- a/tests/fake-transactions.test.ts
+++ b/tests/fake-transactions.test.ts
@@ -485,7 +485,12 @@ describe("memory transaction storage", () => {
 
   it("targets an exact occurrence once", async () => {
     const storage = memoryTransactionStorage({ directories: [".brain"] });
-    storage.fail({ operation: "inspect", timing: "before", occurrence: 2 });
+    const rule = {
+      operation: "inspect" as const,
+      timing: "before" as const,
+      occurrence: 2,
+    };
+    storage.fail(rule);
 
     await expect(
       storage.durableFileSystem.inspect(".brain/missing"),
@@ -496,6 +501,27 @@ describe("memory transaction storage", () => {
     await expect(
       storage.durableFileSystem.inspect(".brain/missing"),
     ).resolves.toEqual({ kind: "missing" });
+    expect(storage.failureHits()).toEqual([rule]);
+  });
+
+  it("returns isolated readonly evidence for reached failure rules", async () => {
+    const storage = memoryTransactionStorage();
+    const rule = {
+      operation: "inspect" as const,
+      timing: "after" as const,
+      occurrence: 1,
+      fault: "permission" as const,
+    };
+    storage.fail(rule);
+
+    await expect(
+      storage.durableFileSystem.inspect(".brain/state.json"),
+    ).rejects.toThrow("permission");
+    const first = storage.failureHits();
+    expect(first).toEqual([rule]);
+
+    (first as (typeof rule)[]).push({ ...rule });
+    expect(storage.failureHits()).toEqual([rule]);
   });
 
   it.each(["permission", "disk_full"] as const)(

--- a/tests/fake-transactions.test.ts
+++ b/tests/fake-transactions.test.ts
@@ -417,6 +417,17 @@ describe("memory transaction storage", () => {
     ).rejects.toThrow("escapes the project");
   });
 
+  it("synchronizes the implicit project root without materializing it", async () => {
+    const storage = memoryTransactionStorage();
+
+    await expect(storage.durableFileSystem.syncDirectory(".")).resolves.toBe(
+      "supported",
+    );
+
+    expect(storage.snapshot()).toEqual(empty);
+    expect(storage.calls()).toEqual(["sync_directory"]);
+  });
+
   it("provides the same deterministic SHA-256 capability as production", () => {
     expect(memoryTransactionStorage().digests.sha256("abc")).toBe(
       "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",

--- a/tests/fixtures/transactions/worker.ts
+++ b/tests/fixtures/transactions/worker.ts
@@ -1,0 +1,172 @@
+import {
+  executeManagedMutation,
+  inspectManagedTransactions,
+  recoverManagedMutation,
+  type TransactionServices,
+} from "@mestre-yoda/runtime/composition";
+import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
+import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
+import {
+  nodeDurableFileSystem,
+  sha256Digests,
+  type DurableOperation,
+  type DurableOperationEvent,
+} from "@mestre-yoda/runtime/infra/node";
+
+interface Barrier {
+  readonly name: string;
+  readonly operation: DurableOperation;
+  readonly timing: DurableOperationEvent["timing"];
+  readonly occurrence: number;
+}
+
+interface RecoveryRequest {
+  readonly transactionId: string;
+  readonly recoveryToken: string;
+}
+
+const handshakeTimeoutMilliseconds = 10_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBarrier(encoded: string): Barrier | null {
+  const value: unknown = JSON.parse(encoded);
+  if (value === null) return null;
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    typeof value.operation !== "string" ||
+    (value.timing !== "before" && value.timing !== "after") ||
+    typeof value.occurrence !== "number" ||
+    !Number.isInteger(value.occurrence) ||
+    value.occurrence <= 0
+  ) {
+    throw new Error("Invalid worker barrier");
+  }
+  return value as unknown as Barrier;
+}
+
+function parseRecoveryRequest(value: unknown): RecoveryRequest {
+  if (
+    !isRecord(value) ||
+    typeof value.transactionId !== "string" ||
+    typeof value.recoveryToken !== "string"
+  ) {
+    throw new Error("Invalid worker recovery request");
+  }
+  return {
+    transactionId: value.transactionId,
+    recoveryToken: value.recoveryToken,
+  };
+}
+
+async function send(message: unknown): Promise<void> {
+  if (process.send === undefined) throw new Error("Worker IPC is unavailable");
+  await new Promise<void>((resolve, reject) => {
+    process.send?.(message, (error) => {
+      if (error === null) resolve();
+      else reject(error);
+    });
+  });
+}
+
+async function waitForStart(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      finish(new Error("Worker start handshake timed out"));
+    }, handshakeTimeoutMilliseconds);
+    const onDisconnect = () => {
+      finish(new Error("Worker IPC disconnected"));
+    };
+    const onMessage = (message: unknown) => {
+      if (isRecord(message) && message.kind === "start") finish(null);
+      else finish(new Error("Worker received an invalid start message"));
+    };
+    function finish(error: Error | null): void {
+      clearTimeout(timer);
+      process.off("disconnect", onDisconnect);
+      process.off("message", onMessage);
+      if (error === null) resolve();
+      else reject(error);
+    }
+    process.once("disconnect", onDisconnect);
+    process.once("message", onMessage);
+  });
+}
+
+function services(root: string, barrier: Barrier | null): TransactionServices {
+  const occurrences = new Map<DurableOperation, number>();
+  return {
+    clock: { now: () => new Date("2026-08-09T00:00:00.000Z") },
+    ids: { next: () => "transaction-1" },
+    digests: sha256Digests(),
+    durableFileSystem: nodeDurableFileSystem(root, async (event) => {
+      let occurrence = occurrences.get(event.operation) ?? 0;
+      if (event.timing === "before") {
+        occurrence += 1;
+        occurrences.set(event.operation, occurrence);
+      }
+      if (
+        barrier !== null &&
+        event.operation === barrier.operation &&
+        event.timing === barrier.timing &&
+        occurrence === barrier.occurrence
+      ) {
+        await send({ kind: "barrier", name: barrier.name });
+        await new Promise<void>(() => undefined);
+      }
+    }),
+    schemaRegistry: createSchemaRegistry(),
+  };
+}
+
+async function main(): Promise<void> {
+  const [mode, root, barrierEncoded, valueEncoded] = process.argv.slice(2);
+  if (
+    (mode !== "execute" && mode !== "inspect" && mode !== "recover") ||
+    root === undefined ||
+    barrierEncoded === undefined ||
+    valueEncoded === undefined
+  ) {
+    throw new Error("Invalid worker arguments");
+  }
+  const barrier = parseBarrier(barrierEncoded);
+  const value: unknown = JSON.parse(valueEncoded);
+  await send({ kind: "ready" });
+  await waitForStart();
+  const transactionServices = services(root, barrier);
+
+  let result: unknown;
+  switch (mode) {
+    case "execute":
+      result = await executeManagedMutation(
+        value as ManagedMutationPlan,
+        { rootMode: "existing" },
+        transactionServices,
+      );
+      break;
+    case "inspect":
+      result = await inspectManagedTransactions(transactionServices);
+      break;
+    case "recover":
+      result = await recoverManagedMutation(
+        parseRecoveryRequest(value),
+        transactionServices,
+      );
+      break;
+  }
+  await send({ kind: "result", value: result });
+}
+
+void main().then(
+  () => {
+    process.disconnect();
+  },
+  async () => {
+    await send({ kind: "error" }).catch(() => undefined);
+    process.disconnect();
+    process.exitCode = 1;
+  },
+);

--- a/tests/node-transaction-security.test.ts
+++ b/tests/node-transaction-security.test.ts
@@ -34,6 +34,118 @@ async function temporaryProject<T>(
 }
 
 describe("node durable filesystem security", () => {
+  it("rejects an operation when the canonical root is persistently replaced by a symlink", async () => {
+    const container = await mkdtemp(join(tmpdir(), "yoda-node-root-swap-"));
+    const root = join(container, "project");
+    const displaced = join(container, "project-original");
+    const outside = join(container, "outside");
+    try {
+      await mkdir(join(root, ".brain"), { recursive: true });
+      await mkdir(join(outside, ".brain"), { recursive: true });
+      await writeFile(join(root, ".brain/state.json"), "ORIGINAL", "utf8");
+      await writeFile(join(outside, ".brain/state.json"), "SENTINEL", "utf8");
+      let armed = false;
+      const fileSystem = nodeDurableFileSystem(root, async (event) => {
+        if (
+          armed &&
+          event.operation === "inspect" &&
+          event.timing === "before"
+        ) {
+          await rename(root, displaced);
+          await symlink(outside, root, "dir");
+        }
+      });
+      await expect(
+        fileSystem.inspect(".brain/state.json"),
+      ).resolves.toMatchObject({
+        kind: "file",
+      });
+      armed = true;
+
+      await expect(fileSystem.inspect(".brain/state.json")).rejects.toThrow(
+        "project root changed",
+      );
+
+      expect(await readFile(join(outside, ".brain/state.json"), "utf8")).toBe(
+        "SENTINEL",
+      );
+      expect(await readFile(join(displaced, ".brain/state.json"), "utf8")).toBe(
+        "ORIGINAL",
+      );
+    } finally {
+      await rm(container, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects root directory synchronization after persistent directory substitution", async () => {
+    const container = await mkdtemp(join(tmpdir(), "yoda-node-root-swap-"));
+    const root = join(container, "project");
+    const displaced = join(container, "project-original");
+    try {
+      await mkdir(join(root, ".brain"), { recursive: true });
+      await writeFile(join(root, ".brain/state.json"), "ORIGINAL", "utf8");
+      let armed = false;
+      const fileSystem = nodeDurableFileSystem(root, async (event) => {
+        if (
+          armed &&
+          event.operation === "sync_directory" &&
+          event.timing === "before"
+        ) {
+          await rename(root, displaced);
+          await mkdir(root);
+          await writeFile(join(root, "sentinel.txt"), "SENTINEL", "utf8");
+        }
+      });
+      await fileSystem.inspect(".brain/state.json");
+      armed = true;
+
+      await expect(fileSystem.syncDirectory(".")).rejects.toThrow(
+        "project root changed",
+      );
+
+      expect(await readFile(join(root, "sentinel.txt"), "utf8")).toBe(
+        "SENTINEL",
+      );
+      expect(await readFile(join(displaced, ".brain/state.json"), "utf8")).toBe(
+        "ORIGINAL",
+      );
+    } finally {
+      await rm(container, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects an operation after the canonical root is renamed away", async () => {
+    const container = await mkdtemp(join(tmpdir(), "yoda-node-root-swap-"));
+    const root = join(container, "project");
+    const displaced = join(container, "project-original");
+    try {
+      await mkdir(join(root, ".brain"), { recursive: true });
+      await writeFile(join(root, ".brain/state.json"), "ORIGINAL", "utf8");
+      let armed = false;
+      const fileSystem = nodeDurableFileSystem(root, async (event) => {
+        if (
+          armed &&
+          event.operation === "inspect" &&
+          event.timing === "before"
+        ) {
+          await rename(root, displaced);
+        }
+      });
+      await fileSystem.inspect(".brain/state.json");
+      armed = true;
+
+      await expect(fileSystem.inspect(".brain/state.json")).rejects.toThrow(
+        "project root changed",
+      );
+
+      expect(await readFile(join(displaced, ".brain/state.json"), "utf8")).toBe(
+        "ORIGINAL",
+      );
+    } finally {
+      await rm(container, { force: true, recursive: true });
+    }
+  });
+
   it("refuses internal and escaping symlink ancestors", async () => {
     await temporaryProject(async (root, outside) => {
       await mkdir(join(root, ".brain/real"), { recursive: true });

--- a/tests/node-transaction-security.test.ts
+++ b/tests/node-transaction-security.test.ts
@@ -1,0 +1,260 @@
+import { execFile } from "node:child_process";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { promisify } from "node:util";
+
+import { nodeDurableFileSystem } from "@mestre-yoda/runtime/infra/node";
+import { describe, expect, it } from "vitest";
+
+const run = promisify(execFile);
+
+async function temporaryProject<T>(
+  body: (root: string, outside: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-node-security-"));
+  const outside = await mkdtemp(join(tmpdir(), "yoda-node-outside-"));
+  try {
+    return await body(root, outside);
+  } finally {
+    await Promise.all([
+      rm(root, { force: true, recursive: true }),
+      rm(outside, { force: true, recursive: true }),
+    ]);
+  }
+}
+
+describe("node durable filesystem security", () => {
+  it("refuses internal and escaping symlink ancestors", async () => {
+    await temporaryProject(async (root, outside) => {
+      await mkdir(join(root, ".brain/real"), { recursive: true });
+      const sentinel = join(outside, "sentinel.txt");
+      await writeFile(sentinel, "SAFE", "utf8");
+      await symlink(join(root, ".brain/real"), join(root, ".brain/internal"));
+      await symlink(outside, join(root, ".brain/escaping"));
+      const fileSystem = nodeDurableFileSystem(root);
+
+      for (const path of [
+        ".brain/internal/state.json",
+        ".brain/escaping/state.json",
+      ]) {
+        await expect(fileSystem.inspect(path)).rejects.toThrow("symlink");
+        await expect(fileSystem.writeSynced(path, "PWNED")).rejects.toThrow(
+          "symlink",
+        );
+      }
+
+      expect(await readFile(sentinel, "utf8")).toBe("SAFE");
+      expect(await lstat(join(root, ".brain/real"))).toMatchObject({});
+    });
+  });
+
+  it("observes a final symlink without reading, replacing, or deleting it", async () => {
+    await temporaryProject(async (root, outside) => {
+      await mkdir(join(root, ".brain"));
+      const sentinel = join(outside, "sentinel.txt");
+      await writeFile(sentinel, "SAFE", "utf8");
+      await symlink(sentinel, join(root, ".brain/alias"));
+      const fileSystem = nodeDurableFileSystem(root);
+      await fileSystem.writeSynced(".brain/staged", "PWNED");
+
+      await expect(fileSystem.inspect(".brain/alias")).resolves.toEqual({
+        kind: "symlink",
+      });
+      await expect(fileSystem.readText(".brain/alias")).rejects.toThrow(
+        "regular file",
+      );
+      await expect(fileSystem.removeFile(".brain/alias")).rejects.toThrow(
+        "regular file",
+      );
+      await expect(
+        fileSystem.replaceFile(".brain/staged", ".brain/alias"),
+      ).rejects.toThrow("regular file");
+
+      expect(await readFile(sentinel, "utf8")).toBe("SAFE");
+      expect((await lstat(join(root, ".brain/alias"))).isSymbolicLink()).toBe(
+        true,
+      );
+    });
+  });
+
+  it("classifies a FIFO as special and never opens or removes it", async () => {
+    if (process.platform === "win32") return;
+
+    await temporaryProject(async (root) => {
+      await mkdir(join(root, ".brain"));
+      const fifo = join(root, ".brain/pipe");
+      await run("mkfifo", [fifo]);
+      const fileSystem = nodeDurableFileSystem(root);
+      await fileSystem.writeSynced(".brain/staged", "content");
+
+      await expect(fileSystem.inspect(".brain/pipe")).resolves.toEqual({
+        kind: "special",
+      });
+      await expect(fileSystem.readText(".brain/pipe")).rejects.toThrow(
+        "regular file",
+      );
+      await expect(fileSystem.removeFile(".brain/pipe")).rejects.toThrow(
+        "regular file",
+      );
+      await expect(
+        fileSystem.replaceFile(".brain/staged", ".brain/pipe"),
+      ).rejects.toThrow("regular file");
+      expect((await lstat(fifo)).isFIFO()).toBe(true);
+    });
+  });
+
+  it("refuses to use a directory as a file", async () => {
+    await temporaryProject(async (root) => {
+      await mkdir(join(root, ".brain/directory"), { recursive: true });
+      const fileSystem = nodeDurableFileSystem(root);
+      await fileSystem.writeSynced(".brain/staged", "content");
+
+      await expect(fileSystem.readText(".brain/directory")).rejects.toThrow(
+        "regular file",
+      );
+      await expect(fileSystem.removeFile(".brain/directory")).rejects.toThrow(
+        "regular file",
+      );
+      await expect(
+        fileSystem.replaceFile(".brain/staged", ".brain/directory"),
+      ).rejects.toThrow("regular file");
+      expect((await lstat(join(root, ".brain/directory"))).isDirectory()).toBe(
+        true,
+      );
+    });
+  });
+
+  it("refuses to traverse through a regular-file ancestor", async () => {
+    await temporaryProject(async (root) => {
+      await mkdir(join(root, ".brain"));
+      await writeFile(join(root, ".brain/file"), "content", "utf8");
+
+      await expect(
+        nodeDurableFileSystem(root).inspect(".brain/file/child"),
+      ).rejects.toThrow("ancestor is not a directory");
+    });
+  });
+
+  it("rethrows native no-follow metadata errors", async () => {
+    await temporaryProject(async (root) => {
+      await mkdir(join(root, ".brain"));
+      const tooLong = `x${"x".repeat(300)}`;
+
+      await expect(
+        nodeDurableFileSystem(root).inspect(`.brain/${tooLong}`),
+      ).rejects.toMatchObject({ code: "ENAMETOOLONG" });
+    });
+  });
+
+  it("refuses a case-colliding sibling on a case-sensitive filesystem", async () => {
+    await temporaryProject(async (root) => {
+      await mkdir(join(root, ".brain"));
+      await writeFile(join(root, ".brain/State.json"), "SAFE", "utf8");
+      try {
+        await lstat(join(root, ".brain/state.json"));
+        return;
+      } catch (error) {
+        if (
+          error === null ||
+          typeof error !== "object" ||
+          !("code" in error) ||
+          error.code !== "ENOENT"
+        ) {
+          throw error;
+        }
+      }
+      const fileSystem = nodeDurableFileSystem(root);
+
+      await expect(fileSystem.inspect(".brain/state.json")).rejects.toThrow(
+        "case collision",
+      );
+      await expect(
+        fileSystem.writeSynced(".brain/state.json", "PWNED"),
+      ).rejects.toThrow("case collision");
+      expect(await readFile(join(root, ".brain/State.json"), "utf8")).toBe(
+        "SAFE",
+      );
+    });
+  });
+
+  it("revalidates parents after an observation before atomic replacement", async () => {
+    await temporaryProject(async (root, outside) => {
+      await mkdir(join(root, ".brain/destination"), { recursive: true });
+      const sentinel = join(outside, "sentinel.txt");
+      await writeFile(sentinel, "SAFE", "utf8");
+      let substitute = false;
+      const fileSystem = nodeDurableFileSystem(root, async (event) => {
+        if (
+          substitute &&
+          event.operation === "replace_file" &&
+          event.timing === "before"
+        ) {
+          await rename(
+            join(root, ".brain/destination"),
+            join(root, ".brain/destination-original"),
+          );
+          await symlink(outside, join(root, ".brain/destination"));
+        }
+      });
+      await fileSystem.writeSynced(".brain/staged", "PWNED");
+      await expect(
+        fileSystem.inspect(".brain/destination/state.json"),
+      ).resolves.toEqual({ kind: "missing" });
+      substitute = true;
+
+      await expect(
+        fileSystem.replaceFile(
+          ".brain/staged",
+          ".brain/destination/state.json",
+        ),
+      ).rejects.toThrow("symlink");
+
+      expect(await readFile(sentinel, "utf8")).toBe("SAFE");
+      await expect(
+        readFile(join(outside, "state.json"), "utf8"),
+      ).rejects.toThrow();
+      expect(await readFile(join(root, ".brain/staged"), "utf8")).toBe("PWNED");
+    });
+  });
+
+  it.each([
+    [
+      "traversal",
+      (root: string, outside: string) =>
+        relative(root, join(outside, "sentinel.txt")),
+    ],
+    [
+      "absolute",
+      (_root: string, outside: string) => join(outside, "sentinel.txt"),
+    ],
+    ["drive", () => "C:/sentinel.txt"],
+    ["backslash", () => ".brain\\sentinel.txt"],
+    ["control", () => ".brain/sentinel\n.txt"],
+  ])(
+    "refuses %s paths without changing an external sentinel",
+    async (_label, candidate) => {
+      await temporaryProject(async (root, outside) => {
+        await mkdir(join(root, ".brain"));
+        const sentinel = join(outside, "sentinel.txt");
+        await writeFile(sentinel, "SAFE", "utf8");
+        const fileSystem = nodeDurableFileSystem(root);
+
+        await expect(
+          fileSystem.writeSynced(candidate(root, outside), "PWNED"),
+        ).rejects.toThrow("escapes the project");
+
+        expect(await readFile(sentinel, "utf8")).toBe("SAFE");
+      });
+    },
+  );
+});

--- a/tests/node-transactions.test.ts
+++ b/tests/node-transactions.test.ts
@@ -1,0 +1,231 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  nodeDurableFileSystem,
+  type DurableOperation,
+  type DurableOperationEvent,
+} from "@mestre-yoda/runtime/infra/node";
+import { isUnsupportedDirectorySyncError } from "../packages/runtime/src/infra/node/transactions.js";
+import { describe, expect, it } from "vitest";
+
+async function temporaryProject<T>(
+  body: (root: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-node-transactions-"));
+  try {
+    return await body(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+describe("node durable filesystem operations", () => {
+  it("observes the exact before and after boundaries of a synced write", async () => {
+    await temporaryProject(async (root) => {
+      const events: DurableOperationEvent[] = [];
+      const fileSystem = nodeDurableFileSystem(root, (event) => {
+        events.push(event);
+        return Promise.resolve();
+      });
+      await fileSystem.createDirectory(".brain");
+      events.length = 0;
+
+      await fileSystem.writeSynced(".brain/state.json", "state");
+
+      expect(events).toEqual([
+        { operation: "open_file", timing: "before" },
+        { operation: "open_file", timing: "after" },
+        { operation: "write_file", timing: "before" },
+        { operation: "write_file", timing: "after" },
+        { operation: "sync_file", timing: "before" },
+        { operation: "sync_file", timing: "after" },
+        { operation: "close_file", timing: "before" },
+        { operation: "close_file", timing: "after" },
+      ]);
+      expect(await readFile(join(root, ".brain/state.json"), "utf8")).toBe(
+        "state",
+      );
+    });
+  });
+
+  it("closes an exclusively opened file when a later boundary fails", async () => {
+    await temporaryProject(async (root) => {
+      const events: DurableOperationEvent[] = [];
+      const failure = new Error("stop before write");
+      const fileSystem = nodeDurableFileSystem(root, (event) => {
+        events.push(event);
+        return event.operation === "write_file" && event.timing === "before"
+          ? Promise.reject(failure)
+          : Promise.resolve();
+      });
+      await fileSystem.createDirectory(".brain");
+      events.length = 0;
+
+      await expect(
+        fileSystem.writeSynced(".brain/state.json", "state"),
+      ).rejects.toBe(failure);
+
+      expect(events).toContainEqual({
+        operation: "close_file",
+        timing: "after",
+      });
+      await expect(fileSystem.removeFile(".brain/state.json")).resolves.toBe(
+        undefined,
+      );
+    });
+  });
+
+  it.each(["before", "after"] as const)(
+    "models a %s-effect atomic replacement failure",
+    async (timing) => {
+      await temporaryProject(async (root) => {
+        const failure = new Error(`${timing} replacement`);
+        let armed = false;
+        const fileSystem = nodeDurableFileSystem(root, (event) =>
+          armed && event.operation === "replace_file" && event.timing === timing
+            ? Promise.reject(failure)
+            : Promise.resolve(),
+        );
+        await fileSystem.createDirectory(".brain");
+        await fileSystem.writeSynced(".brain/staged", "new");
+        await fileSystem.writeSynced(".brain/target", "old");
+        armed = true;
+
+        await expect(
+          fileSystem.replaceFile(".brain/staged", ".brain/target"),
+        ).rejects.toBe(failure);
+
+        expect(await readFile(join(root, ".brain/target"), "utf8")).toBe(
+          timing === "before" ? "old" : "new",
+        );
+        if (timing === "before") {
+          await expect(
+            readFile(join(root, ".brain/staged"), "utf8"),
+          ).resolves.toBe("new");
+        } else {
+          await expect(
+            readFile(join(root, ".brain/staged"), "utf8"),
+          ).rejects.toThrow();
+        }
+      });
+    },
+  );
+
+  it("emits paired observer events for every durable operation", async () => {
+    await temporaryProject(async (root) => {
+      const events: DurableOperationEvent[] = [];
+      const fileSystem = nodeDurableFileSystem(root, (event) => {
+        events.push(event);
+        return Promise.resolve();
+      });
+
+      await fileSystem.createDirectory(".brain");
+      await fileSystem.createDirectory(".brain/run");
+      await fileSystem.createDirectoryExclusive(".brain/exclusive");
+      await fileSystem.writeSynced(".brain/staged", "content");
+      await fileSystem.inspect(".brain/staged");
+      await fileSystem.readText(".brain/staged");
+      await fileSystem.list(".brain");
+      await fileSystem.syncDirectory(".brain");
+      await fileSystem.replaceFile(".brain/staged", ".brain/target");
+      await fileSystem.removeFile(".brain/target");
+      await fileSystem.removeEmptyDirectory(".brain/run");
+
+      const operations: readonly DurableOperation[] = [
+        "inspect",
+        "list",
+        "read_text",
+        "create_directory",
+        "create_directory_exclusive",
+        "open_file",
+        "write_file",
+        "sync_file",
+        "close_file",
+        "replace_file",
+        "remove_file",
+        "remove_empty_directory",
+        "sync_directory",
+      ];
+      for (const operation of operations) {
+        expect(events).toContainEqual({ operation, timing: "before" });
+        expect(events).toContainEqual({ operation, timing: "after" });
+      }
+    });
+  });
+
+  it("never downgrades an observer sync error into an unsupported capability", async () => {
+    await temporaryProject(async (root) => {
+      const failure = Object.assign(new Error("synthetic sync failure"), {
+        code: "EINVAL",
+      });
+      const fileSystem = nodeDurableFileSystem(root, (event) =>
+        event.operation === "sync_directory" && event.timing === "before"
+          ? Promise.reject(failure)
+          : Promise.resolve(),
+      );
+
+      await expect(fileSystem.syncDirectory(".")).rejects.toBe(failure);
+    });
+  });
+
+  it("downgrades only Windows EISDIR for directory synchronization", () => {
+    const error = (code: string): NodeJS.ErrnoException =>
+      Object.assign(new Error(code), { code });
+
+    expect(isUnsupportedDirectorySyncError(error("EISDIR"), "win32")).toBe(
+      true,
+    );
+    for (const code of ["EACCES", "EBADF", "EINVAL", "ENOTSUP", "EPERM"]) {
+      expect(isUnsupportedDirectorySyncError(error(code), "win32"), code).toBe(
+        false,
+      );
+    }
+    expect(isUnsupportedDirectorySyncError(error("EISDIR"), "linux")).toBe(
+      false,
+    );
+    expect(isUnsupportedDirectorySyncError(error("EISDIR"), "darwin")).toBe(
+      false,
+    );
+    expect(isUnsupportedDirectorySyncError(null, "win32")).toBe(false);
+    expect(isUnsupportedDirectorySyncError("EISDIR", "win32")).toBe(false);
+    expect(isUnsupportedDirectorySyncError(new Error("EISDIR"), "win32")).toBe(
+      false,
+    );
+  });
+
+  it("rejects a non-directory project root", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "yoda-node-root-file-"));
+    const root = join(directory, "project");
+    try {
+      await writeFile(root, "not a directory", "utf8");
+
+      await expect(
+        nodeDurableFileSystem(root).inspect(".brain"),
+      ).rejects.toThrow("not a directory");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("refuses to truncate an existing file or replace an existing directory", async () => {
+    await temporaryProject(async (root) => {
+      const fileSystem = nodeDurableFileSystem(root);
+      await fileSystem.createDirectory(".brain");
+      await writeFile(join(root, ".brain/state.json"), "original", "utf8");
+      await fileSystem.createDirectory(".brain/directory");
+
+      await expect(
+        fileSystem.writeSynced(".brain/state.json", "replacement"),
+      ).rejects.toThrow();
+      await expect(
+        fileSystem.writeSynced(".brain/directory", "replacement"),
+      ).rejects.toThrow();
+
+      expect(await readFile(join(root, ".brain/state.json"), "utf8")).toBe(
+        "original",
+      );
+    });
+  });
+});

--- a/tests/package-verifier.test.ts
+++ b/tests/package-verifier.test.ts
@@ -5,6 +5,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
   writeFile,
 } from "node:fs/promises";
@@ -122,7 +123,7 @@ describe("package verifier", () => {
     expect(verify).toThrow();
   });
 
-  it("runs every orientation command from an isolated three-file copy", async () => {
+  it("runs every orientation command from an isolated three-file plugin", async () => {
     const cleanRoom = await mkdtemp(join(tmpdir(), "yoda-package-verifier-"));
     try {
       const runtime = join(cleanRoom, "runtime");
@@ -133,11 +134,19 @@ describe("package verifier", () => {
           join(runtime, staged),
         );
       }
+      expect((await readdir(cleanRoom)).sort()).toEqual(["runtime"]);
+      expect((await readdir(runtime)).sort()).toEqual([
+        "manifest.json",
+        "yoda.core.mjs",
+        "yoda.mjs",
+      ]);
 
       const isolatedEntry = join(runtime, "yoda.mjs");
       for (const [argument, accepts] of [
         ["--help", (stdout: string) => stdout.startsWith("Usage: yoda ")],
+        ["help", (stdout: string) => stdout.startsWith("Usage: yoda ")],
         ["--version", (stdout: string) => stdout === "0.0.0-development\n"],
+        ["version", (stdout: string) => stdout === "0.0.0-development\n"],
         [
           "handshake",
           (stdout: string) =>
@@ -161,6 +170,7 @@ describe("package verifier", () => {
         expect(result.stderr).toBe("");
         expect(accepts(result.stdout)).toBe(true);
       }
+      expect((await readdir(cleanRoom)).sort()).toEqual(["runtime"]);
     } finally {
       await rm(cleanRoom, { force: true, recursive: true });
     }

--- a/tests/ports-contract.test.ts
+++ b/tests/ports-contract.test.ts
@@ -28,6 +28,7 @@ import {
   nodeIds,
   nodeLocks,
   nodeOutput,
+  nodeDurableFileSystem,
 } from "@mestre-yoda/runtime/infra/node";
 import { describe, expect, expectTypeOf, it } from "vitest";
 
@@ -62,6 +63,14 @@ describeDurableFileSystemContract("memory", () => {
     port: storage.durableFileSystem,
     dispose: noDispose,
   });
+});
+
+describeDurableFileSystemContract("node", async () => {
+  const root = await mkdtemp(join(tmpdir(), "yoda-transaction-port-"));
+  return {
+    port: nodeDurableFileSystem(root),
+    dispose: () => rm(root, { force: true, recursive: true }),
+  };
 });
 
 describeClockContract("fixed", () => fixedClock("2026-08-07T00:00:00.000Z"));

--- a/tests/ports-contract.test.ts
+++ b/tests/ports-contract.test.ts
@@ -28,7 +28,7 @@ import {
   nodeLocks,
   nodeOutput,
 } from "@mestre-yoda/runtime/infra/node";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
 import {
   describeClockContract,
@@ -39,8 +39,21 @@ import {
   describeLocksContract,
   describeOutputContract,
 } from "./support/port-contracts.js";
+import {
+  describeDurableFileSystemContract,
+  type DurableFileSystemContractFactory,
+} from "./support/transaction-port-contract.js";
 
 const noDispose = (): Promise<void> => Promise.resolve();
+
+describe("durable filesystem contract suite", () => {
+  it("is ready for the memory and Node factories introduced by later tasks", () => {
+    expectTypeOf(describeDurableFileSystemContract).toEqualTypeOf<
+      (label: string, factory: DurableFileSystemContractFactory) => void
+    >();
+    expect(describeDurableFileSystemContract).toBeTypeOf("function");
+  });
+});
 
 describeClockContract("fixed", () => fixedClock("2026-08-07T00:00:00.000Z"));
 describeIdsContract("sequential", () => sequentialIds());

--- a/tests/ports-contract.test.ts
+++ b/tests/ports-contract.test.ts
@@ -15,6 +15,7 @@ import {
   fixedEnvironment,
   memoryFileSystem,
   memoryLocks,
+  memoryTransactionStorage,
   recordingOutput,
   sequentialIds,
   stubGit,
@@ -47,11 +48,19 @@ import {
 const noDispose = (): Promise<void> => Promise.resolve();
 
 describe("durable filesystem contract suite", () => {
-  it("is ready for the memory and Node factories introduced by later tasks", () => {
+  it("exports the reusable contract factory shape", () => {
     expectTypeOf(describeDurableFileSystemContract).toEqualTypeOf<
       (label: string, factory: DurableFileSystemContractFactory) => void
     >();
     expect(describeDurableFileSystemContract).toBeTypeOf("function");
+  });
+});
+
+describeDurableFileSystemContract("memory", () => {
+  const storage = memoryTransactionStorage();
+  return Promise.resolve({
+    port: storage.durableFileSystem,
+    dispose: noDispose,
   });
 });
 
@@ -60,6 +69,12 @@ describeIdsContract("sequential", () => sequentialIds());
 describeFileSystemContract("memory", () =>
   Promise.resolve({
     port: memoryFileSystem(),
+    dispose: noDispose,
+  }),
+);
+describeFileSystemContract("memory transaction storage", () =>
+  Promise.resolve({
+    port: memoryTransactionStorage().fileSystem,
     dispose: noDispose,
   }),
 );

--- a/tests/result-contract-checker.test.ts
+++ b/tests/result-contract-checker.test.ts
@@ -103,6 +103,18 @@ describe("result contract completeness CLI", () => {
     );
   });
 
+  it("accepts a no-op result when its reason permits mutation", async () => {
+    const paths = await mutationPaths((_catalog, examples) => {
+      const success = examples.find(({ exitCode }) => exitCode === 0);
+      if (success === undefined) throw new Error("missing success example");
+      success.stateChanged = false;
+    });
+
+    const result = run(...paths);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
   it.each([
     [
       "missing legacy reason",
@@ -148,14 +160,6 @@ describe("result contract completeness CLI", () => {
         const blocked = examples.find(({ exitCode }) => exitCode === 3);
         if (blocked === undefined) throw new Error("missing blocked example");
         blocked.stateChanged = true;
-      },
-    ],
-    [
-      "missing mutation claim",
-      (_catalog: JsonObject, examples: JsonObject[]) => {
-        const success = examples.find(({ exitCode }) => exitCode === 0);
-        if (success === undefined) throw new Error("missing success example");
-        success.stateChanged = false;
       },
     ],
     [

--- a/tests/result-validation.test.ts
+++ b/tests/result-validation.test.ts
@@ -31,16 +31,14 @@ describe("result validation", () => {
     );
   });
 
-  it("rejects a missing state mutation claim", () => {
+  it("accepts no mutation when the reason only permits a state change", () => {
     const result = {
       ...resultFor("trail.ok", {
         evidence: [{ kind: "event", ref: ".brain/events.jsonl" }],
       }),
       stateChanged: false,
     };
-    expect(() => validateResult(result)).toThrow(
-      "state mutation claim conflicts with its reason",
-    );
+    expect(validateResult(result)).toEqual(result);
   });
 
   it("rejects forbidden evidence", () => {

--- a/tests/runtime-composition.test.ts
+++ b/tests/runtime-composition.test.ts
@@ -5,14 +5,19 @@ import {
   configurationValidator,
   createRuntime,
   createSchemaRegistry,
+  TransactionFailure,
 } from "@mestre-yoda/runtime/composition";
 import {
   fixedClock,
-  memoryFileSystem,
   memoryTransactionStorage,
   recordingOutput,
   sequentialIds,
 } from "@mestre-yoda/runtime/infra/fake";
+import type {
+  DurableEntry,
+  DurableFileSystem,
+  FileSystem,
+} from "@mestre-yoda/runtime/ports";
 import { describe, expect, it } from "vitest";
 
 describe("composition root", () => {
@@ -64,78 +69,626 @@ describe("composition root", () => {
 });
 
 describe("effect plan application", () => {
-  function fakeRuntime() {
+  function fakeRuntime(
+    seed: Parameters<typeof memoryTransactionStorage>[0] = {
+      directories: [".brain", ".brain/transactions"],
+    },
+  ) {
     const output = recordingOutput();
-    const fileSystem = memoryFileSystem();
+    const storage = memoryTransactionStorage(seed);
     return {
       output,
-      fileSystem,
+      storage,
       ports: createRuntime({
-        clock: fixedClock("2026-08-07T00:00:00.000Z"),
-        ids: sequentialIds(),
-        fileSystem,
+        clock: fixedClock("2026-08-09T00:00:00.000Z"),
+        ids: sequentialIds("transaction"),
+        fileSystem: storage.fileSystem,
+        durableFileSystem: storage.durableFileSystem,
+        digests: storage.digests,
         output,
       }),
     };
   }
 
-  it("applies effects in declared order", async () => {
-    const { fileSystem, ports } = fakeRuntime();
+  it("commits managed effects in their declared order", async () => {
+    const { storage, ports } = fakeRuntime({
+      directories: [".brain", ".brain/transactions"],
+      files: { ".brain/delete.json": "old" },
+    });
 
     await applyPlan(
       planOf(
-        { kind: "write_file", path: "a.txt", content: "first" },
-        { kind: "write_file", path: "a.txt", content: "second" },
+        { kind: "create_directory", path: ".brain/nested" },
+        {
+          kind: "write_file",
+          path: ".brain/nested/first.json",
+          content: "one",
+        },
+        {
+          kind: "write_file",
+          path: ".brain/second.json",
+          content: "two",
+        },
+        { kind: "delete_file", path: ".brain/delete.json" },
       ),
       ports,
     );
 
-    expect(await fileSystem.read("a.txt")).toBe("second");
+    const snapshot = storage.snapshot();
+    expect(snapshot.files[".brain/nested/first.json"]).toBe("one");
+    expect(snapshot.files[".brain/second.json"]).toBe("two");
+    expect(snapshot.files).not.toHaveProperty(".brain/delete.json");
+    const manifest = JSON.parse(
+      snapshot.files[".brain/transactions/transaction-1/manifest.json"] ?? "",
+    ) as { operations: readonly { path: string }[] };
+    expect(manifest.operations.map(({ path }) => path)).toEqual([
+      ".brain/nested",
+      ".brain/nested/first.json",
+      ".brain/second.json",
+      ".brain/delete.json",
+    ]);
   });
 
-  it("performs every effect kind", async () => {
-    const { fileSystem, output, ports } = fakeRuntime();
+  it("does not apply a valid prefix when a later destination is forbidden", async () => {
+    const { storage, ports } = fakeRuntime();
+
+    await expect(
+      applyPlan(
+        planOf(
+          {
+            kind: "write_file",
+            path: ".brain/first.json",
+            content: "one",
+          },
+          {
+            kind: "write_file",
+            path: ".brain/transactions/forbidden",
+            content: "two",
+          },
+        ),
+        ports,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "guard.outside_allow" });
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/first.json");
+    expect(storage.calls()).not.toContain("create_directory_exclusive");
+  });
+
+  it("emits in declared output order only after the transaction commits", async () => {
+    const output = recordingOutput();
+    const storage = memoryTransactionStorage({
+      directories: [".brain", ".brain/transactions"],
+    });
+    const phasesAtOutput: string[] = [];
+    const observeCommitted = (): void => {
+      const progress = JSON.parse(
+        storage.snapshot().files[
+          ".brain/transactions/transaction-1/progress.json"
+        ] ?? "",
+      ) as { phase: string };
+      phasesAtOutput.push(progress.phase);
+    };
+    const ports = createRuntime({
+      clock: fixedClock("2026-08-09T00:00:00.000Z"),
+      ids: sequentialIds("transaction"),
+      fileSystem: storage.fileSystem,
+      durableFileSystem: storage.durableFileSystem,
+      digests: storage.digests,
+      output: {
+        structured(text) {
+          observeCommitted();
+          output.structured(text);
+        },
+        human(text) {
+          observeCommitted();
+          output.human(text);
+        },
+      },
+    });
 
     await applyPlan(
       planOf(
-        { kind: "create_directory", path: ".brain" },
-        { kind: "write_file", path: ".brain/state.json", content: "{}" },
-        { kind: "write_file", path: ".brain/scratch.json", content: "{}" },
-        { kind: "delete_file", path: ".brain/scratch.json" },
-        { kind: "append_event", event: "started" },
-        { kind: "emit", channel: "structured", text: "{}\n" },
-        { kind: "emit", channel: "human", text: "ok\n" },
+        {
+          kind: "emit",
+          channel: "structured",
+          text: "first\n",
+        },
+        {
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        },
+        { kind: "emit", channel: "human", text: "second\n" },
+        { kind: "emit", channel: "structured", text: "third\n" },
       ),
       ports,
     );
 
-    expect(await fileSystem.read(".brain/state.json")).toBe("{}");
-    expect(await fileSystem.stat(".brain/scratch.json")).toBeNull();
-    expect(await fileSystem.read(".brain/events.jsonl")).toBe("started\n");
-    expect(output.structured_).toEqual(["{}\n"]);
-    expect(output.human_).toEqual(["ok\n"]);
+    expect(phasesAtOutput).toEqual(["committed", "committed", "committed"]);
+    expect(output.structured_).toEqual(["first\n", "third\n"]);
+    expect(output.human_).toEqual(["second\n"]);
   });
 
-  it("appends to an existing event log instead of replacing it", async () => {
-    const { fileSystem, ports } = fakeRuntime();
+  it("emits nothing when publication does not commit", async () => {
+    const { storage, output, ports } = fakeRuntime();
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      replaceFile(stagedPath, targetPath) {
+        if (targetPath === ".brain/state.json") {
+          return Promise.reject(new Error("publication stopped"));
+        }
+        return storage.durableFileSystem.replaceFile(stagedPath, targetPath);
+      },
+    };
 
-    await applyPlan(planOf({ kind: "append_event", event: "first" }), ports);
-    await applyPlan(planOf({ kind: "append_event", event: "second" }), ports);
+    await expect(
+      applyPlan(
+        planOf(
+          { kind: "emit", channel: "human", text: "not yet\n" },
+          {
+            kind: "write_file",
+            path: ".brain/state.json",
+            content: "state",
+          },
+        ),
+        { ...ports, durableFileSystem },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    expect(output.human_).toEqual([]);
+    expect(output.structured_).toEqual([]);
+  });
 
-    // Truncating here would be silent, unrecoverable loss in the precursor to
-    // the event store.
-    expect(await fileSystem.read(".brain/events.jsonl")).toBe(
-      "first\nsecond\n",
+  it("refuses append_event until the canonical append operation exists", async () => {
+    const { storage, ports } = fakeRuntime();
+
+    await expect(
+      applyPlan(
+        planOf(
+          {
+            kind: "write_file",
+            path: ".brain/state.json",
+            content: "state",
+          },
+          { kind: "append_event", event: "payload-must-not-appear" },
+        ),
+        ports,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain/events.jsonl" },
+      ]),
+    );
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/state.json");
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/events.jsonl");
+  });
+
+  it.each(["special", "symlink"] as const)(
+    "rejects a %s managed-path observation before creating a transaction",
+    async (kind) => {
+      const { storage, ports } = fakeRuntime();
+      const durableFileSystem: DurableFileSystem = {
+        ...storage.durableFileSystem,
+        inspect(path): Promise<DurableEntry> {
+          if (path === ".brain/state.json") return Promise.resolve({ kind });
+          return storage.durableFileSystem.inspect(path);
+        },
+      };
+
+      await expect(
+        applyPlan(
+          planOf({
+            kind: "write_file",
+            path: ".brain/state.json",
+            content: "state",
+          }),
+          { ...ports, durableFileSystem },
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: ".brain/state.json" },
+        ]),
+      );
+      expect(storage.calls()).not.toContain("create_directory_exclusive");
+    },
+  );
+
+  it.each(["file", "special", "symlink"] as const)(
+    "observes and rejects a %s managed root before descendant paths",
+    async (kind) => {
+      const { storage, ports } = fakeRuntime();
+      const inspected: string[] = [];
+      const durableFileSystem: DurableFileSystem = {
+        ...storage.durableFileSystem,
+        inspect(path): Promise<DurableEntry> {
+          inspected.push(path);
+          if (path === ".brain") {
+            return Promise.resolve(
+              kind === "file"
+                ? { kind, size: 0, sha256: storage.digests.sha256("") }
+                : { kind },
+            );
+          }
+          return Promise.reject(new Error("descendant must not be observed"));
+        },
+      };
+
+      await expect(
+        applyPlan(
+          planOf({
+            kind: "write_file",
+            path: ".brain/state.json",
+            content: "state",
+          }),
+          { ...ports, durableFileSystem },
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: ".brain" },
+        ]),
+      );
+      expect(inspected).toEqual([".brain"]);
+    },
+  );
+
+  it("sanitizes an unexpected durable observation failure", async () => {
+    const { storage, ports } = fakeRuntime();
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      inspect(path) {
+        if (path === ".brain/state.json") {
+          return Promise.reject(new Error("/absolute/private-payload"));
+        }
+        return storage.durableFileSystem.inspect(path);
+      },
+    };
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        }),
+        { ...ports, durableFileSystem },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+
+  it("sanitizes an unexpected no-op marker inspection failure", async () => {
+    const { storage, ports } = fakeRuntime({
+      directories: [".brain", ".brain/transactions"],
+      files: { ".brain/state.json": "same" },
+    });
+    let brainInspections = 0;
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      inspect(path) {
+        if (path === ".brain" && ++brainInspections === 2) {
+          return Promise.reject(new Error("/absolute/private-marker"));
+        }
+        return storage.durableFileSystem.inspect(path);
+      },
+    };
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "same",
+        }),
+        { ...ports, durableFileSystem },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+
+  it("sanitizes an unexpected no-op transaction-list failure", async () => {
+    const { storage, ports } = fakeRuntime({
+      directories: [".brain", ".brain/transactions"],
+      files: { ".brain/state.json": "same" },
+    });
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      list(path) {
+        if (path === ".brain/transactions") {
+          return Promise.reject(new Error("/absolute/private-marker"));
+        }
+        return storage.durableFileSystem.list(path);
+      },
+    };
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "same",
+        }),
+        { ...ports, durableFileSystem },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+
+  it("sanitizes an unexpected digest failure during normalization", async () => {
+    const { ports } = fakeRuntime();
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "private-payload",
+        }),
+        {
+          ...ports,
+          digests: {
+            sha256() {
+              throw new Error("/absolute/private-payload");
+            },
+          },
+        },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+
+  it("rejects malformed managed relationships before mutation", async () => {
+    const { storage, ports } = fakeRuntime();
+
+    await expect(
+      applyPlan(
+        planOf(
+          { kind: "delete_file", path: ".brain/parent" },
+          {
+            kind: "write_file",
+            path: ".brain/parent/child.json",
+            content: "child",
+          },
+        ),
+        ports,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.calls()).not.toContain("create_directory_exclusive");
+  });
+
+  it.each([
+    "",
+    ".brain\\state.json",
+    "C:/state.json",
+    ".brain/state.json\n",
+    ".brain",
+    "outside/state.json",
+    ".brain//state.json",
+    ".brain/./state.json",
+    ".brain/../state.json",
+  ])(
+    "rejects malformed destination spelling %j before mutation",
+    async (path) => {
+      const { storage, ports } = fakeRuntime();
+
+      await expect(
+        applyPlan(
+          planOf({ kind: "write_file", path, content: "state" }),
+          ports,
+        ),
+      ).rejects.toMatchObject({ reasonCode: "guard.outside_allow" });
+      expect(storage.calls()).not.toContain("create_directory_exclusive");
+    },
+  );
+
+  it("does not create a marker for a satisfied no-op plan", async () => {
+    const { storage, ports } = fakeRuntime({
+      directories: [".brain", ".brain/transactions"],
+      files: { ".brain/state.json": "same" },
+    });
+
+    await applyPlan(
+      planOf({
+        kind: "write_file",
+        path: ".brain/state.json",
+        content: "same",
+      }),
+      ports,
+    );
+
+    expect(storage.snapshot().directories).toEqual([
+      ".brain",
+      ".brain/transactions",
+    ]);
+    expect(storage.calls()).not.toContain("create_directory_exclusive");
+  });
+
+  it("observes an already-satisfied managed directory as a no-op", async () => {
+    const { storage, ports } = fakeRuntime({
+      directories: [".brain", ".brain/transactions", ".brain/existing"],
+    });
+
+    await applyPlan(
+      planOf({ kind: "create_directory", path: ".brain/existing" }),
+      ports,
+    );
+
+    expect(storage.calls()).not.toContain("create_directory_exclusive");
+  });
+
+  it("refuses a no-op mutation while an incomplete marker exists", async () => {
+    const { storage, output, ports } = fakeRuntime();
+    const interrupted: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      replaceFile(stagedPath, targetPath) {
+        if (targetPath === ".brain/state.json") {
+          return Promise.reject(new Error("publication stopped"));
+        }
+        return storage.durableFileSystem.replaceFile(stagedPath, targetPath);
+      },
+    };
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        }),
+        { ...ports, durableFileSystem: interrupted },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+
+    await expect(
+      applyPlan(
+        planOf(
+          { kind: "delete_file", path: ".brain/state.json" },
+          { kind: "emit", channel: "human", text: "not available\n" },
+        ),
+        ports,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ]),
+    );
+    expect(output.human_).toEqual([]);
+  });
+
+  it("lets the transaction driver reconcile a safe unmarked crash directory", async () => {
+    const { storage, ports } = fakeRuntime({
+      directories: [
+        ".brain",
+        ".brain/transactions",
+        ".brain/transactions/orphan",
+      ],
+    });
+
+    await applyPlan(
+      planOf({
+        kind: "write_file",
+        path: ".brain/state.json",
+        content: "state",
+      }),
+      ports,
+    );
+
+    expect(storage.snapshot().directories).not.toContain(
+      ".brain/transactions/orphan",
+    );
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("state");
+  });
+
+  it("defaults to an existing root and bootstraps only when explicit", async () => {
+    const refused = fakeRuntime({});
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        }),
+        refused.ports,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(refused.storage.snapshot().directories).toEqual([]);
+
+    const initialized = fakeRuntime({});
+    await applyPlan(
+      planOf({
+        kind: "write_file",
+        path: ".brain/state.json",
+        content: "state",
+      }),
+      initialized.ports,
+      { rootMode: "initialize" },
+    );
+    expect(initialized.storage.snapshot().files[".brain/state.json"]).toBe(
+      "state",
     );
   });
 
-  it("produces byte-identical output across two fixed runs", async () => {
+  it.each([
+    { directories: [] as readonly string[], evidenceRef: ".brain" },
+    {
+      directories: [".brain"] as readonly string[],
+      evidenceRef: ".brain/transactions",
+    },
+  ])(
+    "applies existing-root policy to a no-op when $evidenceRef is missing",
+    async ({ directories, evidenceRef }) => {
+      const { storage, ports } = fakeRuntime({ directories });
+
+      await expect(
+        applyPlan(
+          planOf({ kind: "delete_file", path: ".brain/missing.json" }),
+          ports,
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: evidenceRef },
+        ]),
+      );
+      expect(storage.snapshot().directories).toEqual(directories);
+    },
+  );
+
+  it("keeps an explicit initialize no-op free of bootstrap metadata", async () => {
+    const { storage, ports } = fakeRuntime({});
+
+    await applyPlan(
+      planOf({ kind: "delete_file", path: ".brain/missing.json" }),
+      ports,
+      { rootMode: "initialize" },
+    );
+
+    expect(storage.snapshot()).toEqual({ files: {}, directories: [] });
+    expect(storage.calls()).not.toContain("create_directory_exclusive");
+  });
+
+  it("never uses the ordinary filesystem for managed mutations", async () => {
+    const { storage, ports } = fakeRuntime();
+    const used: (keyof FileSystem)[] = [];
+    const fileSystem: FileSystem = {
+      read(path) {
+        used.push("read");
+        return storage.fileSystem.read(path);
+      },
+      write(path, content) {
+        used.push("write");
+        return storage.fileSystem.write(path, content);
+      },
+      remove(path) {
+        used.push("remove");
+        return storage.fileSystem.remove(path);
+      },
+      makeDirectory(path) {
+        used.push("makeDirectory");
+        return storage.fileSystem.makeDirectory(path);
+      },
+      list(path) {
+        used.push("list");
+        return storage.fileSystem.list(path);
+      },
+      stat(path) {
+        used.push("stat");
+        return storage.fileSystem.stat(path);
+      },
+    };
+
+    await applyPlan(
+      planOf({
+        kind: "write_file",
+        path: ".brain/state.json",
+        content: "state",
+      }),
+      { ...ports, fileSystem },
+    );
+
+    expect(used).toEqual([]);
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("state");
+  });
+
+  it("produces byte-identical output across two fixed emit-only runs", async () => {
     const run = async (): Promise<string> => {
       const { output, ports } = fakeRuntime();
       await applyPlan(
         planOf(
-          { kind: "create_directory", path: ".brain" },
-          { kind: "append_event", event: ports.ids.next() },
           {
             kind: "emit",
             channel: "structured",
@@ -148,27 +701,6 @@ describe("effect plan application", () => {
       return output.structured_.join("|");
     };
 
-    // Determinism is the whole reason the clock and ids are ports at all.
     expect(await run()).toBe(await run());
-  });
-
-  it("stops at the first failing effect without applying later ones", async () => {
-    const { fileSystem, ports } = fakeRuntime();
-
-    await expect(
-      applyPlan(
-        planOf(
-          { kind: "write_file", path: "before.txt", content: "written" },
-          { kind: "write_file", path: "../escape.txt", content: "x" },
-          { kind: "write_file", path: "after.txt", content: "x" },
-        ),
-        ports,
-      ),
-    ).rejects.toThrow("escapes the project");
-
-    expect(await fileSystem.read("before.txt")).toBe("written");
-    // A refused effect must not be stepped over; RUN-05 owns making the
-    // already-applied prefix roll back.
-    expect(await fileSystem.stat("after.txt")).toBeNull();
   });
 });

--- a/tests/runtime-composition.test.ts
+++ b/tests/runtime-composition.test.ts
@@ -1018,18 +1018,81 @@ describe("effect plan application", () => {
     },
   );
 
-  it("keeps an explicit initialize no-op free of bootstrap metadata", async () => {
-    const { storage, ports } = fakeRuntime({});
+  it.each([
+    { label: "a missing root", directories: [] as readonly string[] },
+    { label: "an empty root", directories: [".brain"] as readonly string[] },
+  ])(
+    "keeps an explicit initialize no-op free of bootstrap metadata from $label",
+    async ({ directories }) => {
+      const { storage, ports } = fakeRuntime({ directories });
 
-    await applyPlan(
-      planOf({ kind: "delete_file", path: ".brain/missing.json" }),
-      ports,
-      { rootMode: "initialize" },
-    );
+      await expect(
+        applyPlan(
+          planOf({ kind: "delete_file", path: ".brain/missing.json" }),
+          ports,
+          { rootMode: "initialize" },
+        ),
+      ).resolves.toEqual({ kind: "noop" });
 
-    expect(storage.snapshot()).toEqual({ files: {}, directories: [] });
-    expect(storage.calls()).not.toContain("create_directory_exclusive");
+      expect(storage.snapshot()).toEqual({ files: {}, directories });
+      expect(storage.calls()).not.toContain("create_directory");
+      expect(storage.calls()).not.toContain("create_directory_exclusive");
+    },
+  );
+
+  it("bootstraps a ready initialize plan beneath an empty root", async () => {
+    const { storage, ports } = fakeRuntime({ directories: [".brain"] });
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        }),
+        ports,
+        { rootMode: "initialize" },
+      ),
+    ).resolves.toEqual({ kind: "committed" });
+
+    expect(storage.snapshot().directories).toContain(".brain/transactions");
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("state");
   });
+
+  it.each([
+    {
+      label: "delete is already satisfied",
+      plan: planOf({ kind: "delete_file", path: ".brain/missing.json" }),
+    },
+    {
+      label: "write is already satisfied",
+      plan: planOf({
+        kind: "write_file",
+        path: ".brain/existing.json",
+        content: "existing",
+      }),
+    },
+  ])(
+    "rejects initialize when transactions are absent from a non-empty root and $label",
+    async ({ plan }) => {
+      const { storage, ports } = fakeRuntime({
+        directories: [".brain"],
+        files: { ".brain/existing.json": "existing" },
+      });
+      const before = storage.snapshot();
+
+      await expect(
+        applyPlan(plan, ports, { rootMode: "initialize" }),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: ".brain" },
+        ]),
+      );
+      expect(storage.snapshot()).toEqual(before);
+      expect(storage.calls()).not.toContain("create_directory");
+      expect(storage.calls()).not.toContain("create_directory_exclusive");
+    },
+  );
 
   it("never uses the ordinary filesystem for managed mutations", async () => {
     const { storage, ports } = fakeRuntime();

--- a/tests/runtime-composition.test.ts
+++ b/tests/runtime-composition.test.ts
@@ -5,6 +5,7 @@ import {
   configurationValidator,
   createRuntime,
   createSchemaRegistry,
+  preflightManagedTransactions,
   TransactionFailure,
 } from "@mestre-yoda/runtime/composition";
 import {
@@ -89,6 +90,29 @@ describe("effect plan application", () => {
       }),
     };
   }
+
+  it("exposes a preflight that sanitizes unexpected storage failures", async () => {
+    const { storage, ports } = fakeRuntime();
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      inspect() {
+        return Promise.reject(new Error("/absolute/private-preflight"));
+      },
+    };
+
+    await expect(
+      preflightManagedTransactions(
+        { rootMode: "existing" },
+        {
+          clock: ports.clock,
+          ids: ports.ids,
+          digests: ports.digests,
+          durableFileSystem,
+          schemaRegistry: createSchemaRegistry(),
+        },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
 
   it("commits managed effects in their declared order", async () => {
     const { storage, ports } = fakeRuntime({
@@ -208,6 +232,184 @@ describe("effect plan application", () => {
     expect(output.human_).toEqual(["second\n"]);
   });
 
+  it("snapshots plan effects and root mode before the first await", async () => {
+    const { storage, output, ports } = fakeRuntime({});
+    const write = {
+      kind: "write_file" as const,
+      path: ".brain/original.json",
+      content: "original",
+    };
+    const emit = {
+      kind: "emit" as const,
+      channel: "human" as const,
+      text: "original output\n",
+    };
+    const options: { rootMode: "existing" | "initialize" } = {
+      rootMode: "initialize",
+    };
+    let releaseFirstInspection: (() => void) | undefined;
+    let signalFirstInspection: (() => void) | undefined;
+    const firstInspection = new Promise<void>((resolve) => {
+      signalFirstInspection = resolve;
+    });
+    const blocked = new Promise<void>((resolve) => {
+      releaseFirstInspection = resolve;
+    });
+    let hasBlocked = false;
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      async inspect(path): Promise<DurableEntry> {
+        if (!hasBlocked && path === ".brain") {
+          hasBlocked = true;
+          signalFirstInspection?.();
+          await blocked;
+        }
+        return storage.durableFileSystem.inspect(path);
+      },
+    };
+
+    const applying = applyPlan(
+      planOf(write, emit),
+      { ...ports, durableFileSystem },
+      options,
+    );
+    await firstInspection;
+    options.rootMode = "existing";
+    write.path = ".brain/mutated.json";
+    write.content = "mutated";
+    emit.text = "mutated output\n";
+    releaseFirstInspection?.();
+
+    await expect(applying).resolves.toEqual({ kind: "committed" });
+    expect(storage.snapshot().files[".brain/original.json"]).toBe("original");
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/mutated.json");
+    expect(output.human_).toEqual(["original output\n"]);
+  });
+
+  it("rejects non-primitive apply input without crossing a runtime boundary", async () => {
+    const { storage, ports } = fakeRuntime();
+
+    await expect(
+      applyPlan(
+        {
+          effects: [
+            {
+              kind: "write_file",
+              path: ".brain/state.json",
+              content: 42,
+            },
+          ],
+        } as unknown as Parameters<typeof applyPlan>[0],
+        ports,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain" },
+      ]),
+    );
+    await expect(
+      applyPlan(planOf(), ports, {
+        rootMode: "unexpected",
+      } as unknown as Parameters<typeof applyPlan>[2]),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain" },
+      ]),
+    );
+    const invalidInputs = [
+      () =>
+        applyPlan(null as unknown as Parameters<typeof applyPlan>[0], ports),
+      () =>
+        applyPlan(
+          { effects: "not-an-array" } as unknown as Parameters<
+            typeof applyPlan
+          >[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          planOf(),
+          ports,
+          null as unknown as Parameters<typeof applyPlan>[2],
+        ),
+      () =>
+        applyPlan(
+          { effects: [null] } as unknown as Parameters<typeof applyPlan>[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          { effects: [{ kind: 7 }] } as unknown as Parameters<
+            typeof applyPlan
+          >[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          {
+            effects: [{ kind: "write_file", path: 7, content: "content" }],
+          } as unknown as Parameters<typeof applyPlan>[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          {
+            effects: [{ kind: "delete_file", path: 7 }],
+          } as unknown as Parameters<typeof applyPlan>[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          {
+            effects: [{ kind: "append_event", event: 7 }],
+          } as unknown as Parameters<typeof applyPlan>[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          {
+            effects: [{ kind: "emit", channel: "private", text: "text" }],
+          } as unknown as Parameters<typeof applyPlan>[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          {
+            effects: [{ kind: "emit", channel: "human", text: 7 }],
+          } as unknown as Parameters<typeof applyPlan>[0],
+          ports,
+        ),
+      () =>
+        applyPlan(
+          { effects: [{ kind: "unknown" }] } as unknown as Parameters<
+            typeof applyPlan
+          >[0],
+          ports,
+        ),
+    ];
+    for (const invalidInput of invalidInputs) {
+      await expect(invalidInput()).rejects.toMatchObject({
+        reasonCode: "runtime.state_corrupt",
+        evidence: [{ kind: "artifact", ref: ".brain" }],
+      });
+    }
+    expect(storage.calls()).toEqual([]);
+  });
+
+  it("sanitizes a throwing apply-input accessor", async () => {
+    const { storage, ports } = fakeRuntime();
+    const plan = Object.defineProperty({}, "effects", {
+      get() {
+        throw new Error("/absolute/private-input");
+      },
+    });
+
+    await expect(
+      applyPlan(plan as Parameters<typeof applyPlan>[0], ports),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+    expect(storage.calls()).toEqual([]);
+  });
+
   it("emits nothing when publication does not commit", async () => {
     const { storage, output, ports } = fakeRuntime();
     const durableFileSystem: DurableFileSystem = {
@@ -291,6 +493,40 @@ describe("effect plan application", () => {
     },
   );
 
+  it("rejects a managed root changed after transaction preflight", async () => {
+    const { storage, ports } = fakeRuntime();
+    let brainInspections = 0;
+    const durableFileSystem: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      inspect(path): Promise<DurableEntry> {
+        if (path === ".brain" && ++brainInspections === 4) {
+          return Promise.resolve({
+            kind: "file",
+            size: 0,
+            sha256: storage.digests.sha256(""),
+          });
+        }
+        return storage.durableFileSystem.inspect(path);
+      },
+    };
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        }),
+        { ...ports, durableFileSystem },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain" },
+      ]),
+    );
+    expect(brainInspections).toBe(4);
+  });
+
   it.each(["file", "special", "symlink"] as const)(
     "observes and rejects a %s managed root before descendant paths",
     async (kind) => {
@@ -325,7 +561,7 @@ describe("effect plan application", () => {
           { kind: "artifact", ref: ".brain" },
         ]),
       );
-      expect(inspected).toEqual([".brain"]);
+      expect(inspected).toEqual([".brain", ".brain"]);
     },
   );
 
@@ -496,6 +732,31 @@ describe("effect plan application", () => {
     expect(storage.calls()).not.toContain("create_directory_exclusive");
   });
 
+  it("reports whether managed state committed", async () => {
+    const { ports } = fakeRuntime();
+    const plan = planOf({
+      kind: "write_file",
+      path: ".brain/state.json",
+      content: "state",
+    });
+
+    await expect(applyPlan(plan, ports)).resolves.toEqual({
+      kind: "committed",
+    });
+    await expect(applyPlan(plan, ports)).resolves.toEqual({ kind: "noop" });
+  });
+
+  it("reports emit-only application as a no-op", async () => {
+    const { ports } = fakeRuntime();
+
+    await expect(
+      applyPlan(
+        planOf({ kind: "emit", channel: "human", text: "message\n" }),
+        ports,
+      ),
+    ).resolves.toEqual({ kind: "noop" });
+  });
+
   it("observes an already-satisfied managed directory as a no-op", async () => {
     const { storage, ports } = fakeRuntime({
       directories: [".brain", ".brain/transactions", ".brain/existing"],
@@ -548,6 +809,135 @@ describe("effect plan application", () => {
       ]),
     );
     expect(output.human_).toEqual([]);
+  });
+
+  it("rejects a publishing marker before inspecting a managed target", async () => {
+    const { storage, ports } = fakeRuntime();
+    const interrupted: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      replaceFile(stagedPath, targetPath) {
+        if (targetPath === ".brain/state.json") {
+          return Promise.reject(new Error("publication stopped"));
+        }
+        return storage.durableFileSystem.replaceFile(stagedPath, targetPath);
+      },
+    };
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        }),
+        { ...ports, durableFileSystem: interrupted },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+
+    const inspected: string[] = [];
+    const specialTarget: DurableFileSystem = {
+      ...storage.durableFileSystem,
+      inspect(path): Promise<DurableEntry> {
+        inspected.push(path);
+        if (path === ".brain/state.json") {
+          return Promise.resolve({ kind: "special" });
+        }
+        return storage.durableFileSystem.inspect(path);
+      },
+    };
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "state",
+        }),
+        { ...ports, durableFileSystem: specialTarget },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ]),
+    );
+    expect(inspected).not.toContain(".brain/state.json");
+  });
+
+  it.each([
+    { label: "empty", files: {} },
+    {
+      label: "progress scratch",
+      files: {
+        ".brain/transactions/orphan/progress.next": "partial",
+      },
+    },
+  ])(
+    "reconciles a safe $label unmarked transaction for a no-op",
+    async ({ files }) => {
+      const { storage, ports } = fakeRuntime({
+        directories: [
+          ".brain",
+          ".brain/transactions",
+          ".brain/transactions/orphan",
+        ],
+        files: {
+          ".brain/state.json": "same",
+          ...files,
+        },
+      });
+
+      await expect(
+        applyPlan(
+          planOf({
+            kind: "write_file",
+            path: ".brain/state.json",
+            content: "same",
+          }),
+          ports,
+        ),
+      ).resolves.toEqual({ kind: "noop" });
+
+      expect(storage.snapshot().directories).not.toContain(
+        ".brain/transactions/orphan",
+      );
+      expect(storage.calls()).not.toContain("create_directory_exclusive");
+    },
+  );
+
+  it("preserves unknown unmarked content when a no-op fails closed", async () => {
+    const unknown = ".brain/transactions/orphan/unknown";
+    const { storage, ports } = fakeRuntime({
+      directories: [
+        ".brain",
+        ".brain/transactions",
+        ".brain/transactions/orphan",
+      ],
+      files: {
+        ".brain/state.json": "same",
+        [unknown]: "preserve",
+      },
+    });
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "same",
+        }),
+        ports,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain/transactions/orphan" },
+      ]),
+    );
+    expect(storage.snapshot().files[unknown]).toBe("preserve");
+    expect(storage.calls()).not.toContain("remove_file");
+    expect(storage.calls()).not.toContain("remove_empty_directory");
+    expect(storage.calls()).not.toContain("create_directory_exclusive");
   });
 
   it("lets the transaction driver reconcile a safe unmarked crash directory", async () => {

--- a/tests/runtime-composition.test.ts
+++ b/tests/runtime-composition.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   fixedClock,
   memoryFileSystem,
+  memoryTransactionStorage,
   recordingOutput,
   sequentialIds,
 } from "@mestre-yoda/runtime/infra/fake";
@@ -33,9 +34,16 @@ describe("composition root", () => {
 
   it("replaces exactly the overridden ports and nothing else", () => {
     const clock = fixedClock("2026-08-07T00:00:00.000Z");
-    const ports = createRuntime({ clock });
+    const storage = memoryTransactionStorage();
+    const ports = createRuntime({
+      clock,
+      digests: storage.digests,
+      durableFileSystem: storage.durableFileSystem,
+    });
 
     expect(ports.clock).toBe(clock);
+    expect(ports.digests).toBe(storage.digests);
+    expect(ports.durableFileSystem).toBe(storage.durableFileSystem);
     // An override must not quietly swap its neighbours for fakes.
     expect(ports.environment.workingDirectory()).toBe(process.cwd());
   });
@@ -43,6 +51,8 @@ describe("composition root", () => {
   it("exposes every port named by the contract", () => {
     expect(Object.keys(createRuntime()).sort()).toEqual([
       "clock",
+      "digests",
+      "durableFileSystem",
       "environment",
       "fileSystem",
       "git",

--- a/tests/runtime-distribution.test.ts
+++ b/tests/runtime-distribution.test.ts
@@ -34,7 +34,8 @@ interface ReasonEntry {
 let manifest: DistributionManifest;
 let entry: string;
 let core: Buffer;
-let reason: ReasonEntry | undefined;
+let nodeUnsupportedReason: ReasonEntry | undefined;
+let recoveryRequiredReason: ReasonEntry | undefined;
 
 const embeddedSchemaInputs = [
   "schemas/host/adapter-message.v1.schema.json",
@@ -46,6 +47,8 @@ const embeddedSchemaInputs = [
   "schemas/state/migration.v1.schema.json",
   "schemas/state/project-config.v1.schema.json",
   "schemas/state/snapshot.v1.schema.json",
+  "schemas/state/transaction-manifest.v1.schema.json",
+  "schemas/state/transaction-progress.v1.schema.json",
 ] as const;
 
 beforeAll(async () => {
@@ -60,7 +63,7 @@ beforeAll(async () => {
     readFile(
       join(
         repositoryRoot,
-        "packages/contracts/catalogs/reason-codes.v1.2.json",
+        "packages/contracts/catalogs/reason-codes.v1.3.json",
       ),
       "utf8",
     ),
@@ -68,8 +71,13 @@ beforeAll(async () => {
   manifest = JSON.parse(manifestText) as DistributionManifest;
   entry = entryText;
   core = coreBytes;
-  reason = (JSON.parse(catalogText) as { reasons: ReasonEntry[] }).reasons.find(
+  const reasons = (JSON.parse(catalogText) as { reasons: ReasonEntry[] })
+    .reasons;
+  nodeUnsupportedReason = reasons.find(
     ({ code }) => code === "runtime.node_unsupported",
+  );
+  recoveryRequiredReason = reasons.find(
+    ({ code }) => code === "runtime.recovery_required",
   );
 });
 
@@ -102,11 +110,15 @@ describe("runtime distribution", () => {
   });
 
   it("keeps the preflight text identical to the catalog", () => {
-    expect(reason).toBeDefined();
+    expect(nodeUnsupportedReason).toBeDefined();
     // Slicing the JSON quotes off yields the exact escaped literal the build
     // embedded, so a drifting copy fails here instead of shipping.
-    expect(entry).toContain(JSON.stringify(reason?.recovery).slice(1, -1));
-    expect(entry).toContain(JSON.stringify(reason?.description).slice(1, -1));
+    expect(entry).toContain(
+      JSON.stringify(nodeUnsupportedReason?.recovery).slice(1, -1),
+    );
+    expect(entry).toContain(
+      JSON.stringify(nodeUnsupportedReason?.description).slice(1, -1),
+    );
   });
 
   it("keeps the shebang off the core bundle", () => {
@@ -143,6 +155,19 @@ describe("runtime distribution", () => {
       expect(output.inputs[schema]?.bytesInOutput).toBeGreaterThan(0);
     }
     expect(core.toString("utf8")).not.toMatch(/(?:\.\.\/)+schemas\//u);
+  });
+
+  it("embeds the catalog-backed explicit recovery policy", () => {
+    expect(recoveryRequiredReason).toBeDefined();
+    const bundle = core.toString("utf8");
+    for (const value of [
+      recoveryRequiredReason?.code,
+      recoveryRequiredReason?.description,
+      recoveryRequiredReason?.recovery,
+    ]) {
+      expect(value).toBeDefined();
+      expect(bundle).toContain(value);
+    }
   });
 
   it("stages exactly the manifest, core, and entry point", async () => {

--- a/tests/schema-registry-fixtures.test.ts
+++ b/tests/schema-registry-fixtures.test.ts
@@ -8,6 +8,8 @@ import lock from "../fixtures/contracts/v1/lock.json" with { type: "json" };
 import migration from "../fixtures/contracts/v1/migration.json" with { type: "json" };
 import projectConfig from "../fixtures/contracts/v1/project-config.json" with { type: "json" };
 import snapshot from "../fixtures/contracts/v1/snapshot.json" with { type: "json" };
+import transactionManifest from "../fixtures/contracts/v1/transaction-manifest.json" with { type: "json" };
+import transactionProgress from "../fixtures/contracts/v1/transaction-progress.json" with { type: "json" };
 import type {
   ContractId,
   StructuralReasonCode,
@@ -106,6 +108,26 @@ const fixtures = [
     requiredField: "projectId",
     structuralReasonCode: "runtime.state_corrupt",
     fixture: snapshot,
+    invalidVersionReason: "contract.state_version_invalid",
+    unsupportedVersionReason: "contract.state_version_unsupported",
+  },
+  {
+    id: "state.transaction-manifest",
+    version: "1.0.0",
+    versionField: "stateContract",
+    requiredField: "transactionId",
+    structuralReasonCode: "runtime.state_corrupt",
+    fixture: transactionManifest,
+    invalidVersionReason: "contract.state_version_invalid",
+    unsupportedVersionReason: "contract.state_version_unsupported",
+  },
+  {
+    id: "state.transaction-progress",
+    version: "1.0.0",
+    versionField: "stateContract",
+    requiredField: "transactionId",
+    structuralReasonCode: "runtime.state_corrupt",
+    fixture: transactionProgress,
     invalidVersionReason: "contract.state_version_invalid",
     unsupportedVersionReason: "contract.state_version_unsupported",
   },

--- a/tests/schema-registry-types.test.ts
+++ b/tests/schema-registry-types.test.ts
@@ -1,4 +1,8 @@
-import type { ProjectConfigV1 } from "@mestre-yoda/contracts";
+import type {
+  ProjectConfigV1,
+  TransactionManifestV1,
+  TransactionProgressV1,
+} from "@mestre-yoda/contracts";
 import type {
   ContractId,
   ContractRequest,
@@ -21,11 +25,19 @@ describe("schema registry vocabulary", () => {
       "state.migration",
       "state.project-config",
       "state.snapshot",
+      "state.transaction-manifest",
+      "state.transaction-progress",
     ] as const satisfies readonly ContractId[];
-    expect(ids).toHaveLength(8);
+    expect(ids).toHaveLength(10);
     expectTypeOf<
       ContractValue<"state.project-config">
     >().toEqualTypeOf<ProjectConfigV1>();
+    expectTypeOf<
+      ContractValue<"state.transaction-manifest">
+    >().toEqualTypeOf<TransactionManifestV1>();
+    expectTypeOf<
+      ContractValue<"state.transaction-progress">
+    >().toEqualTypeOf<TransactionProgressV1>();
   });
 
   it("requires the caller to select an existing structural failure policy", () => {

--- a/tests/support/transaction-port-contract.ts
+++ b/tests/support/transaction-port-contract.ts
@@ -219,6 +219,11 @@ export function describeDurableFileSystemContract(
       "a\\b",
       "a\u0000b",
       "a\nb",
+      ".brain//state.json",
+      ".brain/./state.json",
+      ".brain/state.json/",
+      "outside.txt",
+      "relative/path",
     ] as const;
 
     const durableEntryPathOperations: readonly [

--- a/tests/support/transaction-port-contract.ts
+++ b/tests/support/transaction-port-contract.ts
@@ -199,6 +199,9 @@ export function describeDurableFileSystemContract(
       await withFileSystem(async (fileSystem) => {
         await createBrain(fileSystem);
         expect(["supported", "unsupported"]).toContain(
+          await fileSystem.syncDirectory("."),
+        );
+        expect(["supported", "unsupported"]).toContain(
           await fileSystem.syncDirectory(".brain"),
         );
         await expect(
@@ -218,7 +221,7 @@ export function describeDurableFileSystemContract(
       "a\nb",
     ] as const;
 
-    const pathOperations: readonly [
+    const durableEntryPathOperations: readonly [
       label: string,
       run: (fileSystem: DurableFileSystem, path: string) => Promise<unknown>,
     ][] = [
@@ -242,7 +245,6 @@ export function describeDurableFileSystemContract(
         "removeEmptyDirectory",
         (fileSystem, path) => fileSystem.removeEmptyDirectory(path),
       ],
-      ["syncDirectory", (fileSystem, path) => fileSystem.syncDirectory(path)],
       [
         "replaceFile staged path",
         (fileSystem, path) => fileSystem.replaceFile(path, ".brain/target"),
@@ -253,7 +255,27 @@ export function describeDurableFileSystemContract(
       ],
     ];
 
-    it.each(pathOperations)(
+    it.each(durableEntryPathOperations)(
+      "%s refuses the project root sentinel as a managed entry",
+      async (_operation, run) => {
+        await withFileSystem(async (fileSystem) => {
+          await expect(run(fileSystem, ".")).rejects.toThrow(
+            "escapes the project",
+          );
+        });
+      },
+    );
+
+    const unsafePathOperations = [
+      ...durableEntryPathOperations,
+      [
+        "syncDirectory",
+        (fileSystem: DurableFileSystem, path: string) =>
+          fileSystem.syncDirectory(path),
+      ] as const,
+    ];
+
+    it.each(unsafePathOperations)(
       "%s refuses every unsafe project-relative path",
       async (_operation, run) => {
         await withFileSystem(async (fileSystem) => {

--- a/tests/support/transaction-port-contract.ts
+++ b/tests/support/transaction-port-contract.ts
@@ -1,0 +1,273 @@
+import type { DurableFileSystem } from "@mestre-yoda/runtime/ports";
+import { describe, expect, it } from "vitest";
+
+import type { Disposable } from "./port-contracts.js";
+
+const helloDigest =
+  "3c48591d8d098a4538f5e013dfcf406e948eac4d3277b10bf614e295d6068179";
+const replacementDigest =
+  "95713e9cbdd1dfcb2d4080c2537f418d43ca0da25f0d7d6631f4f7c97b89dc47";
+
+/** Behavior every durable filesystem adapter must implement identically. */
+export function describeDurableFileSystemContract(
+  label: string,
+  factory: () => Promise<Disposable<DurableFileSystem>>,
+): void {
+  describe(`DurableFileSystem contract: ${label}`, () => {
+    async function withFileSystem(
+      body: (fileSystem: DurableFileSystem) => Promise<void>,
+    ): Promise<void> {
+      const { port, dispose } = await factory();
+      try {
+        await body(port);
+      } finally {
+        await dispose();
+      }
+    }
+
+    async function createBrain(fileSystem: DurableFileSystem): Promise<void> {
+      await fileSystem.createDirectory(".brain");
+    }
+
+    it("writes, synchronizes, reads, and fingerprints complete UTF-8 text", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.writeSynced(".brain/state.json", "héllo");
+
+        expect(await fileSystem.readText(".brain/state.json")).toBe("héllo");
+        expect(await fileSystem.inspect(".brain/state.json")).toEqual({
+          kind: "file",
+          size: 6,
+          sha256: helloDigest,
+        });
+      });
+    });
+
+    it("reports missing paths without following them", async () => {
+      await withFileSystem(async (fileSystem) => {
+        expect(await fileSystem.inspect(".brain/missing.json")).toEqual({
+          kind: "missing",
+        });
+      });
+    });
+
+    it("rejects reading a missing file", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await expect(
+          fileSystem.readText(".brain/missing.json"),
+        ).rejects.toThrow();
+      });
+    });
+
+    it("creates a directory idempotently", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.createDirectory(".brain/runs");
+        await fileSystem.createDirectory(".brain/runs");
+
+        expect(await fileSystem.inspect(".brain/runs")).toEqual({
+          kind: "directory",
+        });
+      });
+    });
+
+    it("creates a directory exclusively", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.createDirectoryExclusive(".brain/transaction-1");
+
+        expect(await fileSystem.inspect(".brain/transaction-1")).toEqual({
+          kind: "directory",
+        });
+        await expect(
+          fileSystem.createDirectoryExclusive(".brain/transaction-1"),
+        ).rejects.toThrow();
+      });
+    });
+
+    it("does not create undeclared parent directories", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await expect(
+          fileSystem.createDirectory(".brain/runs/deep"),
+        ).rejects.toThrow();
+        await expect(
+          fileSystem.writeSynced(".brain/runs/state.json", "state"),
+        ).rejects.toThrow();
+        expect(await fileSystem.inspect(".brain/runs")).toEqual({
+          kind: "missing",
+        });
+      });
+    });
+
+    it("atomically replaces a destination and consumes the staged file", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.writeSynced(".brain/staged", "replacement");
+        await fileSystem.writeSynced(".brain/state.json", "old");
+
+        await fileSystem.replaceFile(".brain/staged", ".brain/state.json");
+
+        expect(await fileSystem.inspect(".brain/staged")).toEqual({
+          kind: "missing",
+        });
+        expect(await fileSystem.readText(".brain/state.json")).toBe(
+          "replacement",
+        );
+        expect(await fileSystem.inspect(".brain/state.json")).toEqual({
+          kind: "file",
+          size: 11,
+          sha256: replacementDigest,
+        });
+      });
+    });
+
+    it("publishes a staged file to a missing destination", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.writeSynced(".brain/staged", "replacement");
+
+        await fileSystem.replaceFile(".brain/staged", ".brain/new.json");
+
+        expect(await fileSystem.inspect(".brain/staged")).toEqual({
+          kind: "missing",
+        });
+        expect(await fileSystem.readText(".brain/new.json")).toBe(
+          "replacement",
+        );
+      });
+    });
+
+    it("removes only regular files", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.writeSynced(".brain/remove.json", "gone");
+        await fileSystem.createDirectory(".brain/keep");
+
+        await fileSystem.removeFile(".brain/remove.json");
+
+        expect(await fileSystem.inspect(".brain/remove.json")).toEqual({
+          kind: "missing",
+        });
+        await expect(fileSystem.removeFile(".brain/keep")).rejects.toThrow();
+        expect(await fileSystem.inspect(".brain/keep")).toEqual({
+          kind: "directory",
+        });
+      });
+    });
+
+    it("removes only empty directories", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.createDirectory(".brain/empty");
+        await fileSystem.createDirectory(".brain/non-empty");
+        await fileSystem.writeSynced(".brain/non-empty/state.json", "state");
+
+        await fileSystem.removeEmptyDirectory(".brain/empty");
+
+        expect(await fileSystem.inspect(".brain/empty")).toEqual({
+          kind: "missing",
+        });
+        await expect(
+          fileSystem.removeEmptyDirectory(".brain/non-empty"),
+        ).rejects.toThrow();
+        expect(await fileSystem.readText(".brain/non-empty/state.json")).toBe(
+          "state",
+        );
+        await expect(
+          fileSystem.removeEmptyDirectory(".brain/non-empty/state.json"),
+        ).rejects.toThrow();
+      });
+    });
+
+    it("lists only immediate entries in sorted order", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        await fileSystem.writeSynced(".brain/b.json", "b");
+        await fileSystem.writeSynced(".brain/a.json", "a");
+        await fileSystem.createDirectory(".brain/c");
+        await fileSystem.writeSynced(".brain/c/nested.json", "nested");
+
+        expect(await fileSystem.list(".brain")).toEqual([
+          "a.json",
+          "b.json",
+          "c",
+        ]);
+      });
+    });
+
+    it("classifies directory synchronization without hiding path errors", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+        expect(["supported", "unsupported"]).toContain(
+          await fileSystem.syncDirectory(".brain"),
+        );
+        await expect(
+          fileSystem.syncDirectory(".brain/missing"),
+        ).rejects.toThrow();
+      });
+    });
+
+    const unsafePaths = [
+      "../escape",
+      "/absolute",
+      "a/../../escape",
+      "",
+      "C:/windows",
+      "a\\b",
+      "a\u0000b",
+      "a\nb",
+    ] as const;
+
+    const pathOperations: readonly [
+      label: string,
+      run: (fileSystem: DurableFileSystem, path: string) => Promise<unknown>,
+    ][] = [
+      ["inspect", (fileSystem, path) => fileSystem.inspect(path)],
+      ["list", (fileSystem, path) => fileSystem.list(path)],
+      ["readText", (fileSystem, path) => fileSystem.readText(path)],
+      [
+        "createDirectory",
+        (fileSystem, path) => fileSystem.createDirectory(path),
+      ],
+      [
+        "createDirectoryExclusive",
+        (fileSystem, path) => fileSystem.createDirectoryExclusive(path),
+      ],
+      [
+        "writeSynced",
+        (fileSystem, path) => fileSystem.writeSynced(path, "content"),
+      ],
+      ["removeFile", (fileSystem, path) => fileSystem.removeFile(path)],
+      [
+        "removeEmptyDirectory",
+        (fileSystem, path) => fileSystem.removeEmptyDirectory(path),
+      ],
+      ["syncDirectory", (fileSystem, path) => fileSystem.syncDirectory(path)],
+      [
+        "replaceFile staged path",
+        (fileSystem, path) => fileSystem.replaceFile(path, ".brain/target"),
+      ],
+      [
+        "replaceFile target path",
+        (fileSystem, path) => fileSystem.replaceFile(".brain/staged", path),
+      ],
+    ];
+
+    it.each(pathOperations)(
+      "%s refuses every unsafe project-relative path",
+      async (_operation, run) => {
+        await withFileSystem(async (fileSystem) => {
+          for (const path of unsafePaths) {
+            await expect(run(fileSystem, path), path).rejects.toThrow(
+              "escapes the project",
+            );
+          }
+        });
+      },
+    );
+  });
+}
+
+export type DurableFileSystemContractFactory = () => Promise<
+  Disposable<DurableFileSystem>
+>;

--- a/tests/transaction-digests.test.ts
+++ b/tests/transaction-digests.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { sha256Digests } from "../packages/runtime/src/infra/digests.js";
+import type {
+  DurableEntry,
+  DurableFileSystem,
+  Digests,
+} from "@mestre-yoda/runtime/ports";
+
+type ExpectedDurableEntry =
+  | { readonly kind: "missing" }
+  | { readonly kind: "directory" | "symlink" | "special" }
+  | { readonly kind: "file"; readonly size: number; readonly sha256: string };
+
+describe("transaction port vocabulary", () => {
+  it("exports the closed durable entry union", () => {
+    expectTypeOf<DurableEntry>().toEqualTypeOf<ExpectedDurableEntry>();
+  });
+
+  it("exports every narrow durable filesystem primitive", () => {
+    expectTypeOf<DurableFileSystem["inspect"]>().toEqualTypeOf<
+      (path: string) => Promise<DurableEntry>
+    >();
+    expectTypeOf<DurableFileSystem["list"]>().toEqualTypeOf<
+      (path: string) => Promise<readonly string[]>
+    >();
+    expectTypeOf<DurableFileSystem["readText"]>().toEqualTypeOf<
+      (path: string) => Promise<string>
+    >();
+    expectTypeOf<DurableFileSystem["createDirectory"]>().toEqualTypeOf<
+      (path: string) => Promise<void>
+    >();
+    expectTypeOf<DurableFileSystem["createDirectoryExclusive"]>().toEqualTypeOf<
+      (path: string) => Promise<void>
+    >();
+    expectTypeOf<DurableFileSystem["writeSynced"]>().toEqualTypeOf<
+      (path: string, content: string) => Promise<void>
+    >();
+    expectTypeOf<DurableFileSystem["replaceFile"]>().toEqualTypeOf<
+      (stagedPath: string, targetPath: string) => Promise<void>
+    >();
+    expectTypeOf<DurableFileSystem["removeFile"]>().toEqualTypeOf<
+      (path: string) => Promise<void>
+    >();
+    expectTypeOf<DurableFileSystem["removeEmptyDirectory"]>().toEqualTypeOf<
+      (path: string) => Promise<void>
+    >();
+    expectTypeOf<DurableFileSystem["syncDirectory"]>().toEqualTypeOf<
+      (path: string) => Promise<"supported" | "unsupported">
+    >();
+  });
+
+  it("exports the injected digest capability", () => {
+    expectTypeOf<Digests["sha256"]>().toEqualTypeOf<(text: string) => string>();
+  });
+});
+
+describe("SHA-256 digest adapter", () => {
+  it.each([
+    ["", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+    ["abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"],
+    [
+      "café",
+      "850f7dc43910ff890f8879c0ed26fe697c93a067ad93a7d50f466a7028a9bf4e",
+    ],
+  ])("hashes the UTF-8 text %j", (text, expected) => {
+    expect(sha256Digests().sha256(text)).toBe(expected);
+  });
+
+  it("returns lowercase fixed-width digests deterministically", () => {
+    const digests = sha256Digests();
+    const first = digests.sha256("repeatable");
+
+    expect(digests.sha256("repeatable")).toBe(first);
+    expect(first).toMatch(/^[a-f0-9]{64}$/u);
+  });
+});

--- a/tests/transaction-execution.test.ts
+++ b/tests/transaction-execution.test.ts
@@ -1,0 +1,563 @@
+import {
+  executeManagedMutation,
+  inspectManagedTransactions,
+  recoverManagedMutation,
+  TransactionFailure,
+  type TransactionServices,
+} from "@mestre-yoda/runtime/composition";
+import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
+import type {
+  DurableEntry,
+  DurableFileSystem,
+} from "@mestre-yoda/runtime/ports";
+import {
+  fixedClock,
+  memoryTransactionStorage,
+  sequentialIds,
+} from "@mestre-yoda/runtime/infra/fake";
+import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
+import { describe, expect, it } from "vitest";
+
+function services(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+): TransactionServices {
+  return {
+    clock: fixedClock("2026-08-09T00:00:00.000Z"),
+    ids: sequentialIds("transaction"),
+    digests: storage.digests,
+    durableFileSystem: storage.durableFileSystem,
+    schemaRegistry: createSchemaRegistry(),
+  };
+}
+
+function replacementPlan(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+): ManagedMutationPlan {
+  return {
+    operations: [
+      {
+        operationId: "operation-0001",
+        kind: "write_file",
+        path: ".brain/state.json",
+        expected: {
+          kind: "file",
+          size: 3,
+          sha256: storage.digests.sha256("old"),
+        },
+        result: {
+          kind: "file",
+          size: 3,
+          sha256: storage.digests.sha256("new"),
+        },
+        stagedPath: "staging/operation-0001.payload",
+        content: "new",
+      },
+    ],
+  };
+}
+
+describe("managed transaction execution", () => {
+  it("durably prepares, publishes, commits, and removes staged payloads", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+
+    const receipt = await executeManagedMutation(
+      replacementPlan(storage),
+      { rootMode: "existing" },
+      services(storage),
+    );
+
+    expect(receipt).toMatchObject({
+      transactionId: "transaction-1",
+      phase: "committed",
+      directorySync: "supported",
+    });
+    expect(receipt.manifestDigest).toMatch(/^[a-f0-9]{64}$/u);
+    expect(receipt.recoveryToken).toMatch(/^[a-f0-9]{64}$/u);
+    expect(receipt.recoveryToken).toBe(receipt.manifestDigest);
+
+    const snapshot = storage.snapshot();
+    expect(snapshot.files[".brain/state.json"]).toBe("new");
+    expect(snapshot.files).not.toHaveProperty(
+      ".brain/transactions/transaction-1/staging/operation-0001.payload",
+    );
+    expect(snapshot.directories).not.toContain(
+      ".brain/transactions/transaction-1/staging",
+    );
+
+    const manifestText =
+      snapshot.files[".brain/transactions/transaction-1/manifest.json"];
+    const progressText =
+      snapshot.files[".brain/transactions/transaction-1/progress.json"];
+    expect(manifestText?.endsWith("\n")).toBe(true);
+    expect(progressText?.endsWith("\n")).toBe(true);
+    const manifest: unknown = JSON.parse(manifestText ?? "null");
+    const progress: unknown = JSON.parse(progressText ?? "null");
+    expect(JSON.stringify(manifest)).not.toContain("content");
+    expect(manifest).toMatchObject({
+      transactionId: "transaction-1",
+      operations: [
+        {
+          operationId: "operation-0001",
+          stagedPath:
+            ".brain/transactions/transaction-1/staging/operation-0001.payload",
+        },
+      ],
+    });
+    expect(progress).toMatchObject({
+      transactionId: "transaction-1",
+      manifestDigest: receipt.manifestDigest,
+      recoveryToken: receipt.recoveryToken,
+      phase: "committed",
+      publishedOperationIds: ["operation-0001"],
+      directorySync: "supported",
+    });
+
+    const registry = createSchemaRegistry();
+    expect(
+      registry.validate({
+        id: "state.transaction-manifest",
+        version: "1.0.0",
+        value: manifest,
+        structuralReasonCode: "runtime.state_corrupt",
+      }).kind,
+    ).toBe("valid");
+    expect(
+      registry.validate({
+        id: "state.transaction-progress",
+        version: "1.0.0",
+        value: progress,
+        structuralReasonCode: "runtime.state_corrupt",
+      }).kind,
+    ).toBe("valid");
+  });
+
+  it("initializes and synchronizes only the managed root bootstrap", async () => {
+    const storage = memoryTransactionStorage();
+    const plan: ManagedMutationPlan = {
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "write_file",
+          path: ".brain/state.json",
+          expected: { kind: "missing" },
+          result: {
+            kind: "file",
+            size: 3,
+            sha256: storage.digests.sha256("new"),
+          },
+          stagedPath: "staging/operation-0001.payload",
+          content: "new",
+        },
+      ],
+    };
+
+    await expect(
+      executeManagedMutation(
+        plan,
+        { rootMode: "initialize" },
+        services(storage),
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+
+    expect(storage.calls().slice(0, 7)).toEqual([
+      "inspect",
+      "inspect",
+      "create_directory",
+      "sync_directory",
+      "inspect",
+      "create_directory",
+      "sync_directory",
+    ]);
+    expect(storage.snapshot().directories).toEqual([
+      ".brain",
+      ".brain/transactions",
+      ".brain/transactions/transaction-1",
+    ]);
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+  });
+
+  it("refuses a missing existing root without creating bootstrap entries", async () => {
+    const storage = memoryTransactionStorage();
+    const plan: ManagedMutationPlan = {
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "create_directory",
+          path: ".brain/runs",
+          expected: { kind: "missing" },
+          result: { kind: "directory" },
+          stagedPath: null,
+        },
+      ],
+    };
+
+    await expect(
+      executeManagedMutation(plan, { rootMode: "existing" }, services(storage)),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain" },
+      ]),
+    );
+    expect(storage.snapshot()).toEqual({ files: {}, directories: [] });
+    expect(storage.calls()).toEqual(["inspect", "inspect"]);
+  });
+
+  it("leaves a pre-publication revision conflict explicitly abortable", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "actual" },
+    });
+
+    const injected = services(storage);
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({
+      reasonCode: "runtime.revision_conflict",
+      evidence: [{ kind: "artifact", ref: ".brain/state.json" }],
+    });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("actual");
+    const progress = JSON.parse(
+      storage.snapshot().files[
+        ".brain/transactions/transaction-1/progress.json"
+      ] ?? "null",
+    ) as { readonly phase?: unknown };
+    expect(progress.phase).toBe("begun");
+    const [summary] = await inspectManagedTransactions(injected);
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("actual");
+  });
+
+  it("publishes directory creation, file replacement, and deletion in order", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: {
+        ".brain/replace.json": "old",
+        ".brain/delete.json": "delete",
+      },
+    });
+    const mutation: ManagedMutationPlan = {
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "create_directory",
+          path: ".brain/new-directory",
+          expected: { kind: "missing" },
+          result: { kind: "directory" },
+          stagedPath: null,
+        },
+        {
+          operationId: "operation-0002",
+          kind: "write_file",
+          path: ".brain/replace.json",
+          expected: {
+            kind: "file",
+            size: 3,
+            sha256: storage.digests.sha256("old"),
+          },
+          result: {
+            kind: "file",
+            size: 3,
+            sha256: storage.digests.sha256("new"),
+          },
+          stagedPath: "staging/operation-0002.payload",
+          content: "new",
+        },
+        {
+          operationId: "operation-0003",
+          kind: "delete_file",
+          path: ".brain/delete.json",
+          expected: {
+            kind: "file",
+            size: 6,
+            sha256: storage.digests.sha256("delete"),
+          },
+          result: { kind: "missing" },
+          stagedPath: null,
+        },
+      ],
+    };
+
+    await expect(
+      executeManagedMutation(
+        mutation,
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().directories).toContain(".brain/new-directory");
+    expect(storage.snapshot().files[".brain/replace.json"]).toBe("new");
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/delete.json");
+  });
+
+  it("records unsupported directory synchronization in progress and receipt", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const unsupported: DurableFileSystem = {
+      ...base,
+      syncDirectory: async (path) => {
+        await base.syncDirectory(path);
+        return "unsupported";
+      },
+    };
+    const injected = {
+      ...services(storage),
+      durableFileSystem: unsupported,
+    };
+
+    const receipt = await executeManagedMutation(
+      replacementPlan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    expect(receipt.directorySync).toBe("unsupported");
+    const progress = JSON.parse(
+      storage.snapshot().files[
+        ".brain/transactions/transaction-1/progress.json"
+      ] ?? "null",
+    ) as { readonly directorySync?: unknown };
+    expect(progress.directorySync).toBe("unsupported");
+  });
+
+  it("does not initialize a reserved namespace inside a non-empty root", async () => {
+    const storage = memoryTransactionStorage({
+      files: { ".brain/existing.json": "existing" },
+    });
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "initialize" },
+        services(storage),
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files[".brain/existing.json"]).toBe("existing");
+    expect(storage.snapshot().directories).not.toContain(".brain/transactions");
+  });
+
+  it("refuses existing mode when only the managed root exists", async () => {
+    const storage = memoryTransactionStorage({ directories: [".brain"] });
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/runs",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().directories).toEqual([".brain"]);
+  });
+
+  it.each([
+    {
+      label: "special precondition",
+      occurrence: 1,
+      observed: { kind: "special" } as const,
+      reasonCode: "runtime.state_corrupt",
+    },
+    {
+      label: "drift immediately before publication",
+      occurrence: 2,
+      observed: { kind: "missing" } as const,
+      reasonCode: "runtime.revision_conflict",
+    },
+    {
+      label: "wrong immediate publication result",
+      occurrence: 3,
+      observed: { kind: "missing" } as const,
+      reasonCode: "runtime.state_corrupt",
+    },
+    {
+      label: "wrong final publication result",
+      occurrence: 4,
+      observed: { kind: "missing" } as const,
+      reasonCode: "runtime.state_corrupt",
+    },
+  ])(
+    "blocks a $label observation",
+    async ({ occurrence, observed, reasonCode }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const base = storage.durableFileSystem;
+      let targetInspections = 0;
+      const boundary: DurableFileSystem = {
+        ...base,
+        inspect: async (path): Promise<DurableEntry> => {
+          const actual = await base.inspect(path);
+          if (path !== ".brain/state.json") return actual;
+          targetInspections += 1;
+          return targetInspections === occurrence ? observed : actual;
+        },
+      };
+
+      await expect(
+        executeManagedMutation(
+          replacementPlan(storage),
+          { rootMode: "existing" },
+          { ...services(storage), durableFileSystem: boundary },
+        ),
+      ).rejects.toMatchObject({ reasonCode });
+    },
+  );
+
+  it("revalidates the destination parent immediately before publication", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions", ".brain/runs"],
+    });
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) =>
+        path === ".brain/runs" ? { kind: "missing" } : base.inspect(path),
+    };
+    const content = "state";
+    const mutation: ManagedMutationPlan = {
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "write_file",
+          path: ".brain/runs/state.json",
+          expected: { kind: "missing" },
+          result: {
+            kind: "file",
+            size: 5,
+            sha256: storage.digests.sha256(content),
+          },
+          stagedPath: "staging/operation-0001.payload",
+          content,
+        },
+      ],
+    };
+
+    await expect(
+      executeManagedMutation(
+        mutation,
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files).not.toHaveProperty(
+      ".brain/runs/state.json",
+    );
+  });
+
+  it("sanitizes a bootstrap failure before any marker becomes durable", async () => {
+    const storage = memoryTransactionStorage();
+    storage.fail({
+      operation: "create_directory",
+      timing: "before",
+      occurrence: 1,
+    });
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/runs",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+          ],
+        },
+        { rootMode: "initialize" },
+        services(storage),
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+    expect(storage.snapshot()).toEqual({ files: {}, directories: [] });
+  });
+
+  it("sanitizes an unexpected inspection failure while classifying a driver failure", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const base = storage.durableFileSystem;
+    let driverFailed = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      createDirectoryExclusive: () => {
+        driverFailed = true;
+        return Promise.reject(new Error("driver detail"));
+      },
+      inspect: async (path) => {
+        if (driverFailed) throw new Error("inspection detail");
+        return base.inspect(path);
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/runs",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+
+  it("rejects a non-file progress scratch entry", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) =>
+        path.endsWith("/progress.next")
+          ? { kind: "directory" }
+          : base.inspect(path),
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+  });
+});

--- a/tests/transaction-execution.test.ts
+++ b/tests/transaction-execution.test.ts
@@ -6,6 +6,7 @@ import {
   type TransactionServices,
 } from "@mestre-yoda/runtime/composition";
 import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
+import { canonicalizeJson } from "@mestre-yoda/runtime/domain/schema";
 import type {
   DurableEntry,
   DurableFileSystem,
@@ -57,6 +58,431 @@ function replacementPlan(
 }
 
 describe("managed transaction execution", () => {
+  it.each([
+    {
+      label: "non-object plan",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => null,
+    },
+    {
+      label: "non-array operations",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({ operations: "forged" }),
+    },
+    {
+      label: "empty plan",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({ operations: [] }),
+    },
+    {
+      label: "non-object operation",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({ operations: [null] }),
+    },
+    {
+      label: "unknown operation kind",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "rename_file",
+            path: ".brain/state.json",
+            expected: { kind: "missing" },
+            result: { kind: "file", size: 3, sha256: "f".repeat(64) },
+            stagedPath: null,
+          },
+        ],
+      }),
+    },
+    {
+      label: "invalid create fingerprints",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/runs",
+            expected: { kind: "file", size: 1, sha256: "f".repeat(64) },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+        ],
+      }),
+    },
+    {
+      label: "invalid delete fingerprints",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "delete_file",
+            path: ".brain/state.json",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+        ],
+      }),
+    },
+    {
+      label: "non-object fingerprint",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            expected: null,
+          },
+        ],
+      }),
+    },
+    {
+      label: "extended missing fingerprint",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            expected: { kind: "missing", forged: true },
+          },
+        ],
+      }),
+    },
+    {
+      label: "extended directory fingerprint",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/runs",
+            expected: { kind: "missing" },
+            result: { kind: "directory", forged: true },
+            stagedPath: null,
+          },
+        ],
+      }),
+    },
+    {
+      label: "invalid file fingerprint",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            expected: { kind: "file", size: -1, sha256: "not-a-digest" },
+          },
+        ],
+      }),
+    },
+    {
+      label: "unknown fingerprint kind",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            expected: { kind: "special" },
+          },
+        ],
+      }),
+    },
+    {
+      label: "outside destination",
+      reasonCode: "guard.outside_allow",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            path: "src/owned.txt",
+          },
+        ],
+      }),
+    },
+    {
+      label: "reserved destination",
+      reasonCode: "guard.outside_allow",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            path: ".brain/transactions/owned.txt",
+          },
+        ],
+      }),
+    },
+    {
+      label: "unsafe destination",
+      reasonCode: "guard.outside_allow",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            path: ".brain/../owned.txt",
+          },
+        ],
+      }),
+    },
+    {
+      label: "control-character destination",
+      reasonCode: "guard.outside_allow",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            path: ".brain/control\npath",
+          },
+        ],
+      }),
+    },
+    {
+      label: "forged operation ID",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            operationId: "operation-0002",
+            stagedPath: "staging/operation-0002.payload",
+          },
+        ],
+      }),
+    },
+    {
+      label: "forged staged payload",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            stagedPath: "staging/forged.payload",
+          },
+        ],
+      }),
+    },
+    {
+      label: "equal expected and result fingerprints",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => {
+        const operation = replacementPlan(storage).operations[0];
+        return {
+          operations: [
+            {
+              ...operation,
+              expected: operation?.result,
+            },
+          ],
+        };
+      },
+    },
+    {
+      label: "content fingerprint mismatch",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            result: {
+              kind: "file",
+              size: 999,
+              sha256: storage.digests.sha256("forged"),
+            },
+          },
+        ],
+      }),
+    },
+    {
+      label: "case-colliding destinations",
+      reasonCode: "runtime.state_corrupt",
+      plan: () => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/Runs",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+          {
+            operationId: "operation-0002",
+            kind: "create_directory",
+            path: ".brain/runs",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+        ],
+      }),
+    },
+    {
+      label: "duplicate destinations",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          replacementPlan(storage).operations[0],
+          {
+            ...replacementPlan(storage).operations[0],
+            operationId: "operation-0002",
+            stagedPath: "staging/operation-0002.payload",
+          },
+        ],
+      }),
+    },
+    {
+      label: "non-directory parent operation",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            path: ".brain/runs",
+          },
+          {
+            ...replacementPlan(storage).operations[0],
+            operationId: "operation-0002",
+            path: ".brain/runs/state.json",
+            stagedPath: "staging/operation-0002.payload",
+          },
+        ],
+      }),
+    },
+    {
+      label: "invalid parent-child order",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            ...replacementPlan(storage).operations[0],
+            path: ".brain/runs/state.json",
+          },
+          {
+            operationId: "operation-0002",
+            kind: "create_directory",
+            path: ".brain/runs",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+        ],
+      }),
+    },
+  ])(
+    "rejects a forged $label before every injected effect boundary",
+    async ({ plan, reasonCode }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: {
+          ".brain/state.json": "old",
+          "src/owned.txt": "old",
+        },
+      });
+      const before = storage.snapshot();
+      let clockCalls = 0;
+      let idCalls = 0;
+      const injected: TransactionServices = {
+        ...services(storage),
+        clock: {
+          now: () => {
+            clockCalls += 1;
+            return new Date("2026-08-09T00:00:00.000Z");
+          },
+        },
+        ids: {
+          next: () => {
+            idCalls += 1;
+            return "transaction-1";
+          },
+        },
+      };
+
+      await expect(
+        executeManagedMutation(
+          plan(storage) as ManagedMutationPlan,
+          { rootMode: "existing" },
+          injected,
+        ),
+      ).rejects.toMatchObject({ reasonCode });
+      expect(storage.snapshot()).toEqual(before);
+      expect(storage.calls()).toEqual([]);
+      expect(clockCalls).toBe(0);
+      expect(idCalls).toBe(0);
+    },
+  );
+
+  it("executes an immutable snapshot when the caller mutates its plan after preflight", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const original = replacementPlan(storage).operations[0];
+    if (original?.kind !== "write_file") {
+      throw new Error("missing write fixture operation");
+    }
+    const mutablePlan: { operations: ManagedMutationPlan["operations"] } = {
+      operations: [original],
+    };
+    const base = storage.durableFileSystem;
+    let mutated = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) => {
+        if (!mutated) {
+          mutated = true;
+          mutablePlan.operations = [
+            {
+              ...original,
+              content: "evil",
+              result: {
+                kind: "file",
+                size: 4,
+                sha256: storage.digests.sha256("evil"),
+              },
+            },
+          ];
+        }
+        return base.inspect(path);
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        mutablePlan,
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+  });
+
+  it("sanitizes a digest failure during preflight without crossing another boundary", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected: TransactionServices = {
+      ...services(storage),
+      digests: {
+        sha256: () => {
+          throw new Error("digest detail");
+        },
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+    expect(storage.calls()).toEqual([]);
+  });
+
   it("durably prepares, publishes, commits, and removes staged payloads", async () => {
     const storage = memoryTransactionStorage({
       directories: [".brain/transactions"],
@@ -162,7 +588,8 @@ describe("managed transaction execution", () => {
       ),
     ).resolves.toMatchObject({ phase: "committed" });
 
-    expect(storage.calls().slice(0, 7)).toEqual([
+    expect(storage.calls().slice(0, 8)).toEqual([
+      "inspect",
       "inspect",
       "inspect",
       "create_directory",
@@ -202,7 +629,7 @@ describe("managed transaction execution", () => {
       ]),
     );
     expect(storage.snapshot()).toEqual({ files: {}, directories: [] });
-    expect(storage.calls()).toEqual(["inspect", "inspect"]);
+    expect(storage.calls()).toEqual(["inspect", "inspect", "inspect"]);
   });
 
   it("leaves a pre-publication revision conflict explicitly abortable", async () => {
@@ -304,6 +731,47 @@ describe("managed transaction execution", () => {
     expect(storage.snapshot().files).not.toHaveProperty(".brain/delete.json");
   });
 
+  it("accepts a normalized parent-first directory and child write", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const content = "state";
+    const mutation: ManagedMutationPlan = {
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "create_directory",
+          path: ".brain/runs",
+          expected: { kind: "missing" },
+          result: { kind: "directory" },
+          stagedPath: null,
+        },
+        {
+          operationId: "operation-0002",
+          kind: "write_file",
+          path: ".brain/runs/state.json",
+          expected: { kind: "missing" },
+          result: {
+            kind: "file",
+            size: 5,
+            sha256: storage.digests.sha256(content),
+          },
+          stagedPath: "staging/operation-0002.payload",
+          content,
+        },
+      ],
+    };
+
+    await expect(
+      executeManagedMutation(
+        mutation,
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().files[".brain/runs/state.json"]).toBe(content);
+  });
+
   it("records unsupported directory synchronization in progress and receipt", async () => {
     const storage = memoryTransactionStorage({
       directories: [".brain/transactions"],
@@ -387,19 +855,19 @@ describe("managed transaction execution", () => {
       label: "drift immediately before publication",
       occurrence: 2,
       observed: { kind: "missing" } as const,
-      reasonCode: "runtime.revision_conflict",
+      reasonCode: "runtime.recovery_required",
     },
     {
       label: "wrong immediate publication result",
       occurrence: 3,
       observed: { kind: "missing" } as const,
-      reasonCode: "runtime.state_corrupt",
+      reasonCode: "runtime.recovery_required",
     },
     {
       label: "wrong final publication result",
       occurrence: 4,
       observed: { kind: "missing" } as const,
-      reasonCode: "runtime.state_corrupt",
+      reasonCode: "runtime.recovery_required",
     },
   ])(
     "blocks a $label observation",
@@ -429,6 +897,218 @@ describe("managed transaction execution", () => {
       ).rejects.toMatchObject({ reasonCode });
     },
   );
+
+  it("reclassifies persistent drift after publishing as corrupt state", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    let targetInspections = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path): Promise<DurableEntry> => {
+        const actual = await base.inspect(path);
+        if (path !== ".brain/state.json") return actual;
+        targetInspections += 1;
+        return targetInspections >= 2 ? { kind: "missing" } : actual;
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain/state.json" },
+      ]),
+    );
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
+  it("rebinds progress identity while classifying a publishing failure", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    let targetInspections = 0;
+    let progressReads = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path): Promise<DurableEntry> => {
+        const actual = await base.inspect(path);
+        if (path !== ".brain/state.json") return actual;
+        targetInspections += 1;
+        return targetInspections === 2 ? { kind: "missing" } : actual;
+      },
+      readText: async (path) => {
+        const actual = await base.readText(path);
+        if (path !== progressPath) return actual;
+        progressReads += 1;
+        if (progressReads !== 2) return actual;
+        const replacement = JSON.parse(actual) as Record<string, unknown>;
+        replacement.recoveryToken = "f".repeat(64);
+        return `${canonicalizeJson(replacement)}\n`;
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
+  it("classifies persistent create-directory drift from fresh state", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const base = storage.durableFileSystem;
+    let targetInspections = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path): Promise<DurableEntry> => {
+        const actual = await base.inspect(path);
+        if (path !== ".brain/runs") return actual;
+        targetInspections += 1;
+        return targetInspections >= 2
+          ? { kind: "file", size: 1, sha256: "f".repeat(64) }
+          : actual;
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/runs",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain/runs" },
+      ]),
+    );
+  });
+
+  it("classifies an invalid publishing prefix without inventing an operation", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    let targetInspections = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path): Promise<DurableEntry> => {
+        const actual = await base.inspect(path);
+        if (path !== ".brain/state.json") return actual;
+        targetInspections += 1;
+        return targetInspections === 2 ? { kind: "missing" } : actual;
+      },
+      readText: async (path) => {
+        const actual = await base.readText(path);
+        if (path !== progressPath) return actual;
+        const replacement = JSON.parse(actual) as Record<string, unknown>;
+        replacement.publishedOperationIds = ["operation-unknown"];
+        return `${canonicalizeJson(replacement)}\n`;
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+  });
+
+  it("persists directory-sync capability discovered during terminal cleanup", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const root = ".brain/transactions/transaction-1";
+    const staging = `${root}/staging`;
+    const boundary: DurableFileSystem = {
+      ...base,
+      syncDirectory: async (path) => {
+        await base.syncDirectory(path);
+        return path === root && (await base.inspect(staging)).kind === "missing"
+          ? "unsupported"
+          : "supported";
+      },
+    };
+    const injected = { ...services(storage), durableFileSystem: boundary };
+
+    const first = await executeManagedMutation(
+      replacementPlan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    const second = await recoverManagedMutation(
+      {
+        transactionId: first.transactionId,
+        recoveryToken: first.recoveryToken,
+      },
+      injected,
+    );
+    expect(first.directorySync).toBe("unsupported");
+    expect(second).toEqual(first);
+  });
+
+  it("reconstructs a committed receipt after terminal cleanup completed before an error", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    storage.fail({
+      operation: "remove_empty_directory",
+      timing: "after",
+      occurrence: 1,
+    });
+    const injected = services(storage);
+
+    const first = await executeManagedMutation(
+      replacementPlan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    const second = await recoverManagedMutation(
+      {
+        transactionId: first.transactionId,
+        recoveryToken: first.recoveryToken,
+      },
+      injected,
+    );
+    expect(first.phase).toBe("committed");
+    expect(second).toEqual(first);
+  });
 
   it("revalidates the destination parent immediately before publication", async () => {
     const storage = memoryTransactionStorage({
@@ -471,6 +1151,50 @@ describe("managed transaction execution", () => {
     );
   });
 
+  it.each([
+    { label: "altered", action: "alter" as const },
+    { label: "missing", action: "remove" as const },
+  ])(
+    "blocks an $label staged payload immediately before publication",
+    async ({ action }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const base = storage.durableFileSystem;
+      const payload =
+        ".brain/transactions/transaction-1/staging/operation-0001.payload";
+      let tampered = false;
+      const boundary: DurableFileSystem = {
+        ...base,
+        inspect: async (path) => {
+          if (path === ".brain/state.json" && !tampered) {
+            tampered = true;
+            if (action === "alter") {
+              await storage.fileSystem.write(payload, "evil");
+            } else {
+              await base.removeFile(payload);
+            }
+          }
+          return base.inspect(path);
+        },
+      };
+
+      await expect(
+        executeManagedMutation(
+          replacementPlan(storage),
+          { rootMode: "existing" },
+          { ...services(storage), durableFileSystem: boundary },
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: payload },
+        ]),
+      );
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    },
+  );
+
   it("sanitizes a bootstrap failure before any marker becomes durable", async () => {
     const storage = memoryTransactionStorage();
     storage.fail({
@@ -498,6 +1222,40 @@ describe("managed transaction execution", () => {
       ),
     ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
     expect(storage.snapshot()).toEqual({ files: {}, directories: [] });
+  });
+
+  it("sanitizes an exclusive-create failure that leaves no attempt directory", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      createDirectoryExclusive: () =>
+        Promise.reject(new Error("create detail")),
+    };
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/runs",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+    expect(storage.snapshot().directories).not.toContain(
+      ".brain/transactions/transaction-1",
+    );
   });
 
   it("sanitizes an unexpected inspection failure while classifying a driver failure", async () => {

--- a/tests/transaction-execution.test.ts
+++ b/tests/transaction-execution.test.ts
@@ -413,6 +413,72 @@ describe("managed transaction execution", () => {
       }),
     },
     {
+      label: "skipped intermediate prefix beneath a newly created ancestor",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/a",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+          {
+            operationId: "operation-0002",
+            kind: "write_file",
+            path: ".brain/a/b/state.json",
+            expected: { kind: "missing" },
+            result: {
+              kind: "file",
+              size: 3,
+              sha256: storage.digests.sha256("new"),
+            },
+            stagedPath: "staging/operation-0002.payload",
+            content: "new",
+          },
+        ],
+      }),
+    },
+    {
+      label: "skipped deep prefix after a partial created chain",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/a",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+          {
+            operationId: "operation-0002",
+            kind: "create_directory",
+            path: ".brain/a/b",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+          {
+            operationId: "operation-0003",
+            kind: "write_file",
+            path: ".brain/a/b/c/state.json",
+            expected: { kind: "missing" },
+            result: {
+              kind: "file",
+              size: 3,
+              sha256: storage.digests.sha256("new"),
+            },
+            stagedPath: "staging/operation-0003.payload",
+            content: "new",
+          },
+        ],
+      }),
+    },
+    {
       label: "invalid parent-child order",
       reasonCode: "runtime.state_corrupt",
       plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
@@ -833,6 +899,91 @@ describe("managed transaction execution", () => {
     expect(storage.snapshot().files[".brain/runs/state.json"]).toBe(content);
   });
 
+  it("accepts a complete synthesized directory chain before a deep child write", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const content = "state";
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/a",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+            {
+              operationId: "operation-0002",
+              kind: "create_directory",
+              path: ".brain/a/b",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+            {
+              operationId: "operation-0003",
+              kind: "write_file",
+              path: ".brain/a/b/state.json",
+              expected: { kind: "missing" },
+              result: {
+                kind: "file",
+                size: 5,
+                sha256: storage.digests.sha256(content),
+              },
+              stagedPath: "staging/operation-0003.payload",
+              content,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().files[".brain/a/b/state.json"]).toBe(content);
+  });
+
+  it("accepts a deep path beneath preexisting ancestors absent from the plan", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions", ".brain/a", ".brain/a/b"],
+      files: { ".brain/a/b/state.json": "old" },
+    });
+    const content = "new";
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "write_file",
+              path: ".brain/a/b/state.json",
+              expected: {
+                kind: "file",
+                size: 3,
+                sha256: storage.digests.sha256("old"),
+              },
+              result: {
+                kind: "file",
+                size: 3,
+                sha256: storage.digests.sha256(content),
+              },
+              stagedPath: "staging/operation-0001.payload",
+              content,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().files[".brain/a/b/state.json"]).toBe(content);
+  });
+
   it("records unsupported directory synchronization in progress and receipt", async () => {
     const storage = memoryTransactionStorage({
       directories: [".brain/transactions"],
@@ -1202,6 +1353,122 @@ describe("managed transaction execution", () => {
     const [summary] = await inspectManagedTransactions(services(storage));
     expect(summary?.phase).toBe("publishing");
     expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
+  it("uses durable publishing context when a stale typed failure is followed by a raw scan failure", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    let targetInspections = 0;
+    let classificationStarted = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path): Promise<DurableEntry> => {
+        if (classificationStarted && path === ".brain") {
+          throw new Error("classification scan detail");
+        }
+        const actual = await base.inspect(path);
+        if (path !== ".brain/state.json") return actual;
+        targetInspections += 1;
+        if (targetInspections === 2) {
+          classificationStarted = true;
+          return { kind: "missing" };
+        }
+        return actual;
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+    const [summary] = await inspectManagedTransactions(services(storage));
+    expect(summary?.phase).toBe("publishing");
+  });
+
+  it("uses durable publishing context when raw publication and scan both fail", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    let publicationFailed = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      replaceFile: (stagedPath, targetPath) => {
+        if (targetPath === ".brain/state.json") {
+          publicationFailed = true;
+          return Promise.reject(new Error("publication detail"));
+        }
+        return base.replaceFile(stagedPath, targetPath);
+      },
+      inspect: (path) =>
+        publicationFailed && path === ".brain"
+          ? Promise.reject(new Error("classification scan detail"))
+          : base.inspect(path),
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+    const [summary] = await inspectManagedTransactions(services(storage));
+    expect(summary?.phase).toBe("publishing");
+  });
+
+  it("keeps a pre-prepared revision conflict when its classification scan fails", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    let preconditionFailed = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path): Promise<DurableEntry> => {
+        if (preconditionFailed && path === ".brain") {
+          throw new Error("classification scan detail");
+        }
+        const actual = await base.inspect(path);
+        if (path === ".brain/state.json") {
+          preconditionFailed = true;
+          return { kind: "missing" };
+        }
+        return actual;
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.revision_conflict", [
+        { kind: "artifact", ref: ".brain/state.json" },
+      ]),
+    );
+    const [summary] = await inspectManagedTransactions(services(storage));
+    expect(summary?.phase).toBe("begun");
   });
 
   it("persists directory-sync capability discovered during terminal cleanup", async () => {

--- a/tests/transaction-execution.test.ts
+++ b/tests/transaction-execution.test.ts
@@ -715,7 +715,8 @@ describe("managed transaction execution", () => {
       ),
     ).resolves.toMatchObject({ phase: "committed" });
 
-    expect(storage.calls().slice(0, 8)).toEqual([
+    expect(storage.calls().slice(0, 9)).toEqual([
+      "inspect",
       "inspect",
       "inspect",
       "inspect",
@@ -756,8 +757,48 @@ describe("managed transaction execution", () => {
       ]),
     );
     expect(storage.snapshot()).toEqual({ files: {}, directories: [] });
-    expect(storage.calls()).toEqual(["inspect", "inspect", "inspect"]);
+    expect(storage.calls()).toEqual(["inspect", "inspect"]);
   });
+
+  it.each([
+    { path: ".brain", evidenceRef: ".brain" },
+    {
+      path: ".brain/transactions",
+      evidenceRef: ".brain/transactions",
+    },
+  ])(
+    "rejects $path changing after the repeated preflight",
+    async ({ path, evidenceRef }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain", ".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      let inspections = 0;
+      const boundary: DurableFileSystem = {
+        ...storage.durableFileSystem,
+        inspect(candidate): Promise<DurableEntry> {
+          if (candidate === path && ++inspections === 4) {
+            return Promise.resolve({ kind: "special" });
+          }
+          return storage.durableFileSystem.inspect(candidate);
+        },
+      };
+
+      await expect(
+        executeManagedMutation(
+          replacementPlan(storage),
+          { rootMode: "existing" },
+          { ...services(storage), durableFileSystem: boundary },
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: evidenceRef },
+        ]),
+      );
+      expect(inspections).toBe(4);
+      expect(storage.calls()).not.toContain("create_directory_exclusive");
+    },
+  );
 
   it("leaves a pre-publication revision conflict explicitly abortable", async () => {
     const storage = memoryTransactionStorage({

--- a/tests/transaction-execution.test.ts
+++ b/tests/transaction-execution.test.ts
@@ -352,6 +352,67 @@ describe("managed transaction execution", () => {
       }),
     },
     {
+      label: "preexisting child beneath a newly created ancestor",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/runs",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+          {
+            operationId: "operation-0002",
+            kind: "write_file",
+            path: ".brain/runs/state.json",
+            expected: {
+              kind: "file",
+              size: 3,
+              sha256: storage.digests.sha256("old"),
+            },
+            result: {
+              kind: "file",
+              size: 3,
+              sha256: storage.digests.sha256("new"),
+            },
+            stagedPath: "staging/operation-0002.payload",
+            content: "new",
+          },
+        ],
+      }),
+    },
+    {
+      label: "preexisting deleted child beneath a newly created ancestor",
+      reasonCode: "runtime.state_corrupt",
+      plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/runs",
+            expected: { kind: "missing" },
+            result: { kind: "directory" },
+            stagedPath: null,
+          },
+          {
+            operationId: "operation-0002",
+            kind: "delete_file",
+            path: ".brain/runs/state.json",
+            expected: {
+              kind: "file",
+              size: 3,
+              sha256: storage.digests.sha256("old"),
+            },
+            result: { kind: "missing" },
+            stagedPath: null,
+          },
+        ],
+      }),
+    },
+    {
       label: "invalid parent-child order",
       reasonCode: "runtime.state_corrupt",
       plan: (storage: ReturnType<typeof memoryTransactionStorage>) => ({
@@ -1045,6 +1106,102 @@ describe("managed transaction execution", () => {
         { kind: "artifact", ref: progressPath },
       ]),
     );
+  });
+
+  it.each(["inspect", "read", "list"] as const)(
+    "classifies a raw $label failure during fresh publishing observation as recovery required",
+    async (failureBoundary) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const base = storage.durableFileSystem;
+      const progressPath = ".brain/transactions/transaction-1/progress.json";
+      const staging = ".brain/transactions/transaction-1/staging";
+      let targetInspections = 0;
+      let progressReads = 0;
+      const boundary: DurableFileSystem = {
+        ...base,
+        inspect: async (path): Promise<DurableEntry> => {
+          if (path === ".brain/state.json") {
+            targetInspections += 1;
+            if (failureBoundary === "inspect" && targetInspections === 3) {
+              throw new Error("fresh inspect detail");
+            }
+          }
+          const actual = await base.inspect(path);
+          return path === ".brain/state.json" && targetInspections === 2
+            ? { kind: "missing" }
+            : actual;
+        },
+        readText: async (path) => {
+          if (path === progressPath) {
+            progressReads += 1;
+            if (failureBoundary === "read" && progressReads === 2) {
+              throw new Error("fresh read detail");
+            }
+          }
+          return base.readText(path);
+        },
+        list: async (path) => {
+          if (failureBoundary === "list" && path === staging) {
+            throw new Error("fresh list detail");
+          }
+          return base.list(path);
+        },
+      };
+
+      await expect(
+        executeManagedMutation(
+          replacementPlan(storage),
+          { rootMode: "existing" },
+          { ...services(storage), durableFileSystem: boundary },
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.recovery_required", [
+          { kind: "artifact", ref: progressPath },
+        ]),
+      );
+      const [summary] = await inspectManagedTransactions(services(storage));
+      expect(summary?.phase).toBe("publishing");
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    },
+  );
+
+  it("classifies raw original and fresh publishing failures as recovery required", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    const staging = ".brain/transactions/transaction-1/staging";
+    const boundary: DurableFileSystem = {
+      ...base,
+      replaceFile: (stagedPath, targetPath) =>
+        targetPath === ".brain/state.json"
+          ? Promise.reject(new Error("original publish detail"))
+          : base.replaceFile(stagedPath, targetPath),
+      list: (path) =>
+        path === staging
+          ? Promise.reject(new Error("fresh list detail"))
+          : base.list(path),
+    };
+
+    await expect(
+      executeManagedMutation(
+        replacementPlan(storage),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+    const [summary] = await inspectManagedTransactions(services(storage));
+    expect(summary?.phase).toBe("publishing");
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
   });
 
   it("persists directory-sync capability discovered during terminal cleanup", async () => {

--- a/tests/transaction-execution.test.ts
+++ b/tests/transaction-execution.test.ts
@@ -825,15 +825,20 @@ describe("managed transaction execution", () => {
     ) as { readonly phase?: unknown };
     expect(progress.phase).toBe("begun");
     const [summary] = await inspectManagedTransactions(injected);
-    await expect(
-      recoverManagedMutation(
-        {
-          transactionId: "transaction-1",
-          recoveryToken: summary?.recoveryToken ?? "missing",
-        },
-        injected,
-      ),
-    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    const request = {
+      transactionId: "transaction-1",
+      recoveryToken: summary?.recoveryToken ?? "missing",
+    };
+    const first = await recoverManagedMutation(request, injected);
+    const second = await recoverManagedMutation(request, injected);
+    expect(first).toEqual({
+      transactionId: "transaction-1",
+      manifestDigest: null,
+      recoveryToken: summary?.recoveryToken,
+      phase: "aborted",
+      directorySync: "supported",
+    });
+    expect(second).toEqual(first);
     expect(storage.snapshot().files[".brain/state.json"]).toBe("actual");
   });
 

--- a/tests/transaction-fault-campaign.test.ts
+++ b/tests/transaction-fault-campaign.test.ts
@@ -21,6 +21,8 @@ import {
 import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
 import { describe, expect, it } from "vitest";
 
+const campaignTimeoutMilliseconds = 30_000;
+
 function services(
   storage: ReturnType<typeof memoryTransactionStorage>,
 ): TransactionServices {
@@ -234,6 +236,7 @@ describe("transaction fault campaign", () => {
     expect(enumerateMatrix(storage.calls())).toHaveLength(220);
   });
 
+  // prettier-ignore
   it("recovers idempotently at every reached before and after boundary", async () => {
     const baseline = campaignStorage();
     await executeManagedMutation(
@@ -327,7 +330,7 @@ describe("transaction fault campaign", () => {
         firstRecovery.manifestDigest !== null,
       );
     }
-  });
+  }, campaignTimeoutMilliseconds);
 
   it.each(["permission", "disk_full"] as const)(
     "maps a synthetic %s fault without leaking private transaction data",

--- a/tests/transaction-fault-campaign.test.ts
+++ b/tests/transaction-fault-campaign.test.ts
@@ -187,6 +187,7 @@ async function executeCapturing(
 function expectTerminalDestinations(
   storage: ReturnType<typeof memoryTransactionStorage>,
   terminal: "committed" | "aborted",
+  manifestBound: boolean,
 ): void {
   const snapshot = storage.snapshot();
   expect(snapshot.files[".brain/a.json"]).toBe(
@@ -204,6 +205,18 @@ function expectTerminalDestinations(
   ).toEqual([]);
   expect(
     snapshot.directories.filter((path) => path.endsWith("/staging")),
+  ).toEqual([]);
+  const receiptRoot = ".brain/transactions/transaction-1";
+  expect(
+    Object.keys(snapshot.files)
+      .filter((path) => path.startsWith(`${receiptRoot}/`))
+      .map((path) => path.slice(receiptRoot.length + 1))
+      .sort((left, right) => left.localeCompare(right, "en-US")),
+  ).toEqual(
+    manifestBound ? ["manifest.json", "progress.json"] : ["progress.json"],
+  );
+  expect(
+    snapshot.directories.filter((path) => path.startsWith(`${receiptRoot}/`)),
   ).toEqual([]);
 }
 
@@ -236,6 +249,7 @@ describe("transaction fault campaign", () => {
       storage.fail(entry);
       const injected = services(storage);
       const execution = await executeCapturing(storage);
+      expect(storage.failureHits(), label).toEqual([entry]);
       let summaries;
       try {
         summaries = await inspectManagedTransactions(injected);
@@ -307,7 +321,11 @@ describe("transaction fault campaign", () => {
           phase: terminal,
         },
       ]);
-      expectTerminalDestinations(storage, terminal);
+      expectTerminalDestinations(
+        storage,
+        terminal,
+        firstRecovery.manifestDigest !== null,
+      );
     }
   });
 

--- a/tests/transaction-fault-campaign.test.ts
+++ b/tests/transaction-fault-campaign.test.ts
@@ -1,0 +1,405 @@
+import {
+  executeManagedMutation,
+  inspectManagedTransactions,
+  recoverManagedMutation,
+  TransactionFailure,
+  type TransactionReceipt,
+  type TransactionServices,
+} from "@mestre-yoda/runtime/composition";
+import {
+  renderResultHuman,
+  renderResultJson,
+  transactionFailureResult,
+} from "@mestre-yoda/runtime/domain/result";
+import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
+import {
+  fixedClock,
+  memoryTransactionStorage,
+  sequentialIds,
+  type DurableOperation,
+} from "@mestre-yoda/runtime/infra/fake";
+import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
+import { describe, expect, it } from "vitest";
+
+function services(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+): TransactionServices {
+  return {
+    clock: fixedClock("2026-08-09T00:00:00.000Z"),
+    ids: sequentialIds("transaction"),
+    digests: storage.digests,
+    durableFileSystem: storage.durableFileSystem,
+    schemaRegistry: createSchemaRegistry(),
+  };
+}
+
+function campaignStorage(): ReturnType<typeof memoryTransactionStorage> {
+  return memoryTransactionStorage({
+    directories: [".brain/transactions"],
+    files: {
+      ".brain/a.json": "a1",
+      ".brain/delete.json": "delete",
+    },
+  });
+}
+
+function campaignPlan(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+): ManagedMutationPlan {
+  const file = (content: string) => ({
+    kind: "file" as const,
+    size: new TextEncoder().encode(content).byteLength,
+    sha256: storage.digests.sha256(content),
+  });
+  return {
+    operations: [
+      {
+        operationId: "operation-0001",
+        kind: "write_file",
+        path: ".brain/a.json",
+        expected: file("a1"),
+        result: file("a2"),
+        stagedPath: "staging/operation-0001.payload",
+        content: "a2",
+      },
+      {
+        operationId: "operation-0002",
+        kind: "write_file",
+        path: ".brain/b.json",
+        expected: { kind: "missing" },
+        result: file("b1"),
+        stagedPath: "staging/operation-0002.payload",
+        content: "b1",
+      },
+      {
+        operationId: "operation-0003",
+        kind: "delete_file",
+        path: ".brain/delete.json",
+        expected: file("delete"),
+        result: { kind: "missing" },
+        stagedPath: null,
+      },
+    ],
+  };
+}
+
+const durableOperations: readonly DurableOperation[] = [
+  "inspect",
+  "list",
+  "read_text",
+  "create_directory",
+  "create_directory_exclusive",
+  "open_file",
+  "write_file",
+  "sync_file",
+  "close_file",
+  "replace_file",
+  "remove_file",
+  "remove_empty_directory",
+  "sync_directory",
+];
+
+const expectedOperationCounts: Readonly<Record<DurableOperation, number>> = {
+  inspect: 38,
+  list: 3,
+  read_text: 0,
+  create_directory: 1,
+  create_directory_exclusive: 1,
+  open_file: 10,
+  write_file: 10,
+  sync_file: 10,
+  close_file: 10,
+  replace_file: 9,
+  remove_file: 1,
+  remove_empty_directory: 1,
+  sync_directory: 16,
+};
+
+function operationCounts(
+  calls: readonly DurableOperation[],
+): Readonly<Record<DurableOperation, number>> {
+  return Object.fromEntries(
+    durableOperations.map((operation) => [
+      operation,
+      calls.filter((candidate) => candidate === operation).length,
+    ]),
+  ) as Readonly<Record<DurableOperation, number>>;
+}
+
+interface MatrixEntry {
+  readonly operation: DurableOperation;
+  readonly timing: "before" | "after";
+  readonly occurrence: number;
+  readonly expectedPhase:
+    "begun" | "prepared" | "publishing" | "committed" | null;
+}
+
+function enumerateMatrix(calls: readonly DurableOperation[]): MatrixEntry[] {
+  const occurrences = new Map<DurableOperation, number>();
+  let durablePhase: MatrixEntry["expectedPhase"] = null;
+  const entries: MatrixEntry[] = [];
+  for (const operation of calls) {
+    const occurrence = (occurrences.get(operation) ?? 0) + 1;
+    occurrences.set(operation, occurrence);
+    entries.push({
+      operation,
+      timing: "before",
+      occurrence,
+      expectedPhase: durablePhase,
+    });
+    if (operation === "replace_file") {
+      if (occurrence === 1) durablePhase = "begun";
+      if (occurrence === 2) durablePhase = "prepared";
+      if (occurrence === 3) durablePhase = "publishing";
+      if (occurrence === 9) durablePhase = "committed";
+    }
+    entries.push({
+      operation,
+      timing: "after",
+      occurrence,
+      expectedPhase: durablePhase,
+    });
+  }
+  return entries;
+}
+
+async function executeCapturing(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+  plan: ManagedMutationPlan = campaignPlan(storage),
+): Promise<
+  | { readonly kind: "receipt"; readonly receipt: TransactionReceipt }
+  | { readonly kind: "failure"; readonly failure: unknown }
+> {
+  try {
+    return {
+      kind: "receipt",
+      receipt: await executeManagedMutation(
+        plan,
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    };
+  } catch (failure) {
+    return { kind: "failure", failure };
+  }
+}
+
+function expectTerminalDestinations(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+  terminal: "committed" | "aborted",
+): void {
+  const snapshot = storage.snapshot();
+  expect(snapshot.files[".brain/a.json"]).toBe(
+    terminal === "committed" ? "a2" : "a1",
+  );
+  if (terminal === "committed") {
+    expect(snapshot.files[".brain/b.json"]).toBe("b1");
+    expect(snapshot.files).not.toHaveProperty(".brain/delete.json");
+  } else {
+    expect(snapshot.files).not.toHaveProperty(".brain/b.json");
+    expect(snapshot.files[".brain/delete.json"]).toBe("delete");
+  }
+  expect(
+    Object.keys(snapshot.files).filter((path) => path.endsWith(".payload")),
+  ).toEqual([]);
+  expect(
+    snapshot.directories.filter((path) => path.endsWith("/staging")),
+  ).toEqual([]);
+}
+
+describe("transaction fault campaign", () => {
+  it("records every durable operation occurrence reached by the campaign plan", async () => {
+    const storage = campaignStorage();
+
+    await executeManagedMutation(
+      campaignPlan(storage),
+      { rootMode: "existing" },
+      services(storage),
+    );
+
+    expect(operationCounts(storage.calls())).toEqual(expectedOperationCounts);
+    expect(enumerateMatrix(storage.calls())).toHaveLength(220);
+  });
+
+  it("recovers idempotently at every reached before and after boundary", async () => {
+    const baseline = campaignStorage();
+    await executeManagedMutation(
+      campaignPlan(baseline),
+      { rootMode: "existing" },
+      services(baseline),
+    );
+    const matrix = enumerateMatrix(baseline.calls());
+
+    for (const entry of matrix) {
+      const label = `${entry.operation}:${entry.timing}:${String(entry.occurrence)}`;
+      const storage = campaignStorage();
+      storage.fail(entry);
+      const injected = services(storage);
+      const execution = await executeCapturing(storage);
+      let summaries;
+      try {
+        summaries = await inspectManagedTransactions(injected);
+      } catch (error) {
+        throw new Error(`inspection failed for ${label}`, { cause: error });
+      }
+
+      if (entry.expectedPhase === null) {
+        expect(execution, label).toEqual({
+          kind: "failure",
+          failure: new TransactionFailure("runtime.internal_failure", []),
+        });
+        expect(summaries, label).toEqual([]);
+        expect(storage.snapshot().files[".brain/a.json"], label).toBe("a1");
+        expect(storage.snapshot().files).not.toHaveProperty(".brain/b.json");
+        expect(storage.snapshot().files[".brain/delete.json"], label).toBe(
+          "delete",
+        );
+        continue;
+      }
+
+      expect(summaries, label).toHaveLength(1);
+      const summary = summaries[0];
+      expect(summary, label).toEqual({
+        transactionId: "transaction-1",
+        manifestDigest: summary?.manifestDigest ?? null,
+        recoveryToken: summary?.recoveryToken,
+        phase: entry.expectedPhase,
+        evidenceRef: ".brain/transactions/transaction-1/progress.json",
+      });
+      if (execution.kind === "failure") {
+        expect(execution.failure, label).toEqual(
+          new TransactionFailure("runtime.recovery_required", [
+            {
+              kind: "artifact",
+              ref: ".brain/transactions/transaction-1/progress.json",
+            },
+          ]),
+        );
+      } else {
+        expect(entry.expectedPhase, label).toBe("committed");
+      }
+
+      const request = {
+        transactionId: summary?.transactionId ?? "missing",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      };
+      const firstRecovery = await recoverManagedMutation(request, injected);
+      const secondRecovery = await recoverManagedMutation(request, injected);
+      const terminal =
+        entry.expectedPhase === "publishing" ||
+        entry.expectedPhase === "committed"
+          ? "committed"
+          : "aborted";
+      expect(firstRecovery, label).toEqual({
+        transactionId: "transaction-1",
+        manifestDigest: summary?.manifestDigest ?? null,
+        recoveryToken: summary?.recoveryToken,
+        phase: terminal,
+        directorySync: "supported",
+      });
+      expect(secondRecovery, label).toEqual(firstRecovery);
+      if (execution.kind === "receipt") {
+        expect(execution.receipt, label).toEqual(firstRecovery);
+      }
+      expect(await inspectManagedTransactions(injected), label).toEqual([
+        {
+          ...summary,
+          phase: terminal,
+        },
+      ]);
+      expectTerminalDestinations(storage, terminal);
+    }
+  });
+
+  it.each(["permission", "disk_full"] as const)(
+    "maps a synthetic %s fault without leaking private transaction data",
+    async (fault) => {
+      const storage = campaignStorage();
+      storage.fail({
+        operation: "write_file",
+        timing: "before",
+        occurrence: 2,
+        fault,
+      });
+      const injected = services(storage);
+      const firstPrivatePayload = "PRIVATE_STAGING_PAYLOAD_ALPHA_9375";
+      const secondPrivatePayload = "PRIVATE_STAGING_PAYLOAD_BETA_4826";
+      const plan = campaignPlan(storage);
+      const [first, second, third] = plan.operations;
+      if (
+        first?.kind !== "write_file" ||
+        second?.kind !== "write_file" ||
+        third === undefined
+      ) {
+        throw new Error("campaign plan is incomplete");
+      }
+      const privatePlan: ManagedMutationPlan = {
+        operations: [
+          {
+            ...first,
+            content: firstPrivatePayload,
+            result: {
+              kind: "file",
+              size: firstPrivatePayload.length,
+              sha256: storage.digests.sha256(firstPrivatePayload),
+            },
+          },
+          {
+            ...second,
+            content: secondPrivatePayload,
+            result: {
+              kind: "file",
+              size: secondPrivatePayload.length,
+              sha256: storage.digests.sha256(secondPrivatePayload),
+            },
+          },
+          third,
+        ],
+      };
+
+      const execution = await executeCapturing(storage, privatePlan);
+      expect(execution.kind).toBe("failure");
+      if (execution.kind !== "failure") throw new Error("fault was not raised");
+      expect(execution.failure).toBeInstanceOf(TransactionFailure);
+      (execution.failure as TransactionFailure).message =
+        `/home/private/project ${firstPrivatePayload} ${fault}`;
+      const result = transactionFailureResult(
+        execution.failure as TransactionFailure,
+      );
+      const json = renderResultJson(result);
+      const human = renderResultHuman(result);
+      const [summary] = await inspectManagedTransactions(injected);
+      const receipt = await recoverManagedMutation(
+        {
+          transactionId: summary?.transactionId ?? "missing",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      );
+      const publicArtifacts = JSON.stringify({ json, human, receipt });
+
+      expect(result).toMatchObject({
+        status: "blocked",
+        reasonCode: "runtime.recovery_required",
+        stateChanged: false,
+        retryable: true,
+      });
+      expect(receipt).toEqual({
+        transactionId: "transaction-1",
+        manifestDigest: null,
+        recoveryToken: summary?.recoveryToken,
+        phase: "aborted",
+        directorySync: "supported",
+      });
+      for (const privateValue of [
+        fault,
+        firstPrivatePayload,
+        secondPrivatePayload,
+        "/home/private/project",
+        ".payload",
+      ]) {
+        expect(publicArtifacts).not.toContain(privateValue);
+      }
+    },
+  );
+});

--- a/tests/transaction-normalization-properties.test.ts
+++ b/tests/transaction-normalization-properties.test.ts
@@ -1,0 +1,92 @@
+import { planOf } from "@mestre-yoda/runtime/domain/effects";
+import {
+  normalizeManagedMutationPlan,
+  type PathFingerprint,
+} from "@mestre-yoda/runtime/domain/transactions";
+import { describe, expect, it } from "vitest";
+
+function generator(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state;
+  };
+}
+
+function parentObservations(
+  path: string,
+): ReadonlyMap<string, PathFingerprint> {
+  const segments = path.split("/");
+  const entries: [string, PathFingerprint][] = [[path, { kind: "missing" }]];
+  for (let length = 2; length < segments.length; length += 1) {
+    entries.push([segments.slice(0, length).join("/"), { kind: "directory" }]);
+  }
+  return new Map(entries);
+}
+
+describe("managed mutation plan generated properties", () => {
+  it("normalizes 200 generated safe paths deterministically without escaping", () => {
+    const seed = 0x20_02_2026;
+    const next = generator(seed);
+    const segments = ["ordinary", "space name", "café", "中", "😀", "a.b"];
+
+    for (let index = 0; index < 200; index += 1) {
+      const depth = (next() % 4) + 1;
+      const suffix = Array.from(
+        { length: depth },
+        () => segments[next() % segments.length] ?? "ordinary",
+      ).join("/");
+      const path = `.brain/${suffix}-${String(index)}`;
+      const plan = planOf({
+        kind: "write_file",
+        path,
+        content: `value-${String(index)}`,
+      });
+      const observed = parentObservations(path);
+      const digest = (text: string): string => `digest:${text}`;
+      const first = normalizeManagedMutationPlan(plan, observed, digest);
+      const second = normalizeManagedMutationPlan(plan, observed, digest);
+
+      expect(first, `seed=${String(seed)} path=${path}`).toEqual(second);
+      expect(first.kind, `seed=${String(seed)} path=${path}`).toBe("ready");
+      if (first.kind !== "ready") continue;
+      for (const operation of first.plan.operations) {
+        expect(operation.path.startsWith(".brain/")).toBe(true);
+        expect(operation.path.startsWith(".brain/transactions/")).toBe(false);
+        expect(operation.path).not.toContain("\\");
+        expect(operation.path.split("/")).not.toContain("..");
+      }
+    }
+  });
+
+  it("rejects 200 generated unsafe paths", () => {
+    const seed = 0x20_bad_2026;
+    const next = generator(seed);
+    const unsafe = [
+      "outside/file",
+      "/.brain/file",
+      "C:/.brain/file",
+      ".brain\\file",
+      ".brain/../file",
+      ".brain/./file",
+      ".brain//file",
+      ".brain/transactions/file",
+      ".brain/Transactions/file",
+      ".brain/file\u0000",
+      ".brain/file\u007f",
+    ];
+
+    for (let index = 0; index < 200; index += 1) {
+      const path = unsafe[next() % unsafe.length] ?? "";
+      expect(
+        () =>
+          normalizeManagedMutationPlan(
+            planOf({ kind: "write_file", path, content: String(index) }),
+            new Map(),
+            (text) => text,
+          ),
+        `seed=${String(seed)} path=${JSON.stringify(path)}`,
+      ).toThrow(expect.objectContaining({ reasonCode: "guard.outside_allow" }));
+    }
+  });
+});

--- a/tests/transaction-normalization.test.ts
+++ b/tests/transaction-normalization.test.ts
@@ -271,6 +271,42 @@ describe("managed mutation plan normalization", () => {
     expect(JSON.stringify(persisted)).not.toContain("content");
   });
 
+  it("persists directory creation and deletion without transient content", () => {
+    const deleted = { kind: "file", size: 3, sha256: "sha256:old" } as const;
+    const result = normalizeManagedMutationPlan(
+      planOf(
+        { kind: "create_directory", path: ".brain/new" },
+        { kind: "delete_file", path: ".brain/old.json" },
+      ),
+      observations([
+        [".brain/new", missing],
+        [".brain/old.json", deleted],
+      ]),
+      sha256,
+    );
+    expect(result.kind).toBe("ready");
+    if (result.kind !== "ready") return;
+
+    expect(result.plan.operations.map(toPersistedManagedOperation)).toEqual([
+      {
+        operationId: "operation-0001",
+        kind: "create_directory",
+        path: ".brain/new",
+        expected: missing,
+        result: directory,
+        stagedPath: null,
+      },
+      {
+        operationId: "operation-0002",
+        kind: "delete_file",
+        path: ".brain/old.json",
+        expected: deleted,
+        result: missing,
+        stagedPath: null,
+      },
+    ]);
+  });
+
   it.each([
     ["outside the managed root", "state.json"],
     ["the managed root itself", ".brain"],
@@ -361,6 +397,34 @@ describe("managed mutation plan normalization", () => {
       normalizeManagedMutationPlan(
         planOf({ kind: "write_file", path: ".brain/runs", content: "x" }),
         observations([[".brain/runs", directory]]),
+        sha256,
+      ),
+    ).toThrow(expect.objectContaining({ reasonCode: "runtime.state_corrupt" }));
+  });
+
+  it("rejects a write below an observed file parent", () => {
+    expect(() =>
+      normalizeManagedMutationPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/runs/state.json",
+          content: "x",
+        }),
+        observations([
+          [".brain/runs", { kind: "file", size: 1, sha256: "sha256:x" }],
+        ]),
+        sha256,
+      ),
+    ).toThrow(expect.objectContaining({ reasonCode: "runtime.state_corrupt" }));
+  });
+
+  it("rejects creating a directory over an observed file", () => {
+    expect(() =>
+      normalizeManagedMutationPlan(
+        planOf({ kind: "create_directory", path: ".brain/runs" }),
+        observations([
+          [".brain/runs", { kind: "file", size: 1, sha256: "sha256:x" }],
+        ]),
         sha256,
       ),
     ).toThrow(expect.objectContaining({ reasonCode: "runtime.state_corrupt" }));

--- a/tests/transaction-normalization.test.ts
+++ b/tests/transaction-normalization.test.ts
@@ -122,6 +122,70 @@ describe("managed mutation plan normalization", () => {
     });
   });
 
+  it("makes missing parents explicit before a deep directory creation", () => {
+    const result = normalizeManagedMutationPlan(
+      planOf({ kind: "create_directory", path: ".brain/runs/a" }),
+      new Map(),
+      sha256,
+    );
+
+    expect(result).toMatchObject({
+      kind: "ready",
+      plan: {
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/runs",
+          },
+          {
+            operationId: "operation-0002",
+            kind: "create_directory",
+            path: ".brain/runs/a",
+          },
+        ],
+      },
+    });
+  });
+
+  it("creates each missing parent once before a following write", () => {
+    const result = normalizeManagedMutationPlan(
+      planOf(
+        { kind: "create_directory", path: ".brain/runs/a" },
+        {
+          kind: "write_file",
+          path: ".brain/runs/a/state.json",
+          content: "state",
+        },
+      ),
+      new Map(),
+      sha256,
+    );
+
+    expect(result).toMatchObject({
+      kind: "ready",
+      plan: {
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/runs",
+          },
+          {
+            operationId: "operation-0002",
+            kind: "create_directory",
+            path: ".brain/runs/a",
+          },
+          {
+            operationId: "operation-0003",
+            kind: "write_file",
+            path: ".brain/runs/a/state.json",
+          },
+        ],
+      },
+    });
+  });
+
   it("removes an already-equal write and returns a no-op", () => {
     expect(
       normalizeManagedMutationPlan(

--- a/tests/transaction-normalization.test.ts
+++ b/tests/transaction-normalization.test.ts
@@ -1,0 +1,304 @@
+import { planOf } from "@mestre-yoda/runtime/domain/effects";
+import {
+  TransactionPolicyError,
+  normalizeManagedMutationPlan,
+  toPersistedManagedOperation,
+  type PathFingerprint,
+} from "@mestre-yoda/runtime/domain/transactions";
+import { describe, expect, it } from "vitest";
+
+const missing = { kind: "missing" } as const;
+const directory = { kind: "directory" } as const;
+const sha256 = (text: string): string => `sha256:${text}`;
+
+function observations(
+  entries: readonly (readonly [string, PathFingerprint])[],
+): ReadonlyMap<string, PathFingerprint> {
+  return new Map(entries);
+}
+
+describe("managed mutation plan normalization", () => {
+  it("normalizes a write with stable identity and transient content", () => {
+    expect(
+      normalizeManagedMutationPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/runs/a/state.json",
+          content: "new state",
+        }),
+        observations([
+          [".brain/runs", directory],
+          [".brain/runs/a", directory],
+          [".brain/runs/a/state.json", missing],
+        ]),
+        sha256,
+      ),
+    ).toEqual({
+      kind: "ready",
+      plan: {
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "write_file",
+            path: ".brain/runs/a/state.json",
+            expected: missing,
+            result: {
+              kind: "file",
+              size: 9,
+              sha256: "sha256:new state",
+            },
+            stagedPath: "staging/operation-0001.payload",
+            content: "new state",
+          },
+        ],
+      },
+    });
+  });
+
+  it("excludes output effects from the managed plan", () => {
+    expect(
+      normalizeManagedMutationPlan(
+        planOf({ kind: "emit", channel: "human", text: "ready" }),
+        new Map(),
+        sha256,
+      ),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("makes each missing write parent explicit before the write", () => {
+    const result = normalizeManagedMutationPlan(
+      planOf({
+        kind: "write_file",
+        path: ".brain/runs/a/state.json",
+        content: "x",
+      }),
+      new Map(),
+      sha256,
+    );
+
+    expect(result).toMatchObject({
+      kind: "ready",
+      plan: {
+        operations: [
+          {
+            operationId: "operation-0001",
+            kind: "create_directory",
+            path: ".brain/runs",
+          },
+          {
+            operationId: "operation-0002",
+            kind: "create_directory",
+            path: ".brain/runs/a",
+          },
+          {
+            operationId: "operation-0003",
+            kind: "write_file",
+            path: ".brain/runs/a/state.json",
+          },
+        ],
+      },
+    });
+  });
+
+  it("synthesizes a shared missing parent only once", () => {
+    const result = normalizeManagedMutationPlan(
+      planOf(
+        { kind: "write_file", path: ".brain/runs/a.json", content: "a" },
+        { kind: "write_file", path: ".brain/runs/b.json", content: "b" },
+      ),
+      new Map(),
+      sha256,
+    );
+
+    expect(result).toMatchObject({
+      kind: "ready",
+      plan: {
+        operations: [
+          { kind: "create_directory", path: ".brain/runs" },
+          { kind: "write_file", path: ".brain/runs/a.json" },
+          { kind: "write_file", path: ".brain/runs/b.json" },
+        ],
+      },
+    });
+  });
+
+  it("removes an already-equal write and returns a no-op", () => {
+    expect(
+      normalizeManagedMutationPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/state.json",
+          content: "é",
+        }),
+        observations([
+          [".brain/state.json", { kind: "file", size: 2, sha256: "sha256:é" }],
+        ]),
+        sha256,
+      ),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("removes satisfied directory creation and missing deletion", () => {
+    expect(
+      normalizeManagedMutationPlan(
+        planOf(
+          { kind: "create_directory", path: ".brain/runs" },
+          { kind: "delete_file", path: ".brain/old.json" },
+        ),
+        observations([
+          [".brain/runs", directory],
+          [".brain/old.json", missing],
+        ]),
+        sha256,
+      ),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("preserves declared order after satisfied effects are removed", () => {
+    const result = normalizeManagedMutationPlan(
+      planOf(
+        { kind: "emit", channel: "structured", text: "ignored" },
+        { kind: "write_file", path: ".brain/b.json", content: "b" },
+        { kind: "create_directory", path: ".brain/satisfied" },
+        { kind: "delete_file", path: ".brain/a.json" },
+        { kind: "create_directory", path: ".brain/new" },
+      ),
+      observations([
+        [".brain/b.json", missing],
+        [".brain/satisfied", directory],
+        [".brain/a.json", { kind: "file", size: 1, sha256: "sha256:a" }],
+        [".brain/new", missing],
+      ]),
+      sha256,
+    );
+
+    expect(result).toMatchObject({
+      kind: "ready",
+      plan: {
+        operations: [
+          { operationId: "operation-0001", path: ".brain/b.json" },
+          { operationId: "operation-0002", path: ".brain/a.json" },
+          { operationId: "operation-0003", path: ".brain/new" },
+        ],
+      },
+    });
+  });
+
+  it("omits transient write content from persisted operations", () => {
+    const result = normalizeManagedMutationPlan(
+      planOf({ kind: "write_file", path: ".brain/state.json", content: "x" }),
+      observations([[".brain/state.json", missing]]),
+      sha256,
+    );
+    expect(result.kind).toBe("ready");
+    if (result.kind !== "ready") return;
+
+    const persisted = result.plan.operations.map(toPersistedManagedOperation);
+    expect(persisted).toEqual([
+      {
+        operationId: "operation-0001",
+        kind: "write_file",
+        path: ".brain/state.json",
+        expected: missing,
+        result: { kind: "file", size: 1, sha256: "sha256:x" },
+        stagedPath: "staging/operation-0001.payload",
+      },
+    ]);
+    expect(JSON.stringify(persisted)).not.toContain("content");
+  });
+
+  it.each([
+    ["outside the managed root", "state.json"],
+    ["the managed root itself", ".brain"],
+    ["the reserved transaction namespace", ".brain/transactions/forbidden"],
+    ["the reserved namespace with a case alias", ".brain/TRANSACTIONS/x"],
+    ["an absolute path", "/.brain/state.json"],
+    ["a drive-qualified path", "C:/.brain/state.json"],
+    ["a backslash-bearing path", ".brain\\state.json"],
+    ["a traversing path", ".brain/../state.json"],
+    ["a dot segment", ".brain/./state.json"],
+    ["an empty segment", ".brain//state.json"],
+    ["a trailing separator", ".brain/state.json/"],
+    ["a control character", ".brain/state\n.json"],
+  ])("rejects %s", (_name, path) => {
+    expect(() =>
+      normalizeManagedMutationPlan(
+        planOf({ kind: "write_file", path, content: "x" }),
+        new Map(),
+        sha256,
+      ),
+    ).toThrow(expect.objectContaining({ reasonCode: "guard.outside_allow" }));
+  });
+
+  it("rejects append effects until canonical event append exists", () => {
+    expect(() =>
+      normalizeManagedMutationPlan(
+        planOf({ kind: "append_event", event: "event" }),
+        new Map(),
+        sha256,
+      ),
+    ).toThrow(expect.objectContaining({ reasonCode: "runtime.state_corrupt" }));
+  });
+
+  it.each([
+    [
+      "duplicate destinations",
+      planOf(
+        { kind: "write_file", path: ".brain/a", content: "one" },
+        { kind: "write_file", path: ".brain/a", content: "two" },
+      ),
+    ],
+    [
+      "case-colliding destinations",
+      planOf(
+        { kind: "write_file", path: ".brain/A", content: "one" },
+        { kind: "write_file", path: ".brain/a", content: "two" },
+      ),
+    ],
+    [
+      "case-colliding implicit parents",
+      planOf(
+        { kind: "write_file", path: ".brain/Runs/a", content: "one" },
+        { kind: "write_file", path: ".brain/runs/b", content: "two" },
+      ),
+    ],
+    [
+      "a file target overlapping a child target",
+      planOf(
+        { kind: "write_file", path: ".brain/a", content: "one" },
+        { kind: "write_file", path: ".brain/a/child", content: "two" },
+      ),
+    ],
+    [
+      "a parent declared after its child",
+      planOf(
+        { kind: "write_file", path: ".brain/a/child", content: "one" },
+        { kind: "create_directory", path: ".brain/a" },
+      ),
+    ],
+  ])("rejects %s", (_name, plan) => {
+    expect(() => normalizeManagedMutationPlan(plan, new Map(), sha256)).toThrow(
+      expect.objectContaining({ reasonCode: "runtime.state_corrupt" }),
+    );
+  });
+
+  it("rejects deletion of an observed directory", () => {
+    expect(() =>
+      normalizeManagedMutationPlan(
+        planOf({ kind: "delete_file", path: ".brain/runs" }),
+        observations([[".brain/runs", directory]]),
+        sha256,
+      ),
+    ).toThrow(TransactionPolicyError);
+  });
+
+  it("rejects replacing an observed directory with a file", () => {
+    expect(() =>
+      normalizeManagedMutationPlan(
+        planOf({ kind: "write_file", path: ".brain/runs", content: "x" }),
+        observations([[".brain/runs", directory]]),
+        sha256,
+      ),
+    ).toThrow(expect.objectContaining({ reasonCode: "runtime.state_corrupt" }));
+  });
+});

--- a/tests/transaction-process-recovery.test.ts
+++ b/tests/transaction-process-recovery.test.ts
@@ -1,0 +1,459 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
+import type { DurableOperation } from "@mestre-yoda/runtime/infra/node";
+import { build } from "esbuild";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+const workerSource = join(
+  repositoryRoot,
+  "tests/fixtures/transactions/worker.ts",
+);
+const workerTimeoutMilliseconds = 10_000;
+const privatePayloads = {
+  first: "PRIVATE_PROCESS_PAYLOAD_ALPHA_19375",
+  second: "PRIVATE_PROCESS_PAYLOAD_BETA_24826",
+} as const;
+
+interface Barrier {
+  readonly name: string;
+  readonly operation: DurableOperation;
+  readonly timing: "before" | "after";
+  readonly occurrence: number;
+}
+
+interface BoundaryCase extends Barrier {
+  readonly observedPhase: "begun" | "prepared" | "publishing" | "committed";
+  readonly terminalPhase: "aborted" | "committed";
+}
+
+const boundaries: readonly BoundaryCase[] = [
+  {
+    name: "begun",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 2,
+    observedPhase: "begun",
+    terminalPhase: "aborted",
+  },
+  {
+    name: "final-staged-sync",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 5,
+    observedPhase: "begun",
+    terminalPhase: "aborted",
+  },
+  {
+    name: "manifest-sync",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 6,
+    observedPhase: "begun",
+    terminalPhase: "aborted",
+  },
+  {
+    name: "prepared",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 7,
+    observedPhase: "prepared",
+    terminalPhase: "aborted",
+  },
+  {
+    name: "publishing",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 8,
+    observedPhase: "publishing",
+    terminalPhase: "committed",
+  },
+  {
+    name: "first-rename",
+    operation: "replace_file",
+    timing: "after",
+    occurrence: 4,
+    observedPhase: "publishing",
+    terminalPhase: "committed",
+  },
+  {
+    name: "first-publication-directory-sync",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 9,
+    observedPhase: "publishing",
+    terminalPhase: "committed",
+  },
+  {
+    name: "second-rename",
+    operation: "replace_file",
+    timing: "after",
+    occurrence: 6,
+    observedPhase: "publishing",
+    terminalPhase: "committed",
+  },
+  {
+    name: "second-publication-directory-sync",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 11,
+    observedPhase: "publishing",
+    terminalPhase: "committed",
+  },
+  {
+    name: "delete",
+    operation: "remove_file",
+    timing: "after",
+    occurrence: 1,
+    observedPhase: "publishing",
+    terminalPhase: "committed",
+  },
+  {
+    name: "delete-directory-sync",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 13,
+    observedPhase: "publishing",
+    terminalPhase: "committed",
+  },
+  {
+    name: "committed",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 15,
+    observedPhase: "committed",
+    terminalPhase: "committed",
+  },
+  {
+    name: "cleanup",
+    operation: "sync_directory",
+    timing: "after",
+    occurrence: 16,
+    observedPhase: "committed",
+    terminalPhase: "committed",
+  },
+];
+
+interface WorkerMessage {
+  readonly kind: "barrier" | "error" | "ready" | "result";
+  readonly name?: string;
+  readonly value?: unknown;
+}
+
+interface WorkerSession {
+  readonly child: ChildProcess;
+  readonly exit: Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>;
+  readonly output: { stderr: string; stdout: string };
+}
+
+let bundleRoot = "";
+let workerBundle = "";
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function file(content: string) {
+  return {
+    kind: "file" as const,
+    size: Buffer.byteLength(content, "utf8"),
+    sha256: sha256(content),
+  };
+}
+
+function processPlan(): ManagedMutationPlan {
+  return {
+    operations: [
+      {
+        operationId: "operation-0001",
+        kind: "write_file",
+        path: ".brain/a.json",
+        expected: file("a1"),
+        result: file(privatePayloads.first),
+        stagedPath: "staging/operation-0001.payload",
+        content: privatePayloads.first,
+      },
+      {
+        operationId: "operation-0002",
+        kind: "write_file",
+        path: ".brain/b.json",
+        expected: { kind: "missing" },
+        result: file(privatePayloads.second),
+        stagedPath: "staging/operation-0002.payload",
+        content: privatePayloads.second,
+      },
+      {
+        operationId: "operation-0003",
+        kind: "delete_file",
+        path: ".brain/delete.json",
+        expected: file("delete"),
+        result: { kind: "missing" },
+        stagedPath: null,
+      },
+    ],
+  };
+}
+
+function spawnWorker(args: readonly string[]): WorkerSession {
+  const child = fork(workerBundle, [...args], {
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  const output = { stderr: "", stdout: "" };
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    output.stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    output.stderr += chunk;
+  });
+  const exit = new Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>((resolve) => {
+    child.once("exit", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+  return { child, exit, output };
+}
+
+async function waitForWorker(
+  session: WorkerSession,
+  expected: "barrier" | "result",
+): Promise<WorkerMessage> {
+  return new Promise<WorkerMessage>((resolve, reject) => {
+    let ready = false;
+    const timer = setTimeout(() => {
+      finish(new Error(`Worker timed out before ${expected}`));
+    }, workerTimeoutMilliseconds);
+    const onError = (error: Error) => {
+      finish(error);
+    };
+    const onExit = () => {
+      finish(new Error(`Worker exited before ${expected}`));
+    };
+    const onMessage = (candidate: unknown) => {
+      if (!isWorkerMessage(candidate)) {
+        finish(new Error("Worker sent an invalid IPC message"));
+        return;
+      }
+      if (!ready) {
+        if (candidate.kind !== "ready") {
+          finish(new Error("Worker skipped the ready handshake"));
+          return;
+        }
+        ready = true;
+        session.child.send({ kind: "start" }, (error) => {
+          if (error !== null) finish(error);
+        });
+        return;
+      }
+      if (candidate.kind === "error") {
+        finish(new Error("Worker reported a sanitized failure"));
+        return;
+      }
+      if (candidate.kind === expected) finish(null, candidate);
+    };
+    function finish(error: Error | null, message?: WorkerMessage): void {
+      clearTimeout(timer);
+      session.child.off("error", onError);
+      session.child.off("exit", onExit);
+      session.child.off("message", onMessage);
+      if (error !== null) reject(error);
+      else if (message !== undefined) resolve(message);
+    }
+    session.child.on("error", onError);
+    session.child.on("exit", onExit);
+    session.child.on("message", onMessage);
+  });
+}
+
+function isWorkerMessage(value: unknown): value is WorkerMessage {
+  if (typeof value !== "object" || value === null || !("kind" in value)) {
+    return false;
+  }
+  return ["barrier", "error", "ready", "result"].includes(String(value.kind));
+}
+
+async function forceTerminate(session: WorkerSession): Promise<void> {
+  // Node maps kill() to forced process termination on Windows; POSIX uses an
+  // explicit uncatchable signal so neither branch asks the worker to unwind.
+  const killed =
+    process.platform === "win32"
+      ? session.child.kill()
+      : session.child.kill("SIGKILL");
+  expect(killed).toBe(true);
+  const exited = await session.exit;
+  if (process.platform !== "win32") {
+    expect(exited).toEqual({ code: null, signal: "SIGKILL" });
+  }
+}
+
+async function terminateIfRunning(session: WorkerSession): Promise<void> {
+  if (session.child.exitCode !== null || session.child.signalCode !== null) {
+    return;
+  }
+  if (process.platform === "win32") session.child.kill();
+  else session.child.kill("SIGKILL");
+  await session.exit;
+}
+
+async function runFreshWorker(
+  mode: "inspect" | "recover",
+  root: string,
+  value: unknown,
+): Promise<{ readonly message: WorkerMessage; readonly output: string }> {
+  const session = spawnWorker([mode, root, "null", JSON.stringify(value)]);
+  try {
+    const message = await waitForWorker(session, "result");
+    expect(await session.exit).toEqual({ code: 0, signal: null });
+    return {
+      message,
+      output: `${session.output.stdout}${session.output.stderr}`,
+    };
+  } finally {
+    await terminateIfRunning(session);
+  }
+}
+
+async function temporaryProject<T>(
+  body: (root: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-process-recovery-"));
+  try {
+    await mkdir(join(root, ".brain/transactions"), { recursive: true });
+    await writeFile(join(root, ".brain/a.json"), "a1", "utf8");
+    await writeFile(join(root, ".brain/delete.json"), "delete", "utf8");
+    return await body(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+beforeAll(async () => {
+  bundleRoot = await mkdtemp(join(tmpdir(), "yoda-process-worker-"));
+  workerBundle = join(bundleRoot, "transaction-worker.mjs");
+  await build({
+    bundle: true,
+    entryPoints: [workerSource],
+    format: "esm",
+    logLevel: "silent",
+    outfile: workerBundle,
+    platform: "node",
+    sourcemap: false,
+    target: "node24",
+  });
+});
+
+afterAll(async () => {
+  if (bundleRoot !== "") {
+    await rm(bundleRoot, { force: true, recursive: true });
+  }
+});
+
+describe("transaction recovery after process termination", () => {
+  it.each(boundaries)(
+    "recovers after $name",
+    async ({ observedPhase, terminalPhase, ...barrier }) => {
+      await temporaryProject(async (root) => {
+        const execution = spawnWorker([
+          "execute",
+          root,
+          JSON.stringify(barrier),
+          JSON.stringify(processPlan()),
+        ]);
+        try {
+          const reached = await waitForWorker(execution, "barrier");
+          expect(reached).toEqual({ kind: "barrier", name: barrier.name });
+          await forceTerminate(execution);
+        } finally {
+          await terminateIfRunning(execution);
+        }
+        expect(execution.output).toEqual({ stderr: "", stdout: "" });
+
+        const inspected = await runFreshWorker("inspect", root, null);
+        expect(inspected.output).toBe("");
+        const summaries = inspected.message.value as readonly {
+          readonly evidenceRef: string;
+          readonly manifestDigest: string | null;
+          readonly phase: string;
+          readonly recoveryToken: string;
+          readonly transactionId: string;
+        }[];
+        expect(summaries).toHaveLength(1);
+        const summary = summaries[0];
+        expect(summary).toEqual({
+          transactionId: "transaction-1",
+          manifestDigest: summary?.manifestDigest ?? null,
+          recoveryToken: summary?.recoveryToken,
+          phase: observedPhase,
+          evidenceRef: ".brain/transactions/transaction-1/progress.json",
+        });
+
+        const request = {
+          transactionId: summary?.transactionId ?? "missing",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        };
+        const first = await runFreshWorker("recover", root, request);
+        const second = await runFreshWorker("recover", root, request);
+        expect(first.output).toBe("");
+        expect(second.output).toBe("");
+        expect(first.message.value).toEqual({
+          transactionId: "transaction-1",
+          manifestDigest: summary?.manifestDigest ?? null,
+          recoveryToken: summary?.recoveryToken,
+          phase: terminalPhase,
+          directorySync: "supported",
+        });
+        expect(second.message.value).toEqual(first.message.value);
+
+        const finalA = await readFile(join(root, ".brain/a.json"), "utf8");
+        expect(finalA).toBe(
+          terminalPhase === "committed" ? privatePayloads.first : "a1",
+        );
+        if (terminalPhase === "committed") {
+          await expect(
+            readFile(join(root, ".brain/b.json"), "utf8"),
+          ).resolves.toBe(privatePayloads.second);
+          await expect(
+            readFile(join(root, ".brain/delete.json"), "utf8"),
+          ).rejects.toMatchObject({ code: "ENOENT" });
+        } else {
+          await expect(
+            readFile(join(root, ".brain/b.json"), "utf8"),
+          ).rejects.toMatchObject({ code: "ENOENT" });
+          await expect(
+            readFile(join(root, ".brain/delete.json"), "utf8"),
+          ).resolves.toBe("delete");
+        }
+
+        const receiptRoot = join(root, ".brain/transactions/transaction-1");
+        expect(await readdir(receiptRoot)).not.toContain("staging");
+        const ipc = JSON.stringify({
+          first: first.message,
+          inspected: inspected.message,
+          second: second.message,
+        });
+        expect(ipc).not.toContain(root);
+        expect(ipc).not.toContain(privatePayloads.first);
+        expect(ipc).not.toContain(privatePayloads.second);
+      });
+    },
+  );
+});

--- a/tests/transaction-process-recovery.test.ts
+++ b/tests/transaction-process-recovery.test.ts
@@ -22,6 +22,9 @@ const workerSource = join(
   "tests/fixtures/transactions/worker.ts",
 );
 const workerTimeoutMilliseconds = 10_000;
+const testTimeoutMilliseconds = 30_000;
+const expectedDirectorySync =
+  process.platform === "win32" ? "unsupported" : "supported";
 const privatePayloads = {
   first: "PRIVATE_PROCESS_PAYLOAD_ALPHA_19375",
   second: "PRIVATE_PROCESS_PAYLOAD_BETA_24826",
@@ -161,6 +164,8 @@ interface WorkerSession {
   readonly output: { stderr: string; stdout: string };
 }
 
+type WorkerExit = Awaited<WorkerSession["exit"]>;
+
 let bundleRoot = "";
 let workerBundle = "";
 
@@ -233,6 +238,27 @@ function spawnWorker(args: readonly string[]): WorkerSession {
   return { child, exit, output };
 }
 
+async function waitForExit(
+  session: WorkerSession,
+  context: string,
+): Promise<WorkerExit> {
+  return new Promise<WorkerExit>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Worker timed out while ${context}`));
+    }, workerTimeoutMilliseconds);
+    session.exit.then(
+      (exit) => {
+        clearTimeout(timer);
+        resolve(exit);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
 async function waitForWorker(
   session: WorkerSession,
   expected: "barrier" | "result",
@@ -299,7 +325,7 @@ async function forceTerminate(session: WorkerSession): Promise<void> {
       ? session.child.kill()
       : session.child.kill("SIGKILL");
   expect(killed).toBe(true);
-  const exited = await session.exit;
+  const exited = await waitForExit(session, "waiting for forced termination");
   if (process.platform !== "win32") {
     expect(exited).toEqual({ code: null, signal: "SIGKILL" });
   }
@@ -311,7 +337,7 @@ async function terminateIfRunning(session: WorkerSession): Promise<void> {
   }
   if (process.platform === "win32") session.child.kill();
   else session.child.kill("SIGKILL");
-  await session.exit;
+  await waitForExit(session, "cleaning up a worker");
 }
 
 async function runFreshWorker(
@@ -322,7 +348,9 @@ async function runFreshWorker(
   const session = spawnWorker([mode, root, "null", JSON.stringify(value)]);
   try {
     const message = await waitForWorker(session, "result");
-    expect(await session.exit).toEqual({ code: 0, signal: null });
+    expect(
+      await waitForExit(session, "waiting for a result worker to exit"),
+    ).toEqual({ code: 0, signal: null });
     return {
       message,
       output: `${session.output.stdout}${session.output.stderr}`,
@@ -419,7 +447,7 @@ describe("transaction recovery after process termination", () => {
           manifestDigest: summary?.manifestDigest ?? null,
           recoveryToken: summary?.recoveryToken,
           phase: terminalPhase,
-          directorySync: "supported",
+          directorySync: expectedDirectorySync,
         });
         expect(second.message.value).toEqual(first.message.value);
 
@@ -444,7 +472,15 @@ describe("transaction recovery after process termination", () => {
         }
 
         const receiptRoot = join(root, ".brain/transactions/transaction-1");
-        expect(await readdir(receiptRoot)).not.toContain("staging");
+        expect(
+          (await readdir(receiptRoot)).sort((left, right) =>
+            left.localeCompare(right, "en-US"),
+          ),
+        ).toEqual(
+          summary?.manifestDigest === null
+            ? ["progress.json"]
+            : ["manifest.json", "progress.json"],
+        );
         const ipc = JSON.stringify({
           first: first.message,
           inspected: inspected.message,
@@ -455,5 +491,6 @@ describe("transaction recovery after process termination", () => {
         expect(ipc).not.toContain(privatePayloads.second);
       });
     },
+    testTimeoutMilliseconds,
   );
 });

--- a/tests/transaction-recovery-properties.test.ts
+++ b/tests/transaction-recovery-properties.test.ts
@@ -142,6 +142,42 @@ describe("pure transaction recovery decisions", () => {
     });
   });
 
+  it("blocks the same corrupt known payload before and after persisting aborted", () => {
+    const corruptPayload = allPreconditions();
+    corruptPayload.stagedPayloads.set(manifest.operations[0].stagedPath, {
+      kind: "file",
+      size: 1,
+      sha256: "e".repeat(64),
+    });
+    const expected = {
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0001",
+    } as const;
+
+    expect(decideRecovery(manifest, progress("begun"), corruptPayload)).toEqual(
+      expected,
+    );
+    expect(
+      decideRecovery(manifest, progress("aborted"), corruptPayload),
+    ).toEqual(expected);
+  });
+
+  it("aborts begun when known staged payloads are missing or correct", () => {
+    const missingPayload = allPreconditions();
+    missingPayload.stagedPayloads.set(
+      manifest.operations[0].stagedPath,
+      missing,
+    );
+
+    expect(decideRecovery(manifest, progress("begun"), missingPayload)).toEqual(
+      { kind: "abort" },
+    );
+    expect(
+      decideRecovery(manifest, progress("begun"), allPreconditions()),
+    ).toEqual({ kind: "abort" });
+  });
+
   it("records an observed publication before trusting progress", () => {
     const firstAlreadyPublished = allPreconditions();
     firstAlreadyPublished.destinations.set(

--- a/tests/transaction-recovery-properties.test.ts
+++ b/tests/transaction-recovery-properties.test.ts
@@ -1,0 +1,783 @@
+import type {
+  TransactionManifestV1,
+  TransactionProgressV1,
+} from "@mestre-yoda/contracts";
+import {
+  decideRecovery,
+  type PathFingerprint,
+  type RecoveryDecision,
+  type TransactionObservation,
+} from "@mestre-yoda/runtime/domain/transactions";
+import { describe, expect, it } from "vitest";
+
+const manifestDigest = "d".repeat(64);
+const identityToken = "i".repeat(64);
+const firstDigest = "a".repeat(64);
+const secondDigest = "b".repeat(64);
+const missing = { kind: "missing" } as const;
+const createdAt = "2026-08-09T00:00:00.000Z";
+
+const manifest = {
+  contractVersion: "1.0.0",
+  stateContract: "1.0.0",
+  transactionId: "transaction-01",
+  planDigest: "c".repeat(64),
+  createdAt,
+  operations: [
+    {
+      operationId: "operation-0001",
+      kind: "write_file",
+      path: ".brain/first.json",
+      expected: missing,
+      result: { kind: "file", size: 1, sha256: firstDigest },
+      stagedPath:
+        ".brain/transactions/transaction-01/staging/operation-0001.payload",
+    },
+    {
+      operationId: "operation-0002",
+      kind: "write_file",
+      path: ".brain/second.json",
+      expected: missing,
+      result: { kind: "file", size: 1, sha256: secondDigest },
+      stagedPath:
+        ".brain/transactions/transaction-01/staging/operation-0002.payload",
+    },
+  ],
+} as const satisfies TransactionManifestV1;
+
+function progress(
+  phase: TransactionProgressV1["phase"],
+  publishedOperationIds: readonly string[] = [],
+): TransactionProgressV1 {
+  const digest = phase === "begun" ? null : manifestDigest;
+  return {
+    contractVersion: "1.0.0",
+    stateContract: "1.0.0",
+    transactionId: manifest.transactionId,
+    manifestDigest: digest,
+    recoveryToken: digest ?? identityToken,
+    phase,
+    publishedOperationIds: [...publishedOperationIds],
+    fileSync: "required",
+    directorySync: "supported",
+    createdAt,
+    updatedAt: createdAt,
+  } as TransactionProgressV1;
+}
+
+function observation(
+  destinations: readonly (readonly [string, PathFingerprint])[],
+  stagedPayloads: readonly (readonly [string, PathFingerprint])[] = [],
+): TransactionObservation & {
+  readonly destinations: Map<string, PathFingerprint>;
+  readonly stagedPayloads: Map<string, PathFingerprint>;
+} {
+  return {
+    destinations: new Map(destinations),
+    stagedPayloads: new Map(stagedPayloads),
+  };
+}
+
+function allPreconditions(
+  currentManifest: TransactionManifestV1 = manifest,
+): TransactionObservation & {
+  readonly destinations: Map<string, PathFingerprint>;
+  readonly stagedPayloads: Map<string, PathFingerprint>;
+} {
+  return observation(
+    currentManifest.operations.map((operation) => [
+      operation.path,
+      operation.expected,
+    ]),
+    currentManifest.operations.flatMap((operation) =>
+      operation.stagedPath === null
+        ? []
+        : ([[operation.stagedPath, operation.result]] as const),
+    ),
+  );
+}
+
+function allResults(
+  currentManifest: TransactionManifestV1 = manifest,
+  keepPayloads = false,
+): TransactionObservation & {
+  readonly destinations: Map<string, PathFingerprint>;
+  readonly stagedPayloads: Map<string, PathFingerprint>;
+} {
+  return observation(
+    currentManifest.operations.map((operation) => [
+      operation.path,
+      operation.result,
+    ]),
+    keepPayloads
+      ? currentManifest.operations.flatMap((operation) =>
+          operation.stagedPath === null
+            ? []
+            : ([[operation.stagedPath, operation.result]] as const),
+        )
+      : [],
+  );
+}
+
+describe("pure transaction recovery decisions", () => {
+  it("aborts begun and prepared transactions only while all targets remain at preconditions", () => {
+    expect(
+      decideRecovery(manifest, progress("begun"), allPreconditions()),
+    ).toEqual({ kind: "abort" });
+    expect(
+      decideRecovery(manifest, progress("prepared"), allPreconditions()),
+    ).toEqual({ kind: "abort" });
+
+    const changedBeforePublication = allPreconditions();
+    changedBeforePublication.destinations.set(
+      manifest.operations[0].path,
+      manifest.operations[0].result,
+    );
+    expect(
+      decideRecovery(manifest, progress("prepared"), changedBeforePublication),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0001",
+    });
+  });
+
+  it("records an observed publication before trusting progress", () => {
+    const firstAlreadyPublished = allPreconditions();
+    firstAlreadyPublished.destinations.set(
+      manifest.operations[0].path,
+      manifest.operations[0].result,
+    );
+    firstAlreadyPublished.stagedPayloads.set(
+      manifest.operations[0].stagedPath,
+      missing,
+    );
+
+    expect(
+      decideRecovery(manifest, progress("publishing"), firstAlreadyPublished),
+    ).toEqual({
+      kind: "record_published",
+      operationId: "operation-0001",
+    });
+  });
+
+  it("publishes the next operation in manifest order when its target and payload are valid", () => {
+    const nextAtPrecondition = allPreconditions();
+    nextAtPrecondition.destinations.set(
+      manifest.operations[0].path,
+      manifest.operations[0].result,
+    );
+    nextAtPrecondition.stagedPayloads.set(
+      manifest.operations[0].stagedPath,
+      missing,
+    );
+
+    expect(
+      decideRecovery(
+        manifest,
+        progress("publishing", ["operation-0001"]),
+        nextAtPrecondition,
+      ),
+    ).toEqual({ kind: "publish", operationId: "operation-0002" });
+  });
+
+  it("blocks unexpected targets, missing payloads, and wrong payload digests", () => {
+    const unexpectedTarget = allPreconditions();
+    unexpectedTarget.destinations.set(manifest.operations[1].path, {
+      kind: "file",
+      size: 7,
+      sha256: "e".repeat(64),
+    });
+    expect(
+      decideRecovery(
+        manifest,
+        progress("publishing", ["operation-0001"]),
+        unexpectedTarget,
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0002",
+    });
+
+    const missingPayload = allPreconditions();
+    missingPayload.destinations.set(
+      manifest.operations[0].path,
+      manifest.operations[0].result,
+    );
+    missingPayload.stagedPayloads.set(
+      manifest.operations[0].stagedPath,
+      missing,
+    );
+    missingPayload.stagedPayloads.set(
+      manifest.operations[1].stagedPath,
+      missing,
+    );
+    expect(
+      decideRecovery(
+        manifest,
+        progress("publishing", ["operation-0001"]),
+        missingPayload,
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0002",
+    });
+
+    const wrongPayload = allPreconditions();
+    wrongPayload.destinations.set(
+      manifest.operations[0].path,
+      manifest.operations[0].result,
+    );
+    wrongPayload.stagedPayloads.set(manifest.operations[0].stagedPath, missing);
+    wrongPayload.stagedPayloads.set(manifest.operations[1].stagedPath, {
+      kind: "file",
+      size: 1,
+      sha256: "f".repeat(64),
+    });
+    expect(
+      decideRecovery(
+        manifest,
+        progress("publishing", ["operation-0001"]),
+        wrongPayload,
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0002",
+    });
+  });
+
+  it("blocks an out-of-order result instead of rolling past an unpublished prefix", () => {
+    const outOfOrder = allPreconditions();
+    outOfOrder.destinations.set(
+      manifest.operations[1].path,
+      manifest.operations[1].result,
+    );
+
+    expect(
+      decideRecovery(manifest, progress("publishing"), outOfOrder),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0002",
+    });
+  });
+
+  it("commits only after all results are observed and recorded", () => {
+    expect(
+      decideRecovery(
+        manifest,
+        progress("publishing", ["operation-0001"]),
+        allResults(),
+      ),
+    ).toEqual({
+      kind: "record_published",
+      operationId: "operation-0002",
+    });
+    expect(
+      decideRecovery(
+        manifest,
+        progress("publishing", ["operation-0001", "operation-0002"]),
+        allResults(),
+      ),
+    ).toEqual({ kind: "commit" });
+  });
+
+  it("validates transaction identity, manifest digest token, and published prefix", () => {
+    expect(
+      decideRecovery(
+        manifest,
+        { ...progress("prepared"), transactionId: "replacement" },
+        allPreconditions(),
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: null,
+    });
+
+    expect(
+      decideRecovery(
+        manifest,
+        { ...progress("publishing"), recoveryToken: "e".repeat(64) },
+        allPreconditions(),
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: null,
+    });
+
+    for (const publishedOperationIds of [
+      ["operation-0002"],
+      ["operation-0001", "operation-0001"],
+      ["unknown-operation"],
+    ]) {
+      expect(
+        decideRecovery(
+          manifest,
+          progress("publishing", publishedOperationIds),
+          allPreconditions(),
+        ),
+      ).toEqual({
+        kind: "blocked",
+        reasonCode: "runtime.state_corrupt",
+        operationId: null,
+      });
+    }
+  });
+
+  it("blocks ambiguous manifest fingerprints and unexpected staged content", () => {
+    const ambiguousManifest = {
+      ...manifest,
+      operations: [
+        {
+          ...manifest.operations[0],
+          result: manifest.operations[0].expected,
+        },
+        manifest.operations[1],
+      ],
+    } as const satisfies TransactionManifestV1;
+    expect(
+      decideRecovery(
+        ambiguousManifest,
+        progress("publishing"),
+        allPreconditions(ambiguousManifest),
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0001",
+    });
+
+    const unexpectedStaging = allPreconditions();
+    unexpectedStaging.stagedPayloads.set(
+      ".brain/transactions/transaction-01/staging/unexpected.payload",
+      { kind: "file", size: 1, sha256: "e".repeat(64) },
+    );
+    expect(
+      decideRecovery(manifest, progress("publishing"), unexpectedStaging),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: null,
+    });
+  });
+
+  it("blocks duplicate manifest identities and incomplete publication facts", () => {
+    const corruptedManifests = [
+      {
+        ...manifest,
+        operations: [
+          manifest.operations[0],
+          {
+            ...manifest.operations[1],
+            operationId: manifest.operations[0].operationId,
+          },
+        ],
+      },
+      {
+        ...manifest,
+        operations: [
+          manifest.operations[0],
+          { ...manifest.operations[1], path: manifest.operations[0].path },
+        ],
+      },
+      {
+        ...manifest,
+        operations: [
+          manifest.operations[0],
+          {
+            ...manifest.operations[1],
+            stagedPath: manifest.operations[0].stagedPath,
+          },
+        ],
+      },
+    ] as const satisfies readonly TransactionManifestV1[];
+
+    for (const corruptedManifest of corruptedManifests) {
+      expect(
+        decideRecovery(
+          corruptedManifest,
+          progress("publishing"),
+          allPreconditions(corruptedManifest),
+        ),
+      ).toEqual({
+        kind: "blocked",
+        reasonCode: "runtime.state_corrupt",
+        operationId: null,
+      });
+    }
+
+    const missingDestination = allPreconditions();
+    missingDestination.destinations.delete(manifest.operations[0].path);
+    expect(
+      decideRecovery(manifest, progress("publishing"), missingDestination),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0001",
+    });
+
+    expect(
+      decideRecovery(
+        manifest,
+        progress("publishing", ["operation-0001"]),
+        allPreconditions(),
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0001",
+    });
+  });
+
+  it("blocks invalid prepared and terminal payload or destination facts", () => {
+    const unpreparedPayload = allPreconditions();
+    unpreparedPayload.stagedPayloads.delete(manifest.operations[1].stagedPath);
+    expect(
+      decideRecovery(manifest, progress("prepared"), unpreparedPayload),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0002",
+    });
+
+    const incompleteCommit = allResults();
+    incompleteCommit.destinations.set(
+      manifest.operations[0].path,
+      manifest.operations[0].expected,
+    );
+    expect(
+      decideRecovery(
+        manifest,
+        progress("committed", ["operation-0001", "operation-0002"]),
+        incompleteCommit,
+      ),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0001",
+    });
+
+    for (const phase of ["committed", "aborted"] as const) {
+      const terminalObservation =
+        phase === "committed" ? allResults() : allPreconditions();
+      terminalObservation.stagedPayloads.set(
+        manifest.operations[0].stagedPath,
+        {
+          kind: "file",
+          size: 1,
+          sha256: "e".repeat(64),
+        },
+      );
+      expect(
+        decideRecovery(
+          manifest,
+          progress(
+            phase,
+            phase === "committed" ? ["operation-0001", "operation-0002"] : [],
+          ),
+          terminalObservation,
+        ),
+      ).toEqual({
+        kind: "blocked",
+        reasonCode: "runtime.state_corrupt",
+        operationId: "operation-0001",
+      });
+    }
+  });
+
+  it("handles non-write operations without inventing staged payloads", () => {
+    const directoryManifest = {
+      ...manifest,
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "create_directory",
+          path: ".brain/runs",
+          expected: missing,
+          result: { kind: "directory" },
+          stagedPath: null,
+        },
+        manifest.operations[1],
+      ],
+    } as const satisfies TransactionManifestV1;
+    const preparedObservation = allPreconditions(directoryManifest);
+
+    expect(
+      decideRecovery(
+        directoryManifest,
+        progress("prepared"),
+        preparedObservation,
+      ),
+    ).toEqual({ kind: "abort" });
+    expect(
+      decideRecovery(
+        directoryManifest,
+        progress("publishing"),
+        preparedObservation,
+      ),
+    ).toEqual({ kind: "publish", operationId: "operation-0001" });
+    expect(
+      decideRecovery(
+        directoryManifest,
+        progress("committed", ["operation-0001", "operation-0002"]),
+        allResults(directoryManifest),
+      ),
+    ).toEqual({ kind: "complete", terminal: "committed" });
+  });
+
+  it("blocks a published write whose staged payload still exists", () => {
+    const publishedWithPayload = allPreconditions();
+    publishedWithPayload.destinations.set(
+      manifest.operations[0].path,
+      manifest.operations[0].result,
+    );
+
+    expect(
+      decideRecovery(manifest, progress("publishing"), publishedWithPayload),
+    ).toEqual({
+      kind: "blocked",
+      reasonCode: "runtime.state_corrupt",
+      operationId: "operation-0001",
+    });
+  });
+
+  it("keeps terminal recovery idempotent and requests cleanup only for valid leftover payloads", () => {
+    expect(
+      decideRecovery(
+        manifest,
+        progress("committed", ["operation-0001", "operation-0002"]),
+        allResults(manifest, true),
+      ),
+    ).toEqual({ kind: "cleanup", terminal: "committed" });
+
+    const committed = decideRecovery(
+      manifest,
+      progress("committed", ["operation-0001", "operation-0002"]),
+      allResults(),
+    );
+    expect(committed).toEqual({ kind: "complete", terminal: "committed" });
+    expect(
+      decideRecovery(
+        manifest,
+        progress("committed", ["operation-0001", "operation-0002"]),
+        allResults(),
+      ),
+    ).toEqual(committed);
+
+    const abortedWithPayloads = allPreconditions();
+    expect(
+      decideRecovery(manifest, progress("aborted"), abortedWithPayloads),
+    ).toEqual({ kind: "cleanup", terminal: "aborted" });
+
+    const changedAfterAbort = observation([
+      [manifest.operations[0].path, manifest.operations[0].result],
+      [manifest.operations[1].path, manifest.operations[1].expected],
+    ]);
+    const aborted = decideRecovery(
+      manifest,
+      progress("aborted"),
+      changedAfterAbort,
+    );
+    expect(aborted).toEqual({ kind: "complete", terminal: "aborted" });
+    expect(
+      decideRecovery(manifest, progress("aborted"), changedAfterAbort),
+    ).toEqual(aborted);
+  });
+});
+
+describe("generated transaction crash states", () => {
+  it("aborts before publication and rolls forward monotonically after publication", () => {
+    for (let operationCount = 1; operationCount <= 20; operationCount += 1) {
+      const generatedManifest = createManifest(operationCount);
+      const beforePublication = allPreconditions(generatedManifest);
+
+      for (const phase of ["begun", "prepared"] as const) {
+        expect(
+          decideRecovery(
+            generatedManifest,
+            generatedProgress(generatedManifest, phase, []),
+            beforePublication,
+          ),
+        ).toEqual({ kind: "abort" });
+      }
+
+      for (let crashIndex = 0; crashIndex <= operationCount; crashIndex += 1) {
+        const recovered = recoverGeneratedCrash(generatedManifest, crashIndex);
+        expect(recovered.decisions).not.toContainEqual({ kind: "abort" });
+        expect(recovered.publishedCounts).toEqual(
+          [...recovered.publishedCounts].sort((left, right) => left - right),
+        );
+        expect(recovered.finalDecision).toEqual({
+          kind: "complete",
+          terminal: "committed",
+        });
+        expect(
+          decideRecovery(
+            generatedManifest,
+            recovered.progress,
+            recovered.observation,
+          ),
+        ).toEqual(recovered.finalDecision);
+      }
+    }
+  });
+});
+
+function createManifest(operationCount: number): TransactionManifestV1 {
+  const operations = Array.from({ length: operationCount }, (_, index) => {
+    const number = String(index + 1).padStart(4, "0");
+    return {
+      operationId: `operation-${number}`,
+      kind: "write_file" as const,
+      path: `.brain/generated-${number}.json`,
+      expected: missing,
+      result: {
+        kind: "file" as const,
+        size: index + 1,
+        sha256: (index + 1).toString(16).padStart(64, "0"),
+      },
+      stagedPath: `.brain/transactions/generated/staging/operation-${number}.payload`,
+    };
+  });
+  const first = operations[0];
+  if (first === undefined)
+    throw new Error("generated manifest must not be empty");
+  return {
+    contractVersion: "1.0.0",
+    stateContract: "1.0.0",
+    transactionId: "generated",
+    planDigest: "c".repeat(64),
+    createdAt,
+    operations: [first, ...operations.slice(1)],
+  };
+}
+
+function generatedProgress(
+  generatedManifest: TransactionManifestV1,
+  phase: TransactionProgressV1["phase"],
+  publishedOperationIds: readonly string[],
+): TransactionProgressV1 {
+  const digest = phase === "begun" ? null : manifestDigest;
+  return {
+    contractVersion: "1.0.0",
+    stateContract: "1.0.0",
+    transactionId: generatedManifest.transactionId,
+    manifestDigest: digest,
+    recoveryToken: digest ?? identityToken,
+    phase,
+    publishedOperationIds: [...publishedOperationIds],
+    fileSync: "required",
+    directorySync: "supported",
+    createdAt: generatedManifest.createdAt,
+    updatedAt: generatedManifest.createdAt,
+  } as TransactionProgressV1;
+}
+
+function recoverGeneratedCrash(
+  generatedManifest: TransactionManifestV1,
+  crashIndex: number,
+): {
+  readonly decisions: readonly RecoveryDecision[];
+  readonly publishedCounts: readonly number[];
+  readonly finalDecision: RecoveryDecision;
+  readonly progress: TransactionProgressV1;
+  readonly observation: TransactionObservation;
+} {
+  const destinations = new Map<string, PathFingerprint>();
+  const stagedPayloads = new Map<string, PathFingerprint>();
+  generatedManifest.operations.forEach((operation, index) => {
+    destinations.set(
+      operation.path,
+      index < crashIndex ? operation.result : operation.expected,
+    );
+    if (operation.stagedPath !== null) {
+      stagedPayloads.set(
+        operation.stagedPath,
+        index < crashIndex ? missing : operation.result,
+      );
+    }
+  });
+
+  let currentProgress = generatedProgress(
+    generatedManifest,
+    "publishing",
+    generatedManifest.operations
+      .slice(0, Math.max(0, crashIndex - 1))
+      .map((operation) => operation.operationId),
+  );
+  let currentObservation = { destinations, stagedPayloads };
+  const decisions: RecoveryDecision[] = [];
+  const publishedCounts: number[] = [
+    currentProgress.publishedOperationIds.length,
+  ];
+
+  for (
+    let step = 0;
+    step < generatedManifest.operations.length * 3 + 4;
+    step += 1
+  ) {
+    const decision = decideRecovery(
+      generatedManifest,
+      currentProgress,
+      currentObservation,
+    );
+    decisions.push(decision);
+    if (decision.kind === "record_published") {
+      currentProgress = {
+        ...currentProgress,
+        publishedOperationIds: [
+          ...currentProgress.publishedOperationIds,
+          decision.operationId,
+        ],
+      };
+      publishedCounts.push(currentProgress.publishedOperationIds.length);
+      continue;
+    }
+    if (decision.kind === "publish") {
+      const operation = generatedManifest.operations.find(
+        (candidate) => candidate.operationId === decision.operationId,
+      );
+      if (operation === undefined)
+        throw new Error("unknown generated operation");
+      destinations.set(operation.path, operation.result);
+      if (operation.stagedPath !== null) {
+        stagedPayloads.set(operation.stagedPath, missing);
+      }
+      continue;
+    }
+    if (decision.kind === "commit") {
+      currentProgress = {
+        ...currentProgress,
+        phase: "committed",
+      } as TransactionProgressV1;
+      continue;
+    }
+    if (decision.kind === "cleanup") {
+      currentObservation = {
+        destinations,
+        stagedPayloads: new Map(
+          [...stagedPayloads].map(([path]) => [path, missing] as const),
+        ),
+      };
+      continue;
+    }
+    if (decision.kind === "complete") {
+      return {
+        decisions,
+        publishedCounts,
+        finalDecision: decision,
+        progress: currentProgress,
+        observation: currentObservation,
+      };
+    }
+    throw new Error(
+      `generated recovery blocked at crash index ${String(crashIndex)}`,
+    );
+  }
+  throw new Error("generated recovery did not terminate");
+}

--- a/tests/transaction-recovery-properties.test.ts
+++ b/tests/transaction-recovery-properties.test.ts
@@ -154,12 +154,19 @@ describe("pure transaction recovery decisions", () => {
       reasonCode: "runtime.state_corrupt",
       operationId: "operation-0001",
     } as const;
+    const begun = progress("begun");
+    const abortedAfterMarker = {
+      ...begun,
+      phase: "aborted",
+    } satisfies TransactionProgressV1;
 
-    expect(decideRecovery(manifest, progress("begun"), corruptPayload)).toEqual(
-      expected,
-    );
+    expect(decideRecovery(manifest, begun, corruptPayload)).toEqual(expected);
+    expect(abortedAfterMarker).toMatchObject({
+      manifestDigest: null,
+      recoveryToken: identityToken,
+    });
     expect(
-      decideRecovery(manifest, progress("aborted"), corruptPayload),
+      decideRecovery(manifest, abortedAfterMarker, corruptPayload),
     ).toEqual(expected);
   });
 

--- a/tests/transaction-recovery.test.ts
+++ b/tests/transaction-recovery.test.ts
@@ -1,10 +1,13 @@
 import {
+  applyPlan,
+  createRuntime,
   executeManagedMutation,
   inspectManagedTransactions,
   recoverManagedMutation,
   TransactionFailure,
   type TransactionServices,
 } from "@mestre-yoda/runtime/composition";
+import { planOf } from "@mestre-yoda/runtime/domain/effects";
 import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
 import { canonicalizeJson } from "@mestre-yoda/runtime/domain/schema";
 import type {
@@ -84,6 +87,31 @@ function twoWritePlan(
       },
     ],
   };
+}
+
+async function addTerminalResidue(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+  residue: "staging" | "progress.next",
+): Promise<void> {
+  const root = ".brain/transactions/transaction-1";
+  if (residue === "staging") {
+    await storage.durableFileSystem.createDirectory(`${root}/staging`);
+  } else {
+    await storage.durableFileSystem.writeSynced(
+      `${root}/progress.next`,
+      "terminal residue",
+    );
+  }
+}
+
+function runtimePorts(storage: ReturnType<typeof memoryTransactionStorage>) {
+  return createRuntime({
+    clock: fixedClock("2026-08-09T00:00:00.000Z"),
+    ids: sequentialIds("transaction"),
+    digests: storage.digests,
+    durableFileSystem: storage.durableFileSystem,
+    fileSystem: storage.fileSystem,
+  });
 }
 
 describe("managed transaction inspection and recovery", () => {
@@ -175,6 +203,105 @@ describe("managed transaction inspection and recovery", () => {
     expect(storage.calls()).not.toContain("remove_file");
     expect(storage.calls()).not.toContain("remove_empty_directory");
   });
+
+  it.each(["staging", "progress.next"] as const)(
+    "blocks a no-op while a committed transaction retains %s",
+    async (residue) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain", ".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const injected = services(storage);
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          injected,
+        ),
+      ).resolves.toMatchObject({ phase: "committed" });
+      await addTerminalResidue(storage, residue);
+      const exclusiveCreates = storage
+        .calls()
+        .filter((call) => call === "create_directory_exclusive").length;
+
+      await expect(
+        applyPlan(
+          planOf({
+            kind: "write_file",
+            path: ".brain/state.json",
+            content: "new",
+          }),
+          runtimePorts(storage),
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.recovery_required", [
+          {
+            kind: "artifact",
+            ref: ".brain/transactions/transaction-1/progress.json",
+          },
+        ]),
+      );
+      expect(
+        storage.calls().filter((call) => call === "create_directory_exclusive")
+          .length,
+      ).toBe(exclusiveCreates);
+    },
+  );
+
+  it.each(["staging", "progress.next"] as const)(
+    "blocks a no-op while an aborted transaction retains %s",
+    async (residue) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain", ".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const injected = services(storage);
+      storage.fail({
+        operation: "sync_directory",
+        timing: "after",
+        occurrence: 6,
+      });
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          injected,
+        ),
+      ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+      const [prepared] = await inspectManagedTransactions(injected);
+      await expect(
+        recoverManagedMutation(
+          {
+            transactionId: "transaction-1",
+            recoveryToken: prepared?.recoveryToken ?? "missing",
+          },
+          injected,
+        ),
+      ).resolves.toMatchObject({ phase: "aborted" });
+      await addTerminalResidue(storage, residue);
+      const exclusiveCreates = storage
+        .calls()
+        .filter((call) => call === "create_directory_exclusive").length;
+
+      await expect(
+        applyPlan(
+          planOf({ kind: "delete_file", path: ".brain/missing.json" }),
+          runtimePorts(storage),
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.recovery_required", [
+          {
+            kind: "artifact",
+            ref: ".brain/transactions/transaction-1/progress.json",
+          },
+        ]),
+      );
+      expect(
+        storage.calls().filter((call) => call === "create_directory_exclusive")
+          .length,
+      ).toBe(exclusiveCreates);
+    },
+  );
 
   it.each([
     {

--- a/tests/transaction-recovery.test.ts
+++ b/tests/transaction-recovery.test.ts
@@ -1212,6 +1212,170 @@ describe("managed transaction inspection and recovery", () => {
     expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
   });
 
+  it.each([
+    {
+      phase: "begun" as const,
+      syncOccurrence: 5,
+      finalizeAsAborted: false,
+    },
+    {
+      phase: "prepared" as const,
+      syncOccurrence: 6,
+      finalizeAsAborted: false,
+    },
+    {
+      phase: "aborted" as const,
+      syncOccurrence: 5,
+      finalizeAsAborted: true,
+    },
+  ])(
+    "uses validated $phase recovery context when drive and classification reads fail",
+    async ({ phase, syncOccurrence, finalizeAsAborted }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const initial = services(storage);
+      storage.fail({
+        operation: "sync_directory",
+        timing: "after",
+        occurrence: syncOccurrence,
+      });
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          initial,
+        ),
+      ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+      let [summary] = await inspectManagedTransactions(initial);
+      if (finalizeAsAborted) {
+        await recoverManagedMutation(
+          {
+            transactionId: "transaction-1",
+            recoveryToken: summary?.recoveryToken ?? "missing",
+          },
+          initial,
+        );
+        [summary] = await inspectManagedTransactions(initial);
+      }
+      expect(summary?.phase).toBe(phase);
+
+      const progressPath = ".brain/transactions/transaction-1/progress.json";
+      const base = storage.durableFileSystem;
+      let progressReads = 0;
+      let driveFailed = false;
+      const boundary: DurableFileSystem = {
+        ...base,
+        inspect: (path) =>
+          driveFailed && path === ".brain"
+            ? Promise.reject(new Error("classification scan detail"))
+            : base.inspect(path),
+        readText: async (path) => {
+          const actual = await base.readText(path);
+          if (path !== progressPath) return actual;
+          progressReads += 1;
+          if (progressReads === 2) {
+            driveFailed = true;
+            throw new Error("recovery drive detail");
+          }
+          return actual;
+        },
+      };
+
+      await expect(
+        recoverManagedMutation(
+          {
+            transactionId: "transaction-1",
+            recoveryToken: summary?.recoveryToken ?? "missing",
+          },
+          { ...initial, durableFileSystem: boundary },
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.recovery_required", [
+          { kind: "artifact", ref: progressPath },
+        ]),
+      );
+      const [preserved] = await inspectManagedTransactions(initial);
+      expect(preserved?.phase).toBe(phase);
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    },
+  );
+
+  it("does not trust a recovery request before its initial inspection succeeds", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: (path) =>
+        path === ".brain"
+          ? Promise.reject(new Error("initial recovery scan detail"))
+          : base.inspect(path),
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-unvalidated",
+          recoveryToken: "f".repeat(64),
+        },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+
+  it("preserves the active transaction when an unmatched request precedes a raw classification scan", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 5,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    let brainInspections = 0;
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) => {
+        if (path !== ".brain") return base.inspect(path);
+        brainInspections += 1;
+        if (brainInspections === 2) {
+          throw new Error("classification scan detail");
+        }
+        return base.inspect(path);
+      },
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-unvalidated",
+          recoveryToken: "f".repeat(64),
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ]),
+    );
+  });
+
   it("uses the validated recovery context when drive and classification scans fail", async () => {
     const storage = memoryTransactionStorage({
       directories: [".brain/transactions"],

--- a/tests/transaction-recovery.test.ts
+++ b/tests/transaction-recovery.test.ts
@@ -1,0 +1,1010 @@
+import {
+  executeManagedMutation,
+  inspectManagedTransactions,
+  recoverManagedMutation,
+  TransactionFailure,
+  type TransactionServices,
+} from "@mestre-yoda/runtime/composition";
+import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
+import { canonicalizeJson } from "@mestre-yoda/runtime/domain/schema";
+import type {
+  DurableEntry,
+  DurableFileSystem,
+} from "@mestre-yoda/runtime/ports";
+import {
+  fixedClock,
+  memoryTransactionStorage,
+  sequentialIds,
+} from "@mestre-yoda/runtime/infra/fake";
+import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
+import { describe, expect, it } from "vitest";
+
+function services(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+): TransactionServices {
+  return {
+    clock: fixedClock("2026-08-09T00:00:00.000Z"),
+    ids: sequentialIds("transaction"),
+    digests: storage.digests,
+    durableFileSystem: storage.durableFileSystem,
+    schemaRegistry: createSchemaRegistry(),
+  };
+}
+
+function writePlan(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+  expected: string,
+  result: string,
+): ManagedMutationPlan {
+  return {
+    operations: [
+      {
+        operationId: "operation-0001",
+        kind: "write_file",
+        path: ".brain/state.json",
+        expected: {
+          kind: "file",
+          size: Buffer.byteLength(expected, "utf8"),
+          sha256: storage.digests.sha256(expected),
+        },
+        result: {
+          kind: "file",
+          size: Buffer.byteLength(result, "utf8"),
+          sha256: storage.digests.sha256(result),
+        },
+        stagedPath: "staging/operation-0001.payload",
+        content: result,
+      },
+    ],
+  };
+}
+
+function twoWritePlan(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+): ManagedMutationPlan {
+  return {
+    operations: [
+      ...writePlan(storage, "old", "new").operations,
+      {
+        operationId: "operation-0002",
+        kind: "write_file",
+        path: ".brain/second.json",
+        expected: {
+          kind: "file",
+          size: 6,
+          sha256: storage.digests.sha256("second"),
+        },
+        result: {
+          kind: "file",
+          size: 7,
+          sha256: storage.digests.sha256("updated"),
+        },
+        stagedPath: "staging/operation-0002.payload",
+        content: "updated",
+      },
+    ],
+  };
+}
+
+describe("managed transaction inspection and recovery", () => {
+  it("lists validated transaction summaries in stable order without writes", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    const first = await executeManagedMutation(
+      writePlan(storage, "old", "new"),
+      { rootMode: "existing" },
+      injected,
+    );
+    const second = await executeManagedMutation(
+      writePlan(storage, "new", "newer"),
+      { rootMode: "existing" },
+      injected,
+    );
+    const before = storage.snapshot();
+
+    await expect(inspectManagedTransactions(injected)).resolves.toEqual([
+      {
+        transactionId: "transaction-1",
+        manifestDigest: first.manifestDigest,
+        recoveryToken: first.recoveryToken,
+        phase: "committed",
+        evidenceRef: ".brain/transactions/transaction-1/progress.json",
+      },
+      {
+        transactionId: "transaction-2",
+        manifestDigest: second.manifestDigest,
+        recoveryToken: second.recoveryToken,
+        phase: "committed",
+        evidenceRef: ".brain/transactions/transaction-2/progress.json",
+      },
+    ]);
+    expect(storage.snapshot()).toEqual(before);
+  });
+
+  it("aborts explicitly after prepared progress became durable", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 6,
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({
+      reasonCode: "runtime.recovery_required",
+      evidence: [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ],
+    });
+    const [summary] = await inspectManagedTransactions(injected);
+    expect(summary).toMatchObject({
+      transactionId: "transaction-1",
+      phase: "prepared",
+    });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+
+    const first = await recoverManagedMutation(
+      {
+        transactionId: summary?.transactionId ?? "missing",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      },
+      injected,
+    );
+    const second = await recoverManagedMutation(
+      {
+        transactionId: "transaction-1",
+        recoveryToken: first.recoveryToken,
+      },
+      injected,
+    );
+    expect(first).toEqual({
+      transactionId: "transaction-1",
+      manifestDigest: summary?.manifestDigest ?? null,
+      recoveryToken: summary?.recoveryToken,
+      phase: "aborted",
+      directorySync: "supported",
+    });
+    expect(second).toEqual(first);
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    expect(storage.snapshot().directories).not.toContain(
+      ".brain/transactions/transaction-1/staging",
+    );
+  });
+
+  it("aborts a begun transaction after its manifest became durable", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 5,
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(injected);
+    expect(summary).toMatchObject({ phase: "begun", manifestDigest: null });
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).resolves.toMatchObject({ phase: "aborted", manifestDigest: null });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
+  it.each([
+    {
+      label: "exclusive transaction directory creation",
+      operation: "create_directory_exclusive" as const,
+      timing: "after" as const,
+      occurrence: 1,
+    },
+    {
+      label: "opening the initial progress scratch file",
+      operation: "open_file" as const,
+      timing: "after" as const,
+      occurrence: 1,
+    },
+  ])(
+    "cleans an unmarked transaction after $label fails",
+    async ({ operation, timing, occurrence }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      storage.fail({ operation, timing, occurrence });
+
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          services(storage),
+        ),
+      ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+      expect(storage.snapshot().directories).not.toContain(
+        ".brain/transactions/transaction-1",
+      );
+      expect(storage.snapshot().files).not.toHaveProperty(
+        ".brain/transactions/transaction-1/progress.next",
+      );
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    },
+  );
+
+  it("recovers a begun marker that has no manifest", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 1,
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(injected);
+    expect(summary).toMatchObject({ phase: "begun", manifestDigest: null });
+    expect(storage.snapshot().files).not.toHaveProperty(
+      ".brain/transactions/transaction-1/manifest.json",
+    );
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).resolves.toMatchObject({ phase: "aborted", manifestDigest: null });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
+  it("replaces a leftover progress.next from a pre-publishing failure", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "write_file",
+      timing: "after",
+      occurrence: 5,
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const nextPath = ".brain/transactions/transaction-1/progress.next";
+    expect(storage.snapshot().files).toHaveProperty(nextPath);
+    const [summary] = await inspectManagedTransactions(injected);
+    expect(summary?.phase).toBe("prepared");
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).resolves.toMatchObject({ phase: "aborted" });
+    expect(storage.snapshot().files).not.toHaveProperty(nextPath);
+  });
+
+  it("removes staged payloads when aborting before a manifest exists", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 4,
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const payload =
+      ".brain/transactions/transaction-1/staging/operation-0001.payload";
+    expect(storage.snapshot().files).toHaveProperty(payload, "new");
+    const [summary] = await inspectManagedTransactions(injected);
+
+    const first = await recoverManagedMutation(
+      {
+        transactionId: "transaction-1",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      },
+      injected,
+    );
+    expect(first.phase).toBe("aborted");
+    expect(storage.snapshot().files).not.toHaveProperty(payload);
+    expect(storage.snapshot().directories).not.toContain(
+      ".brain/transactions/transaction-1/staging",
+    );
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: first.recoveryToken,
+        },
+        injected,
+      ),
+    ).resolves.toEqual(first);
+  });
+
+  it.each([
+    {
+      label: "unknown file name",
+      name: "unexpected.payload",
+      kind: "file" as const,
+    },
+    {
+      label: "non-file payload",
+      name: "operation-0002.payload",
+      kind: "directory" as const,
+    },
+  ])(
+    "blocks a $label before cleaning an unmanifested staging directory",
+    async ({ name, kind }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const injected = services(storage);
+      storage.fail({
+        operation: "sync_directory",
+        timing: "after",
+        occurrence: 4,
+      });
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          injected,
+        ),
+      ).rejects.toBeInstanceOf(Error);
+      const path = `.brain/transactions/transaction-1/staging/${name}`;
+      if (kind === "file") await storage.fileSystem.write(path, "unexpected");
+      else await storage.fileSystem.makeDirectory(path);
+      const [summary] = await inspectManagedTransactions(injected);
+      const before = storage.snapshot();
+
+      await expect(
+        recoverManagedMutation(
+          {
+            transactionId: "transaction-1",
+            recoveryToken: summary?.recoveryToken ?? "missing",
+          },
+          injected,
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: path },
+        ]),
+      );
+      expect(storage.snapshot()).toEqual(before);
+    },
+  );
+
+  it("cleans a scratch file from an already-aborted unmanifested marker", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 1,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toBeInstanceOf(Error);
+    const [summary] = await inspectManagedTransactions(injected);
+    const receipt = await recoverManagedMutation(
+      {
+        transactionId: "transaction-1",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      },
+      injected,
+    );
+    const next = ".brain/transactions/transaction-1/progress.next";
+    await storage.fileSystem.write(next, "scratch");
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: receipt.recoveryToken,
+        },
+        injected,
+      ),
+    ).resolves.toEqual(receipt);
+    expect(storage.snapshot().files).not.toHaveProperty(next);
+  });
+
+  it("rolls forward create and delete operations from a publishing marker", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/delete.json": "delete" },
+    });
+    const injected = services(storage);
+    const mutation: ManagedMutationPlan = {
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "create_directory",
+          path: ".brain/new-directory",
+          expected: { kind: "missing" },
+          result: { kind: "directory" },
+          stagedPath: null,
+        },
+        {
+          operationId: "operation-0002",
+          kind: "delete_file",
+          path: ".brain/delete.json",
+          expected: {
+            kind: "file",
+            size: 6,
+            sha256: storage.digests.sha256("delete"),
+          },
+          result: { kind: "missing" },
+          stagedPath: null,
+        },
+      ],
+    };
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 3,
+    });
+    await expect(
+      executeManagedMutation(mutation, { rootMode: "existing" }, injected),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(injected);
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().directories).toContain(".brain/new-directory");
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/delete.json");
+  });
+
+  it("blocks an unknown staged payload and preserves the marker", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 6,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toBeInstanceOf(Error);
+    const unknown = ".brain/transactions/transaction-1/staging/unknown.payload";
+    await storage.fileSystem.write(unknown, "unknown");
+    const [summary] = await inspectManagedTransactions(injected);
+    const before = storage.snapshot();
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ]),
+    );
+    expect(storage.snapshot()).toEqual(before);
+  });
+
+  it("removes a terminal progress scratch file idempotently", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    const receipt = await executeManagedMutation(
+      writePlan(storage, "old", "new"),
+      { rootMode: "existing" },
+      injected,
+    );
+    const next = ".brain/transactions/transaction-1/progress.next";
+    await storage.fileSystem.write(next, "scratch");
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: receipt.transactionId,
+          recoveryToken: receipt.recoveryToken,
+        },
+        injected,
+      ),
+    ).resolves.toEqual(receipt);
+    expect(storage.snapshot().files).not.toHaveProperty(next);
+  });
+
+  it("verifies the result after applying a recovery publication", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 3,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toBeInstanceOf(Error);
+    const [summary] = await inspectManagedTransactions(initial);
+    const base = storage.durableFileSystem;
+    let targetInspections = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path): Promise<DurableEntry> => {
+        const actual = await base.inspect(path);
+        if (path !== ".brain/state.json") return actual;
+        targetInspections += 1;
+        return targetInspections === 2 ? { kind: "missing" } : actual;
+      },
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+  });
+
+  it("revalidates a destination parent before recovery publication", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions", ".brain/runs"],
+    });
+    const initial = services(storage);
+    const mutation: ManagedMutationPlan = {
+      operations: [
+        {
+          operationId: "operation-0001",
+          kind: "write_file",
+          path: ".brain/runs/state.json",
+          expected: { kind: "missing" },
+          result: {
+            kind: "file",
+            size: 5,
+            sha256: storage.digests.sha256("state"),
+          },
+          stagedPath: "staging/operation-0001.payload",
+          content: "state",
+        },
+      ],
+    };
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 3,
+    });
+    await expect(
+      executeManagedMutation(mutation, { rootMode: "existing" }, initial),
+    ).rejects.toBeInstanceOf(Error);
+    const [summary] = await inspectManagedTransactions(initial);
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) =>
+        path === ".brain/runs" ? { kind: "missing" } : base.inspect(path),
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files).not.toHaveProperty(
+      ".brain/runs/state.json",
+    );
+  });
+
+  it("revalidates the manifest identity on the recovery read", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 6,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toBeInstanceOf(Error);
+    const manifestPath = ".brain/transactions/transaction-1/manifest.json";
+    const persisted = storage.snapshot().files[manifestPath] ?? "null";
+    const tampered = JSON.parse(persisted) as Record<string, unknown>;
+    tampered.createdAt = "2026-08-09T00:00:01.000Z";
+    const base = storage.durableFileSystem;
+    let manifestReads = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      readText: async (path) => {
+        const actual = await base.readText(path);
+        if (path !== manifestPath) return actual;
+        manifestReads += 1;
+        return manifestReads === 2 ? `${canonicalizeJson(tampered)}\n` : actual;
+      },
+    };
+    const [summary] = await inspectManagedTransactions(initial);
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: manifestPath },
+      ]),
+    );
+  });
+
+  it.each([
+    {
+      label: "atomic replacement",
+      operation: "replace_file" as const,
+      occurrence: 4,
+    },
+    {
+      label: "published-directory synchronization",
+      operation: "sync_directory" as const,
+      occurrence: 8,
+    },
+  ])(
+    "rolls forward after a failure following $label",
+    async ({ operation, occurrence }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const injected = services(storage);
+      storage.fail({ operation, timing: "after", occurrence });
+
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          injected,
+        ),
+      ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+      const [summary] = await inspectManagedTransactions(injected);
+      expect(summary?.phase).toBe("publishing");
+
+      const first = await recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      );
+      const second = await recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: first.recoveryToken,
+        },
+        injected,
+      );
+      expect(first).toMatchObject({
+        transactionId: "transaction-1",
+        phase: "committed",
+      });
+      expect(second).toEqual(first);
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+    },
+  );
+
+  it("rolls forward when publishing became durable before the first target", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 3,
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    const [summary] = await inspectManagedTransactions(injected);
+    expect(summary?.phase).toBe("publishing");
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+  });
+
+  it("blocks roll-forward when a later destination is unexpected", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: {
+        ".brain/state.json": "old",
+        ".brain/second.json": "second",
+      },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 4,
+    });
+    await expect(
+      executeManagedMutation(
+        twoWritePlan(storage),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    await storage.fileSystem.write(".brain/second.json", "intruder");
+    const [summary] = await inspectManagedTransactions(injected);
+    const before = storage.snapshot();
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        injected,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain/second.json" },
+      ]),
+    );
+    expect(storage.snapshot()).toEqual(before);
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+    expect(storage.snapshot().files[".brain/second.json"]).toBe("intruder");
+  });
+
+  it("finishes cleanup after committed progress became durable", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "remove_empty_directory",
+      timing: "before",
+      occurrence: 1,
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(injected);
+    expect(summary?.phase).toBe("committed");
+    expect(storage.snapshot().directories).toContain(
+      ".brain/transactions/transaction-1/staging",
+    );
+
+    const receipt = await recoverManagedMutation(
+      {
+        transactionId: "transaction-1",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      },
+      injected,
+    );
+    expect(receipt.phase).toBe("committed");
+    expect(storage.snapshot().directories).not.toContain(
+      ".brain/transactions/transaction-1/staging",
+    );
+  });
+
+  it("requires recovery before another mutation can use an incomplete marker", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 6,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toBeInstanceOf(Error);
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "other"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ]),
+    );
+  });
+
+  it("refuses stale recovery identity without changing the marker", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 6,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toBeInstanceOf(Error);
+    const before = storage.snapshot();
+
+    await expect(
+      recoverManagedMutation(
+        { transactionId: "transaction-1", recoveryToken: "f".repeat(64) },
+        injected,
+      ),
+    ).rejects.toMatchObject({
+      reasonCode: "runtime.recovery_required",
+    });
+    await expect(
+      recoverManagedMutation(
+        { transactionId: "transaction-stale", recoveryToken: "f".repeat(64) },
+        injected,
+      ),
+    ).rejects.toMatchObject({
+      reasonCode: "runtime.recovery_required",
+    });
+    expect(storage.snapshot()).toEqual(before);
+  });
+
+  it("reports a missing recovery transaction as corrupt when no marker is active", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-missing",
+          recoveryToken: "f".repeat(64),
+        },
+        services(storage),
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-missing",
+        },
+      ]),
+    );
+  });
+});

--- a/tests/transaction-recovery.test.ts
+++ b/tests/transaction-recovery.test.ts
@@ -87,6 +87,319 @@ function twoWritePlan(
 }
 
 describe("managed transaction inspection and recovery", () => {
+  it.each([
+    {
+      label: "empty transaction directory",
+      seed: {
+        directories: [
+          ".brain/transactions",
+          ".brain/transactions/transaction-1",
+        ],
+        files: { ".brain/state.json": "old" },
+      },
+    },
+    {
+      label: "partial progress scratch",
+      seed: {
+        directories: [
+          ".brain/transactions",
+          ".brain/transactions/transaction-1",
+        ],
+        files: {
+          ".brain/state.json": "old",
+          ".brain/transactions/transaction-1/progress.next": "partial",
+        },
+      },
+    },
+    {
+      label: "multiple sorted empty transaction directories",
+      seed: {
+        directories: [
+          ".brain/transactions",
+          ".brain/transactions/transaction-2",
+          ".brain/transactions/transaction-1",
+        ],
+        files: { ".brain/state.json": "old" },
+      },
+    },
+  ])(
+    "reconciles a safe unmarked $label before starting a new transaction",
+    async ({ seed }) => {
+      const storage = memoryTransactionStorage(seed);
+
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          services(storage),
+        ),
+      ).resolves.toMatchObject({
+        transactionId: "transaction-1",
+        phase: "committed",
+      });
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+      expect(storage.calls()).toContain("remove_empty_directory");
+      expect(storage.calls()).toContain("sync_directory");
+    },
+  );
+
+  it("blocks unknown content in an unmarked transaction without removing it", async () => {
+    const unknownPath = ".brain/transactions/transaction-crash/unknown-content";
+    const storage = memoryTransactionStorage({
+      directories: [
+        ".brain/transactions",
+        ".brain/transactions/transaction-crash",
+      ],
+      files: {
+        ".brain/state.json": "old",
+        [unknownPath]: "preserve",
+      },
+    });
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-crash",
+        },
+      ]),
+    );
+    expect(storage.snapshot().files[unknownPath]).toBe("preserve");
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    expect(storage.calls()).not.toContain("remove_file");
+    expect(storage.calls()).not.toContain("remove_empty_directory");
+  });
+
+  it.each([
+    {
+      label: "invalid transaction ID",
+      seed: {
+        directories: [".brain/transactions", ".brain/transactions/-invalid"],
+      },
+      evidenceRef: ".brain/transactions",
+    },
+    {
+      label: "non-directory transaction entry",
+      seed: {
+        directories: [".brain/transactions"],
+        files: { ".brain/transactions/transaction-foreign": "foreign" },
+      },
+      evidenceRef: ".brain/transactions/transaction-foreign",
+    },
+    {
+      label: "non-file progress scratch",
+      seed: {
+        directories: [
+          ".brain/transactions",
+          ".brain/transactions/transaction-foreign",
+          ".brain/transactions/transaction-foreign/progress.next",
+        ],
+      },
+      evidenceRef: ".brain/transactions/transaction-foreign/progress.next",
+    },
+  ])("blocks a safe-reconciliation $label", async ({ seed, evidenceRef }) => {
+    const storage = memoryTransactionStorage(seed);
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/runs",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        services(storage),
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: evidenceRef },
+      ]),
+    );
+  });
+
+  it("blocks content that appears while an unmarked layout is revalidated", async () => {
+    const root = ".brain/transactions/transaction-crash";
+    const concurrent = `${root}/concurrent`;
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions", root],
+    });
+    const base = storage.durableFileSystem;
+    let rootLists = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      list: async (path) => {
+        if (path !== root) return base.list(path);
+        rootLists += 1;
+        if (rootLists === 2) {
+          await storage.fileSystem.write(concurrent, "preserve");
+        }
+        return base.list(path);
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        {
+          operations: [
+            {
+              operationId: "operation-0001",
+              kind: "create_directory",
+              path: ".brain/runs",
+              expected: { kind: "missing" },
+              result: { kind: "directory" },
+              stagedPath: null,
+            },
+          ],
+        },
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: root },
+      ]),
+    );
+    expect(storage.snapshot().files[concurrent]).toBe("preserve");
+  });
+
+  it("cleans only the current unmarked attempt while classifying its failure", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const foreignRoot = ".brain/transactions/transaction-foreign";
+    const boundary: DurableFileSystem = {
+      ...base,
+      createDirectoryExclusive: async (path) => {
+        await base.createDirectoryExclusive(path);
+        await base.createDirectoryExclusive(foreignRoot);
+        throw new Error("current attempt failed");
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: `${foreignRoot}/progress.json` },
+      ]),
+    );
+    expect(storage.snapshot().directories).toContain(foreignRoot);
+    expect(storage.snapshot().directories).not.toContain(
+      ".brain/transactions/transaction-1",
+    );
+  });
+
+  it("preserves unknown content created in the current unmarked attempt", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const root = ".brain/transactions/transaction-1";
+    const unknown = `${root}/unknown`;
+    const boundary: DurableFileSystem = {
+      ...base,
+      createDirectoryExclusive: async (path) => {
+        await base.createDirectoryExclusive(path);
+        await storage.fileSystem.write(unknown, "preserve");
+        throw new Error("current attempt failed");
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files[unknown]).toBe("preserve");
+  });
+
+  it("preserves a non-file scratch created in the current unmarked attempt", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const next = ".brain/transactions/transaction-1/progress.next";
+    const boundary: DurableFileSystem = {
+      ...base,
+      createDirectoryExclusive: async (path) => {
+        await base.createDirectoryExclusive(path);
+        await base.createDirectory(next);
+        throw new Error("current attempt failed");
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: next },
+      ]),
+    );
+    expect(storage.snapshot().directories).toContain(next);
+  });
+
+  it("preserves content racing with cleanup of the current unmarked attempt", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const base = storage.durableFileSystem;
+    const root = ".brain/transactions/transaction-1";
+    const concurrent = `${root}/concurrent`;
+    let rootLists = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      createDirectoryExclusive: async (path) => {
+        await base.createDirectoryExclusive(path);
+        throw new Error("current attempt failed");
+      },
+      list: async (path) => {
+        if (path !== root) return base.list(path);
+        rootLists += 1;
+        if (rootLists === 2) {
+          await storage.fileSystem.write(concurrent, "preserve");
+        }
+        return base.list(path);
+      },
+    };
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        { ...services(storage), durableFileSystem: boundary },
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files[concurrent]).toBe("preserve");
+  });
+
   it("lists validated transaction summaries in stable order without writes", async () => {
     const storage = memoryTransactionStorage({
       directories: [".brain/transactions"],
@@ -622,7 +935,7 @@ describe("managed transaction inspection and recovery", () => {
         const actual = await base.inspect(path);
         if (path !== ".brain/state.json") return actual;
         targetInspections += 1;
-        return targetInspections === 2 ? { kind: "missing" } : actual;
+        return targetInspections === 3 ? { kind: "missing" } : actual;
       },
     };
 
@@ -634,8 +947,17 @@ describe("managed transaction inspection and recovery", () => {
         },
         { ...initial, durableFileSystem: boundary },
       ),
-    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
     expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        initial,
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
   });
 
   it("revalidates a destination parent before recovery publication", async () => {
@@ -740,6 +1062,66 @@ describe("managed transaction inspection and recovery", () => {
     );
   });
 
+  it("rejects a valid replacement identity between recovery inspection and drive", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    await executeManagedMutation(
+      writePlan(storage, "old", "new"),
+      { rootMode: "existing" },
+      initial,
+    );
+    const [summary] = await inspectManagedTransactions(initial);
+    const root = ".brain/transactions/transaction-1";
+    const progressPath = `${root}/progress.json`;
+    const manifestPath = `${root}/manifest.json`;
+    const snapshot = storage.snapshot();
+    const replacementManifest = JSON.parse(
+      snapshot.files[manifestPath] ?? "null",
+    ) as Record<string, unknown>;
+    replacementManifest.createdAt = "2026-08-09T00:00:01.000Z";
+    const manifestText = canonicalizeJson(replacementManifest);
+    const manifestDigest = storage.digests.sha256(manifestText);
+    const replacementProgress = JSON.parse(
+      snapshot.files[progressPath] ?? "null",
+    ) as Record<string, unknown>;
+    replacementProgress.createdAt = "2026-08-09T00:00:01.000Z";
+    replacementProgress.updatedAt = "2026-08-09T00:00:01.000Z";
+    replacementProgress.manifestDigest = manifestDigest;
+    replacementProgress.recoveryToken = manifestDigest;
+    const progressText = canonicalizeJson(replacementProgress);
+    const base = storage.durableFileSystem;
+    let progressReads = 0;
+    const boundary: DurableFileSystem = {
+      ...base,
+      readText: async (path) => {
+        const actual = await base.readText(path);
+        if (path !== progressPath) return actual;
+        progressReads += 1;
+        if (progressReads !== 2) return actual;
+        await storage.fileSystem.write(manifestPath, `${manifestText}\n`);
+        await storage.fileSystem.write(progressPath, `${progressText}\n`);
+        return `${progressText}\n`;
+      },
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+  });
+
   it.each([
     {
       label: "atomic replacement",
@@ -830,6 +1212,183 @@ describe("managed transaction inspection and recovery", () => {
     expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
   });
 
+  it.each([
+    { label: "altered", action: "alter" as const },
+    { label: "missing", action: "remove" as const },
+  ])(
+    "blocks an $label payload introduced after recovery observation",
+    async ({ action }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const initial = services(storage);
+      storage.fail({
+        operation: "replace_file",
+        timing: "after",
+        occurrence: 3,
+      });
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          initial,
+        ),
+      ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+      const [summary] = await inspectManagedTransactions(initial);
+      const payload =
+        ".brain/transactions/transaction-1/staging/operation-0001.payload";
+      const base = storage.durableFileSystem;
+      let observedPayload = false;
+      let tampered = false;
+      const boundary: DurableFileSystem = {
+        ...base,
+        inspect: async (path) => {
+          if (path === payload) observedPayload = true;
+          if (path === ".brain" && observedPayload && !tampered) {
+            tampered = true;
+            if (action === "alter") {
+              await storage.fileSystem.write(payload, "evil");
+            } else {
+              await base.removeFile(payload);
+            }
+          }
+          return base.inspect(path);
+        },
+      };
+
+      await expect(
+        recoverManagedMutation(
+          {
+            transactionId: "transaction-1",
+            recoveryToken: summary?.recoveryToken ?? "missing",
+          },
+          { ...initial, durableFileSystem: boundary },
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.state_corrupt", [
+          { kind: "artifact", ref: payload },
+        ]),
+      );
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    },
+  );
+
+  it("blocks target drift introduced after recovery observation", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 3,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(initial);
+    const payload =
+      ".brain/transactions/transaction-1/staging/operation-0001.payload";
+    const base = storage.durableFileSystem;
+    let observedTarget = false;
+    let observedPayload = false;
+    let drifted = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) => {
+        if (path === ".brain/state.json") observedTarget = true;
+        if (path === payload) observedPayload = true;
+        if (
+          path === ".brain" &&
+          observedTarget &&
+          observedPayload &&
+          !drifted
+        ) {
+          drifted = true;
+          await storage.fileSystem.write(".brain/state.json", "intruder");
+        }
+        return base.inspect(path);
+      },
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: ".brain/state.json" },
+      ]),
+    );
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("intruder");
+  });
+
+  it("records a target that reached its result after recovery observation", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 3,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(initial);
+    const payload =
+      ".brain/transactions/transaction-1/staging/operation-0001.payload";
+    const base = storage.durableFileSystem;
+    let observedTarget = false;
+    let observedPayload = false;
+    let publishedExternally = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) => {
+        if (path === ".brain/state.json") observedTarget = true;
+        if (path === payload) observedPayload = true;
+        if (
+          path === ".brain" &&
+          observedTarget &&
+          observedPayload &&
+          !publishedExternally
+        ) {
+          publishedExternally = true;
+          await storage.fileSystem.write(".brain/state.json", "new");
+          await base.removeFile(payload);
+        }
+        return base.inspect(path);
+      },
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).resolves.toMatchObject({ phase: "committed" });
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
+  });
+
   it("blocks roll-forward when a later destination is unexpected", async () => {
     const storage = memoryTransactionStorage({
       directories: [".brain/transactions"],
@@ -911,6 +1470,100 @@ describe("managed transaction inspection and recovery", () => {
     );
   });
 
+  it("reconstructs the terminal receipt when recovery cleanup completed before an error", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "remove_empty_directory",
+      timing: "before",
+      occurrence: 1,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(injected);
+    storage.fail({
+      operation: "remove_empty_directory",
+      timing: "after",
+      occurrence: 2,
+    });
+
+    const first = await recoverManagedMutation(
+      {
+        transactionId: "transaction-1",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      },
+      injected,
+    );
+    const second = await recoverManagedMutation(
+      {
+        transactionId: first.transactionId,
+        recoveryToken: first.recoveryToken,
+      },
+      injected,
+    );
+    expect(first.phase).toBe("committed");
+    expect(second).toEqual(first);
+  });
+
+  it("persists unsupported directory sync discovered by recovery cleanup", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "remove_empty_directory",
+      timing: "before",
+      occurrence: 1,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(initial);
+    const root = ".brain/transactions/transaction-1";
+    const staging = `${root}/staging`;
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      syncDirectory: async (path) => {
+        await base.syncDirectory(path);
+        return path === root && (await base.inspect(staging)).kind === "missing"
+          ? "unsupported"
+          : "supported";
+      },
+    };
+    const injected = { ...initial, durableFileSystem: boundary };
+
+    const first = await recoverManagedMutation(
+      {
+        transactionId: "transaction-1",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      },
+      injected,
+    );
+    const second = await recoverManagedMutation(
+      {
+        transactionId: first.transactionId,
+        recoveryToken: first.recoveryToken,
+      },
+      injected,
+    );
+    expect(first.directorySync).toBe("unsupported");
+    expect(second).toEqual(first);
+  });
+
   it("requires recovery before another mutation can use an incomplete marker", async () => {
     const storage = memoryTransactionStorage({
       directories: [".brain/transactions"],
@@ -944,6 +1597,31 @@ describe("managed transaction inspection and recovery", () => {
         },
       ]),
     );
+  });
+
+  it("requires recovery before another mutation when terminal scratch remains", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    const receipt = await executeManagedMutation(
+      writePlan(storage, "old", "new"),
+      { rootMode: "existing" },
+      injected,
+    );
+    await storage.fileSystem.write(
+      `.brain/transactions/${receipt.transactionId}/progress.next`,
+      "scratch",
+    );
+
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "new", "newer"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
   });
 
   it("refuses stale recovery identity without changing the marker", async () => {

--- a/tests/transaction-recovery.test.ts
+++ b/tests/transaction-recovery.test.ts
@@ -661,6 +661,202 @@ describe("managed transaction inspection and recovery", () => {
   });
 
   it.each([
+    { label: "empty", content: "" },
+    { label: "partial", content: '{"contractVersion":' },
+    { label: "arbitrary", content: "untrusted regular bytes" },
+  ])(
+    "aborts a begun transaction with an unbound $label manifest write",
+    async ({ content }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+        files: { ".brain/state.json": "old" },
+      });
+      const root = ".brain/transactions/transaction-1";
+      const manifestPath = `${root}/manifest.json`;
+      const base = storage.durableFileSystem;
+      const boundary: DurableFileSystem = {
+        ...base,
+        writeSynced: async (path, intended) => {
+          if (path !== manifestPath) return base.writeSynced(path, intended);
+          await base.writeSynced(path, content);
+          throw new Error("interrupted manifest write");
+        },
+      };
+      const injected = { ...services(storage), durableFileSystem: boundary };
+
+      await expect(
+        executeManagedMutation(
+          writePlan(storage, "old", "new"),
+          { rootMode: "existing" },
+          injected,
+        ),
+      ).rejects.toEqual(
+        new TransactionFailure("runtime.recovery_required", [
+          { kind: "artifact", ref: `${root}/progress.json` },
+        ]),
+      );
+      expect(storage.snapshot().files[manifestPath]).toBe(content);
+      const [summary] = await inspectManagedTransactions(injected);
+      expect(summary).toMatchObject({ phase: "begun", manifestDigest: null });
+
+      const request = {
+        transactionId: summary?.transactionId ?? "missing",
+        recoveryToken: summary?.recoveryToken ?? "missing",
+      };
+      const first = await recoverManagedMutation(request, injected);
+      const second = await recoverManagedMutation(request, injected);
+      expect(first).toEqual({
+        transactionId: "transaction-1",
+        manifestDigest: null,
+        recoveryToken: summary?.recoveryToken,
+        phase: "aborted",
+        directorySync: "supported",
+      });
+      expect(second).toEqual(first);
+      expect(storage.snapshot().files).not.toHaveProperty(manifestPath);
+      expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+    },
+  );
+
+  it("preserves strict validation for a bound malformed manifest", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 6,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const manifestPath = ".brain/transactions/transaction-1/manifest.json";
+    await storage.fileSystem.write(manifestPath, '{"contractVersion":');
+
+    await expect(inspectManagedTransactions(injected)).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: manifestPath },
+      ]),
+    );
+  });
+
+  it("preserves an unbound non-file manifest as corrupt evidence", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 5,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const manifestPath = ".brain/transactions/transaction-1/manifest.json";
+    const base = storage.durableFileSystem;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) =>
+        path === manifestPath ? { kind: "special" } : base.inspect(path),
+    };
+
+    await expect(
+      inspectManagedTransactions({
+        ...initial,
+        durableFileSystem: boundary,
+      }),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: manifestPath },
+      ]),
+    );
+    expect(storage.snapshot().files[manifestPath]).toBeDefined();
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
+  it("requires recovery while an aborted unbound manifest awaits cleanup", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const injected = services(storage);
+    storage.fail({
+      operation: "sync_directory",
+      timing: "after",
+      occurrence: 5,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [begun] = await inspectManagedTransactions(injected);
+    const request = {
+      transactionId: begun?.transactionId ?? "missing",
+      recoveryToken: begun?.recoveryToken ?? "missing",
+    };
+    storage.fail({
+      operation: "remove_file",
+      timing: "before",
+      occurrence: 2,
+    });
+
+    await expect(recoverManagedMutation(request, injected)).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ]),
+    );
+    const [aborted] = await inspectManagedTransactions(injected);
+    expect(aborted).toMatchObject({ phase: "aborted", manifestDigest: null });
+    const manifestPath = ".brain/transactions/transaction-1/manifest.json";
+    expect(storage.snapshot().files[manifestPath]).toBeDefined();
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        injected,
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        {
+          kind: "artifact",
+          ref: ".brain/transactions/transaction-1/progress.json",
+        },
+      ]),
+    );
+
+    const first = await recoverManagedMutation(request, injected);
+    const second = await recoverManagedMutation(request, injected);
+    expect(first).toEqual({
+      transactionId: "transaction-1",
+      manifestDigest: null,
+      recoveryToken: begun?.recoveryToken,
+      phase: "aborted",
+      directorySync: "supported",
+    });
+    expect(second).toEqual(first);
+    expect(storage.snapshot().files).not.toHaveProperty(manifestPath);
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
+  it.each([
     {
       label: "exclusive transaction directory creation",
       operation: "create_directory_exclusive" as const,

--- a/tests/transaction-recovery.test.ts
+++ b/tests/transaction-recovery.test.ts
@@ -1212,6 +1212,61 @@ describe("managed transaction inspection and recovery", () => {
     expect(storage.snapshot().files[".brain/state.json"]).toBe("new");
   });
 
+  it("uses the validated recovery context when drive and classification scans fail", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+      files: { ".brain/state.json": "old" },
+    });
+    const initial = services(storage);
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 3,
+    });
+    await expect(
+      executeManagedMutation(
+        writePlan(storage, "old", "new"),
+        { rootMode: "existing" },
+        initial,
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.recovery_required" });
+    const [summary] = await inspectManagedTransactions(initial);
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    const base = storage.durableFileSystem;
+    let brainInspections = 0;
+    let driveFailed = false;
+    const boundary: DurableFileSystem = {
+      ...base,
+      inspect: async (path) => {
+        if (path !== ".brain") return base.inspect(path);
+        brainInspections += 1;
+        if (brainInspections === 2) {
+          driveFailed = true;
+          throw new Error("recovery drive detail");
+        }
+        if (driveFailed) throw new Error("classification scan detail");
+        return base.inspect(path);
+      },
+    };
+
+    await expect(
+      recoverManagedMutation(
+        {
+          transactionId: "transaction-1",
+          recoveryToken: summary?.recoveryToken ?? "missing",
+        },
+        { ...initial, durableFileSystem: boundary },
+      ),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.recovery_required", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+    const [preserved] = await inspectManagedTransactions(initial);
+    expect(preserved?.phase).toBe("publishing");
+    expect(storage.snapshot().files[".brain/state.json"]).toBe("old");
+  });
+
   it.each([
     { label: "altered", action: "alter" as const },
     { label: "missing", action: "remove" as const },

--- a/tests/transaction-schema-boundary.test.ts
+++ b/tests/transaction-schema-boundary.test.ts
@@ -1,0 +1,521 @@
+import {
+  canonicalizeJson,
+  type SchemaRegistry,
+} from "@mestre-yoda/runtime/domain/schema";
+import {
+  executeManagedMutation,
+  inspectManagedTransactions,
+  TransactionFailure,
+  type TransactionServices,
+} from "@mestre-yoda/runtime/composition";
+import type { ManagedMutationPlan } from "@mestre-yoda/runtime/domain/transactions";
+import {
+  fixedClock,
+  memoryTransactionStorage,
+  sequentialIds,
+} from "@mestre-yoda/runtime/infra/fake";
+import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
+import { describe, expect, it } from "vitest";
+
+function plan(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+): ManagedMutationPlan {
+  return {
+    operations: [
+      {
+        operationId: "operation-0001",
+        kind: "write_file",
+        path: ".brain/state.json",
+        expected: { kind: "missing" },
+        result: {
+          kind: "file",
+          size: 6,
+          sha256: storage.digests.sha256("secret"),
+        },
+        stagedPath: "staging/operation-0001.payload",
+        content: "secret",
+      },
+    ],
+  };
+}
+
+function services(
+  storage: ReturnType<typeof memoryTransactionStorage>,
+  schemaRegistry: SchemaRegistry,
+): TransactionServices {
+  return {
+    clock: fixedClock("2026-08-09T00:00:00.000Z"),
+    ids: sequentialIds("transaction"),
+    digests: storage.digests,
+    durableFileSystem: storage.durableFileSystem,
+    schemaRegistry,
+  };
+}
+
+describe("transaction schema boundary", () => {
+  it("uses the injected registry for every persisted and inspected contract", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const production = createSchemaRegistry();
+    const ids: string[] = [];
+    const tracking: SchemaRegistry = {
+      validate: (request) => {
+        ids.push(request.id);
+        return production.validate(request);
+      },
+    };
+    const injected = services(storage, tracking);
+
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    const writes = [...ids];
+    ids.length = 0;
+    await inspectManagedTransactions(injected);
+
+    expect(writes).toContain("state.transaction-manifest");
+    expect(
+      writes.filter((id) => id === "state.transaction-progress").length,
+    ).toBeGreaterThan(4);
+    expect(ids).toEqual([
+      "state.transaction-progress",
+      "state.transaction-manifest",
+    ]);
+  });
+
+  it("rejects non-canonical persisted progress without exposing payloads", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const injected = services(storage, createSchemaRegistry());
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    const progress = storage.snapshot().files[progressPath] ?? "{}";
+    await storage.fileSystem.write(progressPath, ` ${progress}`);
+
+    await expect(inspectManagedTransactions(injected)).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+    expect(JSON.stringify(await inspectFailure(injected))).not.toContain(
+      "secret",
+    );
+  });
+
+  it.each([
+    {
+      label: "plan digest",
+      mutate: (manifest: Record<string, unknown>) => {
+        manifest.planDigest = "f".repeat(64);
+      },
+    },
+    {
+      label: "staged payload namespace",
+      mutate: (manifest: Record<string, unknown>) => {
+        const operations = manifest.operations as Record<string, unknown>[];
+        const operation = operations[0];
+        if (operation !== undefined) {
+          operation.stagedPath = ".brain/outside-staging.payload";
+        }
+      },
+    },
+    {
+      label: "operation identity",
+      mutate: (manifest: Record<string, unknown>) => {
+        const operations = manifest.operations as Record<string, unknown>[];
+        const operation = operations[0];
+        if (operation !== undefined) operation.operationId = "operation-9999";
+      },
+    },
+    ...[
+      "",
+      ".brain\\escape",
+      "C:/escape",
+      ".brain/control\npath",
+      ".brain/transactions/escape",
+    ].map((path) => ({
+      label: `managed destination ${JSON.stringify(path)}`,
+      mutate: (manifest: Record<string, unknown>) => {
+        const operations = manifest.operations as Record<string, unknown>[];
+        const operation = operations[0];
+        if (operation !== undefined) operation.path = path;
+      },
+    })),
+    {
+      label: "create-directory fingerprints",
+      mutate: (manifest: Record<string, unknown>) => {
+        const operations = manifest.operations as Record<string, unknown>[];
+        const operation = operations[0];
+        if (operation !== undefined) {
+          operation.kind = "create_directory";
+          operation.stagedPath = null;
+        }
+      },
+    },
+    {
+      label: "delete-file fingerprints",
+      mutate: (manifest: Record<string, unknown>) => {
+        const operations = manifest.operations as Record<string, unknown>[];
+        const operation = operations[0];
+        if (operation !== undefined) {
+          operation.kind = "delete_file";
+          operation.stagedPath = null;
+        }
+      },
+    },
+  ])("rejects a manifest with a forged $label", async ({ mutate }) => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const injected = services(storage, createSchemaRegistry());
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    const root = ".brain/transactions/transaction-1";
+    const manifestPath = `${root}/manifest.json`;
+    const progressPath = `${root}/progress.json`;
+    const manifest = JSON.parse(
+      storage.snapshot().files[manifestPath] ?? "null",
+    ) as Record<string, unknown>;
+    mutate(manifest);
+    const manifestText = canonicalizeJson(manifest);
+    const digest = storage.digests.sha256(manifestText);
+    const progress = JSON.parse(
+      storage.snapshot().files[progressPath] ?? "null",
+    ) as Record<string, unknown>;
+    progress.manifestDigest = digest;
+    progress.recoveryToken = digest;
+    await storage.fileSystem.write(manifestPath, `${manifestText}\n`);
+    await storage.fileSystem.write(
+      progressPath,
+      `${canonicalizeJson(progress)}\n`,
+    );
+
+    await expect(inspectManagedTransactions(injected)).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: manifestPath },
+      ]),
+    );
+  });
+
+  it.each([
+    {
+      label: "missing managed root",
+      seed: {},
+      expected: [] as const,
+    },
+    {
+      label: "missing transaction namespace",
+      seed: { directories: [".brain"] },
+      expected: [] as const,
+    },
+  ])("reports no markers for a $label", async ({ seed, expected }) => {
+    const storage = memoryTransactionStorage(seed);
+    await expect(
+      inspectManagedTransactions(services(storage, createSchemaRegistry())),
+    ).resolves.toEqual(expected);
+  });
+
+  it.each([
+    {
+      label: "managed root file",
+      seed: { files: { ".brain": "file" } },
+      evidenceRef: ".brain",
+    },
+    {
+      label: "transaction namespace file",
+      seed: { files: { ".brain/transactions": "file" } },
+      evidenceRef: ".brain/transactions",
+    },
+    {
+      label: "transaction entry file",
+      seed: { files: { ".brain/transactions/transaction-1": "file" } },
+      evidenceRef: ".brain/transactions/transaction-1",
+    },
+  ])("rejects a $label", async ({ seed, evidenceRef }) => {
+    const storage = memoryTransactionStorage(seed);
+    await expect(
+      inspectManagedTransactions(services(storage, createSchemaRegistry())),
+    ).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: evidenceRef },
+      ]),
+    );
+  });
+
+  it.each([
+    {
+      label: "unknown transaction entry",
+      path: ".brain/transactions/transaction-1/unknown",
+      kind: "file" as const,
+      evidenceRef: ".brain/transactions/transaction-1",
+    },
+    {
+      label: "directory manifest",
+      path: ".brain/transactions/transaction-1/manifest.json",
+      kind: "directory" as const,
+      evidenceRef: ".brain/transactions/transaction-1/manifest.json",
+    },
+    {
+      label: "file staging root",
+      path: ".brain/transactions/transaction-1/staging",
+      kind: "file" as const,
+      evidenceRef: ".brain/transactions/transaction-1/staging",
+    },
+  ])("rejects a $label in a receipt", async ({ path, kind, evidenceRef }) => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const injected = services(storage, createSchemaRegistry());
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    if (kind === "directory") {
+      await storage.fileSystem.remove(path);
+      await storage.fileSystem.makeDirectory(path);
+    } else {
+      await storage.fileSystem.write(path, "unexpected");
+    }
+
+    await expect(inspectManagedTransactions(injected)).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: evidenceRef },
+      ]),
+    );
+  });
+
+  it.each([
+    { label: "invalid JSON", text: "{\n" },
+    { label: "schema-invalid JSON", text: "{}\n" },
+  ])("rejects $label in progress", async ({ text }) => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const injected = services(storage, createSchemaRegistry());
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    await storage.fileSystem.write(progressPath, text);
+
+    await expect(inspectManagedTransactions(injected)).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+  });
+
+  it("rejects a schema-invalid manifest from the injected registry before publication", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const production = createSchemaRegistry();
+    const rejecting: SchemaRegistry = {
+      validate: (request) =>
+        request.id === "state.transaction-manifest"
+          ? { kind: "invalid", diagnostics: [] }
+          : production.validate(request),
+    };
+
+    await expect(
+      executeManagedMutation(
+        plan(storage),
+        { rootMode: "existing" },
+        services(storage, rejecting),
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
+    expect(storage.snapshot().files).not.toHaveProperty(".brain/state.json");
+  });
+
+  it.each([
+    {
+      label: "directory identity",
+      mutate: (progress: Record<string, unknown>) => {
+        progress.transactionId = "transaction-other";
+      },
+      removeManifest: false,
+    },
+    {
+      label: "recovery token",
+      mutate: (progress: Record<string, unknown>) => {
+        progress.recoveryToken = "f".repeat(64);
+      },
+      removeManifest: false,
+    },
+    {
+      label: "required manifest",
+      mutate: () => undefined,
+      removeManifest: true,
+    },
+  ])(
+    "rejects a progress marker with a forged $label",
+    async ({ mutate, removeManifest }) => {
+      const storage = memoryTransactionStorage({
+        directories: [".brain/transactions"],
+      });
+      const injected = services(storage, createSchemaRegistry());
+      await executeManagedMutation(
+        plan(storage),
+        { rootMode: "existing" },
+        injected,
+      );
+      const root = ".brain/transactions/transaction-1";
+      const progressPath = `${root}/progress.json`;
+      const manifestPath = `${root}/manifest.json`;
+      const progress = JSON.parse(
+        storage.snapshot().files[progressPath] ?? "null",
+      ) as Record<string, unknown>;
+      mutate(progress);
+      await storage.fileSystem.write(
+        progressPath,
+        `${canonicalizeJson(progress)}\n`,
+      );
+      if (removeManifest) await storage.fileSystem.remove(manifestPath);
+
+      await expect(inspectManagedTransactions(injected)).rejects.toMatchObject({
+        reasonCode: "runtime.state_corrupt",
+      });
+    },
+  );
+
+  it("rejects a manifest whose identity changed without a matching progress digest", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const injected = services(storage, createSchemaRegistry());
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      injected,
+    );
+    const manifestPath = ".brain/transactions/transaction-1/manifest.json";
+    const manifest = JSON.parse(
+      storage.snapshot().files[manifestPath] ?? "null",
+    ) as Record<string, unknown>;
+    manifest.createdAt = "2026-08-09T00:00:01.000Z";
+    await storage.fileSystem.write(
+      manifestPath,
+      `${canonicalizeJson(manifest)}\n`,
+    );
+
+    await expect(inspectManagedTransactions(injected)).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: manifestPath },
+      ]),
+    );
+  });
+
+  it("rejects an empty managed plan before writing a manifest", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+
+    await expect(
+      executeManagedMutation(
+        { operations: [] },
+        { rootMode: "existing" },
+        services(storage, createSchemaRegistry()),
+      ),
+    ).rejects.toEqual(new TransactionFailure("runtime.state_corrupt", []));
+    expect(storage.snapshot().files).not.toHaveProperty(
+      ".brain/transactions/transaction-1/manifest.json",
+    );
+  });
+
+  it("rejects a forged begun recovery token", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const injected = services(storage, createSchemaRegistry());
+    storage.fail({
+      operation: "replace_file",
+      timing: "after",
+      occurrence: 1,
+    });
+    await expect(
+      executeManagedMutation(plan(storage), { rootMode: "existing" }, injected),
+    ).rejects.toBeInstanceOf(Error);
+    const progressPath = ".brain/transactions/transaction-1/progress.json";
+    const progress = JSON.parse(
+      storage.snapshot().files[progressPath] ?? "null",
+    ) as Record<string, unknown>;
+    progress.recoveryToken = "f".repeat(64);
+    await storage.fileSystem.write(
+      progressPath,
+      `${canonicalizeJson(progress)}\n`,
+    );
+
+    await expect(inspectManagedTransactions(injected)).rejects.toEqual(
+      new TransactionFailure("runtime.state_corrupt", [
+        { kind: "artifact", ref: progressPath },
+      ]),
+    );
+  });
+
+  it("sanitizes an unexpected injected registry failure while inspecting", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      services(storage, createSchemaRegistry()),
+    );
+    const throwing: SchemaRegistry = {
+      validate: () => {
+        throw new Error("registry detail");
+      },
+    };
+
+    await expect(
+      inspectManagedTransactions(services(storage, throwing)),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+
+  it("sanitizes an unexpected manifest-registry failure while inspecting", async () => {
+    const storage = memoryTransactionStorage({
+      directories: [".brain/transactions"],
+    });
+    const production = createSchemaRegistry();
+    await executeManagedMutation(
+      plan(storage),
+      { rootMode: "existing" },
+      services(storage, production),
+    );
+    const throwing: SchemaRegistry = {
+      validate: (request) => {
+        if (request.id === "state.transaction-manifest") {
+          throw new Error("registry detail");
+        }
+        return production.validate(request);
+      },
+    };
+
+    await expect(
+      inspectManagedTransactions(services(storage, throwing)),
+    ).rejects.toEqual(new TransactionFailure("runtime.internal_failure", []));
+  });
+});
+
+async function inspectFailure(injected: TransactionServices): Promise<unknown> {
+  try {
+    await inspectManagedTransactions(injected);
+    return null;
+  } catch (error) {
+    return error;
+  }
+}

--- a/tests/transaction-transition.test.ts
+++ b/tests/transaction-transition.test.ts
@@ -1,0 +1,44 @@
+import type { TransactionProgressV1 } from "@mestre-yoda/contracts";
+import { assertPhaseTransition } from "@mestre-yoda/runtime/domain/transactions";
+import { describe, expect, it } from "vitest";
+
+const phases = [
+  "begun",
+  "prepared",
+  "publishing",
+  "committed",
+  "aborted",
+] as const satisfies readonly TransactionProgressV1["phase"][];
+
+const legal = [
+  ["begun", "prepared"],
+  ["begun", "aborted"],
+  ["prepared", "publishing"],
+  ["prepared", "aborted"],
+  ["publishing", "committed"],
+] as const satisfies readonly (readonly [
+  TransactionProgressV1["phase"],
+  TransactionProgressV1["phase"],
+])[];
+
+describe("transaction phase transitions", () => {
+  it("accepts exactly the five legal forward transitions", () => {
+    for (const from of phases) {
+      for (const to of phases) {
+        const isLegal = legal.some(
+          ([legalFrom, legalTo]) => legalFrom === from && legalTo === to,
+        );
+
+        if (isLegal) {
+          expect(() => {
+            assertPhaseTransition(from, to);
+          }).not.toThrow();
+        } else {
+          expect(() => {
+            assertPhaseTransition(from, to);
+          }).toThrow("Illegal transaction phase transition");
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- define versioned transaction manifest/progress contracts and deterministic normalization/recovery policies
- add fault-injectable and real Node durable filesystem adapters with staged writes, file/directory sync, atomic replacement, cleanup, and path ownership enforcement
- route managed state effects through transaction execution and catalog-backed recovery-required results
- prove recovery with a 220-boundary deterministic campaign and 13 real process-termination barriers
- embed transaction schemas and recovery policy in the isolated three-file runtime package

## Design decisions

- transactions use explicit `begun -> prepared -> publishing -> committed` phases; only pre-publication states may abort
- once publishing begins, recovery rolls forward or blocks with durable evidence
- recovery requires the transaction identity plus a manifest-bound digest token
- project-owned paths are normalized and allowlisted before mutation; the transaction namespace is reserved
- directory sync is reported as a capability because Windows does not support the same directory-handle durability primitive
- public recovery command wiring, event append behavior (RUN-06), and concurrent-writer leases/fencing (RUN-07) remain out of scope

## Compatibility impact

No existing public orientation command or result contract is removed. The runtime package remains the same three-file distribution and continues to run without a global Yoda installation. This adds internal typed transaction execution, inspection, and recovery APIs plus the `runtime.recovery_required` catalog policy.

## Verification

- `npm test -- tests/transaction-fault-campaign.test.ts tests/transaction-process-recovery.test.ts tests/node-transaction-security.test.ts`
- `npm test -- tests/architecture.test.ts tests/runtime-distribution.test.ts tests/package-verifier.test.ts`
- `npm run build`
- `npm run package:verify`
- `npm run verify`
- `git diff --check`

Final clean verification on Node.js 24.18.0 / npm 11.16.0 passed 77 files and 1,374 tests in both unit and coverage runs, with 100% statements, branches, functions, and lines. All formatting, spelling, lint, type, oracle, parity, result, contracts, differential, build, and package gates passed.

Detailed reproducible evidence is recorded in `docs/verification/issue-20-transaction-evidence.md`.

Closes #20
