### PR TITLE
test: bring the event-chain corpus back inside the CI budget

### DIFF
--- a/tests/event-chain-properties.test.ts
+++ b/tests/event-chain-properties.test.ts
@@ -145,9 +145,38 @@ function corruptScalar(line: string, scalar: ProtectedScalar): string {
 }
 
 const seed = 0x21_08_2026;
+
+// Stream lengths cycle 1 through 32, so 32 streams cover every length exactly
+// once and the "covers every generated length" assertion below still holds.
+//
+// The corpus used to be 200 streams, repeating each length about six times
+// with different content. The per-stream cost is quadratic — every record is
+// deleted in turn and the whole chain re-verified — so that repetition cost
+// roughly 6.25x the work for redundant length coverage. It took this file to
+// ~9 minutes on its own and pushed the CI job past its 15-minute limit.
+//
+// The wider sweep is still available on demand:
+//
+//   YODA_TEST_EXHAUSTIVE_EVENT_CHAIN=1 npx vitest run tests/event-chain-properties.test.ts
+const exhaustiveStreamCount = 200;
+const cycleStreamCount = 32;
+
+// Corpus size and per-case duration are separate problems. Trimming the corpus
+// fixes the suite's total runtime, but the longest streams stay individually
+// expensive: one case deletes every record of a 32-event stream and re-verifies
+// the whole chain each time, which is quadratic in the stream's length. Under
+// v8 coverage instrumentation that tips past vitest's 5-second default, so the
+// heavy case gets an explicit budget rather than a shrinking stream length that
+// would weaken what it proves. Same remedy as `28d1c3a` for the fault campaign.
+const sequenceCorruptionTimeoutMilliseconds = 30_000;
+const streamCount =
+  process.env.YODA_TEST_EXHAUSTIVE_EVENT_CHAIN === "1"
+    ? exhaustiveStreamCount
+    : cycleStreamCount;
+
 const cases = (() => {
   const random = generator(seed);
-  return Array.from({ length: 200 }, (_, streamIndex) => ({
+  return Array.from({ length: streamCount }, (_, streamIndex) => ({
     streamIndex,
     streamSeed: random(),
     count: (streamIndex % 32) + 1,
@@ -284,5 +313,6 @@ describe("event hash-chain generated corruption cases", () => {
         ).toBe("invalid_sequence");
       }
     },
+    sequenceCorruptionTimeoutMilliseconds,
   );
 });


### PR DESCRIPTION
Closes #94. Unblocks `main` and #93, both of which currently fail CI on the
15-minute job limit rather than on any test.

## Two problems, not one

**Total runtime** — the generated corpus was 200 streams while stream lengths
cycle 1 through 32, so each length was covered about six times with different
content. Per-stream cost is quadratic: every record is deleted in turn and the
whole chain re-verified. That repetition bought redundant length coverage at
roughly 6.25x the work, and the file alone took 545 s.

Trimmed to one full cycle of 32 streams. Every generated length is still
covered exactly once — the file's own `covers every generated length from one
through 32` assertion continues to hold unchanged.

**Per-case duration** — trimming the corpus does not make any individual stream
faster, and the longest ones still exceeded vitest's 5000 ms default under v8
coverage instrumentation. Verified: with only the trim applied,
`test:coverage` still failed on streams 27 and 28, the two longest in the
reduced corpus.

The sequence-corruption case therefore gets an explicit 30-second budget,
following `28d1c3a` ("test: allow coverage overhead in fault campaign"). The
alternative — shortening the streams — would weaken what the case proves.

## The exhaustive sweep is kept

```bash
YODA_TEST_EXHAUSTIVE_EVENT_CHAIN=1 npx vitest run tests/event-chain-properties.test.ts
```

restores all 200 streams. Verified passing: 3605 tests. The `YODA_TEST_*`
prefix follows the existing `YODA_TEST_NODE_VERSION` and `YODA_TEST_SECRET`.

## What is not changed

No production code, no coverage threshold, no assertion. The reduction removes
repetition of the same lengths, not any distinct property under test — and the
100% gate over `domain/**` and `composition/**` holds unchanged, which is the
check that would have caught an over-eager trim.

## Verification

| Measurement | Before | After |
| --- | --- | --- |
| `tests/event-chain-properties.test.ts` | 3605 tests, 545 s | 593 tests, 73 s |
| `npm run test:coverage` | failed on 5000 ms timeout | passes, 4m42s |
| `npm run verify` | failed at `test:coverage` | passes end to end |
| `YODA_TEST_EXHAUSTIVE_EVENT_CHAIN=1` | n/a | 3605 tests, passing |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)