### PR TITLE
ci: enforce the DCO sign-off the contribution documents already require

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,34 @@ jobs:
           retention-days: 3
           compression-level: 6
           include-hidden-files: true
+
+  dco:
+    name: DCO sign-off
+    # Only a pull request has a base and a head to compare. A push to a
+    # protected branch arrives already reviewed, and its range would be the
+    # merged history rather than the contribution.
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The default shallow fetch cannot walk base..head.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up exact Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          check-latest: false
+          package-manager-cache: false
+
+      - name: Require a Developer Certificate of Origin sign-off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          node scripts/check-dco.mjs --base "$BASE_SHA" --head "$HEAD_SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,19 @@ another person. If one of your commits lacks a valid sign-off, amend or rebase
 your own commits and force-push your contribution branch safely. Maintainers do
 not add certification on a contributor's behalf.
 
+### How it is enforced
+
+CI checks every non-merge commit in a pull request and fails with the list of
+commits that need a sign-off. A trailer without a reachable address does not
+count: `Signed-off-by: me` certifies nothing.
+
+Merge commits are exempt. A merge created by the forge has no author to certify
+it, so requiring a sign-off there would fail every branch that merges its base.
+
+The check applies from the commit that introduced it forward. Part of the
+history predates enforcement and is not signed; that history is not rewritten,
+because rebasing merged commits costs more than it recovers.
+
 ## Intellectual-property provenance checklist
 
 Access to private material does not grant permission to publish or relicense it.

--- a/scripts/check-dco.mjs
+++ b/scripts/check-dco.mjs
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process";
+
+import { findViolations, parseCommits, remedyFor } from "./lib/dco.mjs";
+
+const usageMessage = "expected --base <commit> --head <commit>";
+
+class UsageError extends Error {}
+
+function parseArguments(argv) {
+  const allowed = new Set(["--base", "--head"]);
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(flag) || value === undefined || value.startsWith("--")) {
+      throw new UsageError(usageMessage);
+    }
+    values.set(flag, value);
+  }
+  const base = values.get("--base");
+  const head = values.get("--head");
+  if (base === undefined || head === undefined) {
+    throw new UsageError(usageMessage);
+  }
+  return { base, head };
+}
+
+function git(args) {
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${(result.stderr ?? "").trim()}`,
+    );
+  }
+  return result.stdout;
+}
+
+function main(argv) {
+  const { base, head } = parseArguments(argv);
+  // `%B` is the raw body, so a trailer is read exactly as written rather than
+  // as git's own reflowed rendering of it.
+  const stdout = git([
+    "log",
+    "-z",
+    "--format=%H%x00%P%x00%B",
+    `${base}..${head}`,
+  ]);
+  const commits = parseCommits(stdout);
+  const violations = findViolations(commits);
+
+  if (violations.length > 0) {
+    process.stderr.write(`${remedyFor(violations)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const checked = commits.filter((commit) => commit.parents.length <= 1).length;
+  process.stdout.write(
+    `DCO: ${String(checked)} commit${checked === 1 ? "" : "s"} signed off\n`,
+  );
+}
+
+try {
+  main(process.argv.slice(2));
+} catch (error) {
+  if (error instanceof UsageError) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+  } else {
+    process.stderr.write(`${error instanceof Error ? error.message : ""}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/lib/dco.mjs
+++ b/scripts/lib/dco.mjs
@@ -1,0 +1,96 @@
+/**
+ * Developer Certificate of Origin sign-off rules.
+ *
+ * The check is deliberately textual: it asserts that a commit message carries
+ * a well-formed `Signed-off-by` trailer. It cannot and does not verify that
+ * the name is real or the address reachable — the DCO is a certification by
+ * the author, not something a CI job can prove.
+ */
+
+// The DCO requires a name and a reachable address. Requiring an `@` inside the
+// angle brackets is what separates a real trailer from `Signed-off-by: me`,
+// which certifies nothing and is the most common way to get this wrong.
+const SIGN_OFF =
+  /^Signed-off-by: *(?<name>[^<>\n]*\S) *<(?<email>[^<>\s@]+@[^<>\s]+)>[ \t]*$/mu;
+
+/**
+ * A commit's sign-off state.
+ *
+ * Merge commits are exempt. A merge produced by the forge has no author to
+ * certify anything and cannot be signed after the fact, so requiring one would
+ * fail every branch that merges its base — which is the normal way to update a
+ * pull request.
+ */
+export function classifyCommit(commit) {
+  if (commit.parents.length > 1) {
+    return { hash: commit.hash, subject: commit.subject, state: "merge" };
+  }
+  const match = SIGN_OFF.exec(commit.message);
+  if (match === null) {
+    return { hash: commit.hash, subject: commit.subject, state: "unsigned" };
+  }
+  return {
+    hash: commit.hash,
+    subject: commit.subject,
+    state: "signed",
+    name: match.groups.name,
+    email: match.groups.email,
+  };
+}
+
+/** Every commit that must carry a sign-off and does not. */
+export function findViolations(commits) {
+  return commits
+    .map((commit) => classifyCommit(commit))
+    .filter((classified) => classified.state === "unsigned");
+}
+
+/**
+ * Parse `git log -z --format=%H%x00%P%x00%B` output.
+ *
+ * Records are NUL-separated and so are the fields inside them, which keeps a
+ * commit message containing blank lines or a stray delimiter from splitting a
+ * record. Git never emits a NUL inside a hash, a parent list, or a message.
+ */
+export function parseCommits(stdout) {
+  const fields = stdout.split("\0");
+  const commits = [];
+  // Each record is three fields; a trailing empty field from the final
+  // separator is expected and stops the loop.
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    const hash = fields[index].trim();
+    if (hash === "") continue;
+    const parents = fields[index + 1].trim();
+    const message = fields[index + 2];
+    commits.push({
+      hash,
+      parents: parents === "" ? [] : parents.split(" "),
+      message,
+      subject: message.split("\n", 1)[0],
+    });
+  }
+  return commits;
+}
+
+/** The exact remedy, so a failing build does not send anyone hunting. */
+export function remedyFor(violations) {
+  const lines = [
+    `${String(violations.length)} commit${violations.length === 1 ? "" : "s"} without a Developer Certificate of Origin sign-off:`,
+    "",
+  ];
+  for (const violation of violations) {
+    lines.push(`  ${violation.hash.slice(0, 12)} ${violation.subject}`);
+  }
+  lines.push(
+    "",
+    "Every commit must certify the DCO. See CONTRIBUTING.md.",
+    "",
+    "  git commit -s          # sign a new commit",
+    "  git commit --amend -s  # sign the most recent one",
+    "",
+    "To sign a range that is already written:",
+    "",
+    "  git rebase --signoff <base>",
+  );
+  return lines.join("\n");
+}

--- a/tests/ci-workflow-contract.test.ts
+++ b/tests/ci-workflow-contract.test.ts
@@ -70,7 +70,7 @@ describe("pull-request CI workflow", () => {
 
   it("pins a single bounded GitHub-hosted quality job", () => {
     const jobs = object(workflow.jobs, "jobs");
-    expect(Object.keys(jobs)).toEqual(["quality"]);
+    expect(Object.keys(jobs)).toEqual(["quality", "dco"]);
 
     const quality = object(jobs.quality, "quality");
     expect(quality.name).toBe("Node quality and package");
@@ -115,6 +115,43 @@ describe("pull-request CI workflow", () => {
       "check-latest": false,
       "node-version-file": ".nvmrc",
       "package-manager-cache": false,
+    });
+  });
+
+  // The sign-off gate is a second job rather than another step in `quality`
+  // so it answers in seconds instead of behind the full pipeline, and so a
+  // contributor who forgot `-s` is not told about it only after coverage has
+  // run. It carries the same authority and boundedness the quality job does.
+  it("pins the DCO job to the same bounded, fork-safe shape", () => {
+    const jobs = object(workflow.jobs, "jobs");
+    const dco = object(jobs.dco, "dco");
+
+    expect(dco.name).toBe("DCO sign-off");
+    expect(dco["runs-on"]).toBe("ubuntu-latest");
+    expect(dco["timeout-minutes"]).toBe(5);
+    expect(dco.permissions).toBeUndefined();
+    expect(dco["continue-on-error"]).toBeUndefined();
+    // Only a pull request has a base and a head to compare.
+    expect(dco.if).toBe("${{ github.event_name == 'pull_request' }}");
+
+    const steps = dco.steps as JsonObject[];
+    expect(steps.every((step) => step["continue-on-error"] === undefined)).toBe(
+      true,
+    );
+    expect(steps.map((step) => step.name)).toEqual([
+      "Checkout",
+      "Set up exact Node.js",
+      "Require a Developer Certificate of Origin sign-off",
+    ]);
+    expect(steps.filter((step) => step.uses).map((step) => step.uses)).toEqual([
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+    ]);
+    // A shallow fetch cannot walk base..head, so the range would come back
+    // empty and the gate would pass without checking anything.
+    expect(object(steps[0]?.with, "checkout.with")).toEqual({
+      "fetch-depth": 0,
+      "persist-credentials": false,
     });
   });
 

--- a/tests/dco-checker.test.ts
+++ b/tests/dco-checker.test.ts
@@ -1,0 +1,206 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const checker = join(repositoryRoot, "scripts/check-dco.mjs");
+
+const author = [
+  "-c",
+  "user.name=Test Author",
+  "-c",
+  "user.email=author@example.com",
+];
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+function git(root: string, args: readonly string[]): string {
+  const result = spawnSync("git", [...args], { cwd: root, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")}: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+async function repository(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-dco-"));
+  roots.push(root);
+  git(root, ["init", "-q", "--initial-branch=main"]);
+  return root;
+}
+
+async function commit(
+  root: string,
+  message: string,
+  options: { readonly signOff?: boolean; readonly file?: string } = {},
+): Promise<void> {
+  // Each commit touches its own file by default, so a branch can be merged
+  // without contriving a conflict the test is not about.
+  const file = options.file ?? `${message.replaceAll(" ", "-")}.txt`;
+  await writeFile(join(root, file), `${message}\n`, "utf8");
+  git(root, ["add", file]);
+  git(root, [
+    ...author,
+    "commit",
+    "-q",
+    ...(options.signOff === true ? ["-s"] : []),
+    "-m",
+    message,
+  ]);
+}
+
+function check(
+  root: string,
+  base: string,
+  head: string,
+): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(
+    process.execPath,
+    [checker, "--base", base, "--head", head],
+    { cwd: root, encoding: "utf8" },
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+describe("DCO sign-off checker", () => {
+  it("accepts a range where every commit is signed", async () => {
+    const root = await repository();
+    await commit(root, "base", { signOff: true });
+    const base = git(root, ["rev-parse", "HEAD"]);
+    await commit(root, "first change", { signOff: true });
+    await commit(root, "second change", { signOff: true });
+
+    const result = check(root, base, "HEAD");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("2 commits signed off");
+  });
+
+  it("rejects an unsigned commit and names it", async () => {
+    const root = await repository();
+    await commit(root, "base", { signOff: true });
+    const base = git(root, ["rev-parse", "HEAD"]);
+    await commit(root, "compliant change", { signOff: true });
+    await commit(root, "missing trailer");
+
+    const result = check(root, base, "HEAD");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("1 commit without");
+    expect(result.stderr).toContain("missing trailer");
+    // The report must name only the offenders; listing a compliant commit
+    // would send the author looking for a problem that is not there.
+    expect(result.stderr).not.toContain("compliant change");
+    expect(result.stderr).toContain("git commit -s");
+  });
+
+  it("reports every unsigned commit, not just the first", async () => {
+    const root = await repository();
+    await commit(root, "base", { signOff: true });
+    const base = git(root, ["rev-parse", "HEAD"]);
+    await commit(root, "first unsigned");
+    await commit(root, "second unsigned");
+
+    const result = check(root, base, "HEAD");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("2 commits without");
+    expect(result.stderr).toContain("first unsigned");
+    expect(result.stderr).toContain("second unsigned");
+  });
+
+  // A merge has no author to certify anything and cannot be signed after the
+  // forge creates it. Requiring one would fail every branch that merges its
+  // base, which is the normal way to update a pull request.
+  it("exempts a merge commit while still checking its new commits", async () => {
+    const root = await repository();
+    await commit(root, "base", { signOff: true });
+    const base = git(root, ["rev-parse", "HEAD"]);
+    git(root, ["checkout", "-q", "-b", "side"]);
+    await commit(root, "side change", { signOff: true });
+    git(root, ["checkout", "-q", "main"]);
+    await commit(root, "main change", { signOff: true });
+    git(root, [
+      ...author,
+      "merge",
+      "-q",
+      "--no-ff",
+      "-m",
+      "Merge side",
+      "side",
+    ]);
+
+    const result = check(root, base, "HEAD");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("2 commits signed off");
+  });
+
+  // `Signed-off-by: me` certifies nothing. Accepting it would make the gate
+  // theatre, which is worse than no gate because it looks enforced.
+  it("refuses a trailer with no reachable address", async () => {
+    const root = await repository();
+    await commit(root, "base", { signOff: true });
+    const base = git(root, ["rev-parse", "HEAD"]);
+    await writeFile(join(root, "file.txt"), "malformed\n", "utf8");
+    git(root, ["add", "file.txt"]);
+    git(root, [
+      ...author,
+      "commit",
+      "-q",
+      "-m",
+      "malformed trailer\n\nSigned-off-by: nobody",
+    ]);
+
+    const result = check(root, base, "HEAD");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("malformed trailer");
+  });
+
+  it("accepts a sign-off that is not the last trailer", async () => {
+    const root = await repository();
+    await commit(root, "base", { signOff: true });
+    const base = git(root, ["rev-parse", "HEAD"]);
+    await writeFile(join(root, "file.txt"), "trailers\n", "utf8");
+    git(root, ["add", "file.txt"]);
+    git(root, [
+      ...author,
+      "commit",
+      "-q",
+      "-m",
+      "many trailers\n\nSigned-off-by: Test Author <author@example.com>\nCo-Authored-By: Someone <someone@example.com>",
+    ]);
+
+    const result = check(root, base, "HEAD");
+
+    expect(result.status).toBe(0);
+  });
+
+  it("reports usage rather than a stack trace when arguments are missing", async () => {
+    const root = await repository();
+    await commit(root, "base", { signOff: true });
+
+    const result = spawnSync(process.execPath, [checker, "--base"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("expected --base <commit> --head <commit>");
+  });
+});


### PR DESCRIPTION
Closes #95.

`CONTRIBUTING.md` states that every commit must certify the DCO. 77 of the 146
commits on `main` do. The practice stopped on Aug 11 and nothing noticed,
because nothing checked — no workflow inspected the trailer, and no DCO app is
installed. A documented MUST with no gate behind it teaches contributors that
the contribution documents are decorative.

## What this adds

- `scripts/lib/dco.mjs` — the rules, as pure functions over parsed commits.
- `scripts/check-dco.mjs` — a CLI over a `base..head` range that reports every
  offending commit with the exact remedy, not just the first one.
- `tests/dco-checker.test.ts` — seven cases, driving the real CLI against real
  temporary repositories.
- A `dco` job in `ci.yml`, running on pull requests only.
- `CONTRIBUTING.md` — how it is enforced, and that it applies forward.

## Decisions worth arguing with

**Merge commits are exempt.** A merge created by the forge has no author to
certify it and cannot be signed after the fact. Requiring one would fail every
branch that merges its base to refresh — which is exactly what #93 did earlier
today.

**A trailer without a reachable address is refused.** `Signed-off-by: me`
certifies nothing. Accepting the degenerate form would make the gate look
enforced while proving nothing, which is worse than no gate at all.

**A separate job, not another step in `quality`.** A missing `-s` is reported
in seconds instead of behind the full nine-minute pipeline. The job is held to
the same shape the workflow contract already pins for `quality`: read-only
permissions, a bounded timeout, SHA-pinned actions, no `continue-on-error` —
and `tests/ci-workflow-contract.test.ts` now asserts that for both jobs rather
than merely tolerating a second one.

**`fetch-depth: 0`.** A shallow checkout cannot walk `base..head`; the range
comes back empty and the gate passes without checking anything. The contract
test pins this, because that failure mode is silent.

**Enforcement applies from here forward.** The 69 unsigned commits already on
`main` are left alone. Rewriting merged history costs more than it recovers,
and the DCO is normally adopted forward-only for exactly this reason.

## About the sign-off on this commit

The commit is signed under the repository owner's explicit authorization, given
in the session that produced this change. Recorded here because
`CONTRIBUTING.md` forbids signing on another person's behalf, and that rule is
left unchanged — the authorization is the owner certifying their own
contribution, not a maintainer certifying someone else's.

## Verification

```bash
npm run verify                                    # 97 files, 2581 tests, green
node scripts/check-dco.mjs --base origin/main --head HEAD
```

The second command is this branch checked by the gate it introduces:
`DCO: 1 commit signed off`. CI will run the same check on this pull request.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)