### PR TITLE
feat: extend the managed transaction surface to the initialization destinations

### DIFF
--- a/docs/architecture/atomic-transactions.md
+++ b/docs/architecture/atomic-transactions.md
@@ -7,7 +7,7 @@ It does not add a public state command or complete the SDD trail. The staged CLI
 still supports only `help`, `version`, and `handshake`.
 
 The boundary turns one normalized, ordered managed mutation plan into a durable
-transaction below `.brain/`. That normalized plan is currently an internal
+transaction inside the managed surface. That normalized plan is currently an internal
 input to execution. This issue adds no public dry-run wiring; a future command
 can render the same plan without creating transaction metadata. A plan whose
 results are already present is a no-op and also creates no transaction.
@@ -15,9 +15,27 @@ results are already present is a no-op and also creates no transaction.
 ## Managed scope and layout
 
 Caller-owned operations may create directories, write files, or delete regular
-files below `.brain/`. The transaction manager exclusively owns
-`.brain/transactions/**`; a caller cannot target that namespace, even through a
-case variant.
+files inside the managed surface:
+
+| Destination | Accepted | Why |
+| --- | --- | --- |
+| `.brain/**` | yes | Managed state |
+| `.brain/transactions/**` | no | The transaction manager owns the namespace exclusively, even through a case variant |
+| `.claude/**`, `.codex/**` | yes | The host surfaces `init` generates |
+| `CLAUDE.md`, `AGENTS.md` | yes | The two instruction files, by exact spelling |
+| Any other root file | no | A pattern over the project root would accept files this runtime has no business writing |
+| `.brain` itself | no | The manager creates it before any plan runs; two owners for one directory is one too many |
+| `.claude`, `.codex` themselves | as directories only | A host root has no bootstrap, so the plan that writes inside one creates it |
+
+One module states this rule and every layer reads it: the domain normalizer,
+the transaction manager, and the Node adapter. The adapter answers a
+deliberately wider question than a plan may ask, because the manager writes its
+own reserved namespace through that same adapter.
+
+A destination at the project root has the root as its parent. `inspect` and
+`syncDirectory` accept the exact `.` sentinel for that reason, and no other
+operation does: the project root is not a file to read, a directory to create,
+or an entry to remove.
 
 An active or retained transaction uses this bounded layout:
 
@@ -149,7 +167,7 @@ capability actually observed.
 | Incomplete transaction or terminal cleanup residue | `runtime.recovery_required` |
 | Destination drift before publication | `runtime.revision_conflict` |
 | Invalid marker, bound manifest, progress, payload, layout, or ambiguous destination | `runtime.state_corrupt` |
-| Destination outside `.brain/` or inside the reserved namespace | `guard.outside_allow` |
+| Destination outside the managed surface or inside the reserved namespace | `guard.outside_allow` |
 | Unexpected failure before a durable marker exists | `runtime.internal_failure` |
 
 Universal results use catalog text and relative evidence only. They never
@@ -160,10 +178,10 @@ transaction terminal first.
 
 ## Path and cleanup safety
 
-Every destination must be one canonical project-relative spelling below
-`.brain/`. Absolute, drive-qualified, backslash-bearing, control-character,
-traversing, empty, reserved, overlapping, contradictory, and case-colliding
-paths are rejected before mutation.
+Every destination must be one canonical project-relative spelling inside the
+managed surface. Absolute, drive-qualified, backslash-bearing,
+control-character, traversing, empty, reserved, overlapping, contradictory, and
+case-colliding paths are rejected before mutation.
 
 The Node adapter anchors operations to the original canonical project root and
 revalidates that root plus every existing path component without following

--- a/docs/superpowers/plans/2026-08-14-managed-transaction-surface.md
+++ b/docs/superpowers/plans/2026-08-14-managed-transaction-surface.md
@@ -1,0 +1,154 @@
+# Managed Transaction Surface Implementation Plan
+
+Implements the design in
+[`2026-08-14-managed-transaction-surface-design.md`](../specs/2026-08-14-managed-transaction-surface-design.md)
+for issue [#101](https://github.com/thiagocorreanet/mestre-yoda/issues/101)
+(`RUN-05a`).
+
+## Global constraints
+
+- Test-first: write the failing assertion, watch it fail for the stated reason,
+  then implement.
+- No existing refusal weakens. Every path refused before this change is refused
+  after it.
+- Coverage stays at 100% on all four measures.
+- Source, tests, comments, and commits in English.
+
+## Specification coverage map
+
+| Design section | Task |
+| --- | --- |
+| One rule, three consumers | 1, 2 |
+| The widened surface | 1, 2 |
+| The project root as a parent | 3 |
+| What stays refused | 1, 4 |
+| Testing strategy | 1-4 |
+
+---
+
+### Task 1: One rule
+
+**Files:**
+
+- Create: `packages/runtime/src/domain/transactions/surface.ts`
+- Create: `tests/managed-surface.test.ts`
+- Modify: `packages/runtime/src/domain/transactions/normalize.ts`
+
+**Interfaces:**
+
+- Produces: `isManagedDestination(path): boolean`, total and pure.
+
+- [ ] **Step 1: Write the accept and refuse tables**
+
+Both tables in one place, since they are one rule. The refuse table is the
+existing one from `tests/transaction-normalization.test.ts`, copied
+deliberately: a rule that stops refusing what it refused is the regression this
+task exists to prevent.
+
+- [ ] **Step 2: Verify RED, implement, verify GREEN**
+
+The normalizer keeps throwing `guard.outside_allow`; only the question it asks
+moves.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "refactor: state the managed-surface rule once"
+```
+
+---
+
+### Task 2: Three consumers, one answer
+
+**Files:**
+
+- Modify: `packages/runtime/src/composition/transactions.ts`,
+  `packages/runtime/src/infra/node/transactions.ts`
+- Modify: `tests/managed-surface.test.ts`
+
+- [ ] **Step 1: Write the agreement property**
+
+Over the accept table, the refuse table, and generated near-misses -- a
+trailing slash, a doubled separator, a case variant, a traversal, a root file
+one character off -- the normalizer, the composition predicate, and the adapter
+reach the same verdict. Disagreement is the defect this asserts against, so the
+property compares them rather than checking each against a list.
+
+- [ ] **Step 2: Verify RED, replace both restatements, verify GREEN**
+
+`infra` may import `domain`, so the adapter consumes the rule rather than
+restating it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "refactor: have every layer ask the one surface rule"
+```
+
+---
+
+### Task 3: A root destination has a parent
+
+**Files:**
+
+- Modify: `packages/runtime/src/ports/transactions.ts`,
+  `packages/runtime/src/infra/node/transactions.ts`,
+  `packages/runtime/src/infra/fake/**`,
+  `packages/runtime/src/composition/transactions.ts`
+- Modify: `tests/node-transaction-security.test.ts`,
+  `tests/transaction-port-contract.ts`
+
+- [ ] **Step 1: Write the sentinel contract test**
+
+`inspect(".")` reports a directory, resolved through the same anchored root the
+adapter validates for every other operation, and a project root that is not a
+usable directory fails the way it already does. The port contract suite carries
+this so the fake and the Node adapter answer alike.
+
+- [ ] **Step 2: Publish a root file end to end**
+
+A plan writing `CLAUDE.md` commits: its parent is inspected, its directory is
+synchronized, and the receipt records the destination. The `parentOf` coverage
+ignore goes away because the branch is now reached.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat: inspect the project root a managed file sits in"
+```
+
+---
+
+### Task 4: Interruption across the whole surface
+
+**Files:**
+
+- Create: `tests/transaction-surface-campaign.test.ts`
+- Modify: `docs/architecture/atomic-transactions.md`
+
+- [ ] **Step 1: Campaign across the three zones**
+
+One plan writing under `.brain/`, under `.claude/`, and at the project root,
+interrupted at every mutating durable boundary, leaves the project untouched or
+complete. The campaign shape is the one `RUN-05` and `RUN-07` already use, and
+the timeout allows for coverage instrumentation.
+
+- [ ] **Step 2: Correct the documented contract**
+
+The architecture document states the `.brain/`-only rule as the contract in
+three places. It becomes the surface table from the design, including what
+stays refused and why root files are accepted by exact name.
+
+- [ ] **Step 3: Full repository gate**
+
+```bash
+npm test && npm run test:coverage
+npm run format:check && npm run spellcheck && npm run lint && npm run typecheck
+npm run oracle:verify && npm run parity:check && npm run result:check
+npm run contracts:check && npm run differential:check
+npm run build && npm run package:verify
+```
+
+- [ ] **Step 4: Commit, open the PR, merge on green**
+
+The PR links #101, states that no refusal weakened, and carries `Closes #101`.

--- a/docs/superpowers/specs/2026-08-14-managed-transaction-surface-design.md
+++ b/docs/superpowers/specs/2026-08-14-managed-transaction-surface-design.md
@@ -1,0 +1,119 @@
+# Managed Transaction Surface Design
+
+Issue [#101](https://github.com/thiagocorreanet/mestre-yoda/issues/101)
+(`RUN-05a`). Epic
+[#15](https://github.com/thiagocorreanet/mestre-yoda/issues/15). Extends
+[#20](https://github.com/thiagocorreanet/mestre-yoda/issues/20) (`RUN-05`) and
+unblocks [#25](https://github.com/thiagocorreanet/mestre-yoda/issues/25)
+(`SDD-01`).
+
+## Problem
+
+The managed transaction accepts destinations below `.brain/` and nothing else.
+That was the entire managed surface when `RUN-05` landed, and the rule is
+written three times: `assertManagedPath` in the domain normalizer,
+`isManagedDestination` in the composition transaction manager, and
+`normalizeManagedPath` in the Node adapter. Three spellings of one rule is two
+opportunities for them to disagree.
+
+`SDD-01` is the first command that writes what a user asked for, and four of
+its frozen destinations are outside that surface: `.claude/`, `.codex/`,
+`CLAUDE.md`, and `AGENTS.md`. Its design commits one `EffectPlan` through
+`applyPlan`, which is what makes an interrupted initialization leave the
+project untouched or complete. Writing the host files outside the transaction
+would surrender that guarantee for more than half the files the command
+creates.
+
+## Goals
+
+- State the managed-surface rule once and have all three layers consume it.
+- Accept the initialization destinations without loosening any existing
+  refusal.
+- Give a destination at the project root a parent the protocol can inspect and
+  synchronize.
+
+## Non-goals
+
+- The `init` command, its flags, and its answers contract, which are `SDD-01`.
+- Any destination outside the frozen `init` inventory. A widened surface is not
+  an open one.
+- Changing what a transaction guarantees. The commit, recovery, and failure
+  contracts are untouched; only the set of destinations they accept moves.
+
+## One rule, three consumers
+
+The rule moves to `domain/transactions/surface.ts` as a total predicate over a
+project-relative path. The domain normalizer keeps throwing
+`guard.outside_allow`, the composition manager keeps its boolean question, and
+the Node adapter keeps refusing before it touches a syscall -- but all three
+ask the same function.
+
+`infra` may import `domain`, so the adapter consumes the rule directly rather
+than restating it. That is what makes "the three layers agree" a property of
+the code instead of a claim a test has to re-establish for every path anybody
+thinks to try.
+
+## The widened surface
+
+| Destination | Accepted | Why |
+| --- | --- | --- |
+| `.brain/**` | yes | Managed state, as before |
+| `.brain/transactions/**` | no | The manager owns the namespace exclusively |
+| `.claude/**`, `.codex/**` | yes | Host surfaces the frozen `init` inventory generates |
+| `CLAUDE.md`, `AGENTS.md` | yes | The two instruction files, by exact name |
+| Any other root file | no | `state.json` at the root is still outside |
+| A managed root itself | no | `.brain`, `.claude`, and `.codex` are not destinations |
+
+Root files are accepted by exact spelling rather than by pattern. A pattern
+over the project root -- any `*.md`, say -- would accept a file this runtime
+has no business writing, and the inventory names exactly two.
+
+Case aliasing keeps its existing treatment: the reserved namespace is matched
+case-insensitively, and the collision key stays lowercase, so a plan cannot
+target `CLAUDE.md` and `claude.md` in one transaction.
+
+## The project root as a parent
+
+`parentOf` returns `"."` for a path with no separator. That branch was
+unreachable, and carried a coverage ignore saying so. It becomes reachable the
+moment `CLAUDE.md` is a legal destination.
+
+The durable port already documents `.` as the project-root sentinel, but only
+`syncDirectory` accepts it. `inspect` learns the same sentinel, resolving it
+through the adapter's existing anchored-root validation, so publishing a root
+file can assert its parent is a directory the way every other operation does.
+
+No new port method appears. The sentinel is one value on two existing methods,
+which keeps a project root from becoming a second kind of path that every
+future operation has to reason about.
+
+## What stays refused
+
+Every refusal `RUN-05` established survives unchanged: absolute,
+drive-qualified, backslash-bearing, control-character, traversing, empty,
+trailing-separator, reserved, overlapping, contradictory, and case-colliding
+paths. The Node adapter keeps anchoring to the canonical root, keeps
+revalidating every existing component without following symlinks, and keeps
+refusing symlinks and special entries at a destination.
+
+The failure mapping does not move. A destination outside the surface is still
+`guard.outside_allow`, and the reason catalog gains nothing.
+
+## Testing strategy
+
+**One rule.** A property test asserts the three layers accept and refuse the
+same paths, over the accept table, the refuse table, and generated
+near-misses -- because the point of the change is that they cannot disagree.
+
+**Widened accept table.** `.claude/settings.json`, `.codex/agents/x.toml`,
+`CLAUDE.md`, and `AGENTS.md` normalize into operations; `.claude` alone,
+`state.json`, and `readme.md` do not.
+
+**Root parent.** A plan writing `CLAUDE.md` inspects and synchronizes `.`, and
+the Node adapter resolves that sentinel through the same validated root it
+anchors everything else to.
+
+**Interruption.** A fault campaign over a plan spanning `.brain/`, a host
+directory, and the project root, reusing the campaign shape `RUN-05` and
+`RUN-07` already use. This is the assertion that the widened surface did not
+weaken the guarantee it was widened to preserve.

--- a/docs/superpowers/specs/2026-08-14-managed-transaction-surface-design.md
+++ b/docs/superpowers/specs/2026-08-14-managed-transaction-surface-design.md
@@ -40,16 +40,29 @@ creates.
 - Changing what a transaction guarantees. The commit, recovery, and failure
   contracts are untouched; only the set of destinations they accept moves.
 
-## One rule, three consumers
+## One rule, two questions, three consumers
 
-The rule moves to `domain/transactions/surface.ts` as a total predicate over a
+The rule moves to `domain/transactions/surface.ts` as total predicates over a
 project-relative path. The domain normalizer keeps throwing
 `guard.outside_allow`, the composition manager keeps its boolean question, and
 the Node adapter keeps refusing before it touches a syscall -- but all three
-ask the same function.
+read the same module.
 
-`infra` may import `domain`, so the adapter consumes the rule directly rather
-than restating it. That is what makes "the three layers agree" a property of
+There are two questions, because the transaction manager is itself a caller of
+the adapter and needs more than a plan does:
+
+| Question | Asked by | Accepts |
+| --- | --- | --- |
+| `isManagedPathShape` | the Node adapter | one canonical spelling inside the managed surface, including the roots themselves and `.brain/transactions/**` |
+| `isManagedDestination` | the normalizer and the transaction manager | the same surface minus the reserved namespace and minus the roots themselves |
+
+The manager creates `.brain`, inspects it, and writes its own namespace through
+that adapter. A plan may do neither. Naming the difference is what keeps it
+from being rediscovered as a bug later; collapsing the two questions into one
+would either close the namespace to its owner or open it to everybody.
+
+`infra` may import `domain`, so the adapter consumes the shape rule directly
+rather than restating it. That is what makes "the layers agree" a property of
 the code instead of a claim a test has to re-establish for every path anybody
 thinks to try.
 
@@ -62,7 +75,7 @@ thinks to try.
 | `.claude/**`, `.codex/**` | yes | Host surfaces the frozen `init` inventory generates |
 | `CLAUDE.md`, `AGENTS.md` | yes | The two instruction files, by exact name |
 | Any other root file | no | `state.json` at the root is still outside |
-| A managed root itself | no | `.brain`, `.claude`, and `.codex` are not destinations |
+| A managed root itself | no | `.brain`, `.claude`, and `.codex` are places a plan writes inside, not destinations |
 
 Root files are accepted by exact spelling rather than by pattern. A pattern
 over the project root -- any `*.md`, say -- would accept a file this runtime
@@ -101,9 +114,12 @@ The failure mapping does not move. A destination outside the surface is still
 
 ## Testing strategy
 
-**One rule.** A property test asserts the three layers accept and refuse the
-same paths, over the accept table, the refuse table, and generated
-near-misses -- because the point of the change is that they cannot disagree.
+**One rule.** A property test walks the accept table, the refuse table, and a
+list of near-misses, and asserts that the adapter answers the shape question
+and the planner answers the destination question for every one of them. The
+point of the change is that the two cannot drift apart, so the test compares
+each layer's real behavior against the shared rule rather than against a list
+somebody maintained by hand.
 
 **Widened accept table.** `.claude/settings.json`, `.codex/agents/x.toml`,
 `CLAUDE.md`, and `AGENTS.md` normalize into operations; `.claude` alone,

--- a/packages/runtime/src/composition/index.ts
+++ b/packages/runtime/src/composition/index.ts
@@ -13,6 +13,7 @@ import {
   type JsonState,
 } from "../domain/events/index.js";
 import {
+  isManagedDirectoryDestination,
   managedPathCollisionKey,
   normalizeManagedMutationPlan,
   toPersistedManagedOperation,
@@ -873,7 +874,7 @@ function managedObservationPaths(plan: EffectPlan): readonly string[] {
     if (
       effect.kind === "emit" ||
       effect.kind === "append_event" ||
-      !isObservationCandidate(effect.path)
+      !isManagedDirectoryDestination(effect.path)
     ) {
       continue;
     }
@@ -882,32 +883,14 @@ function managedObservationPaths(plan: EffectPlan): readonly string[] {
     // normalization below remains the authoritative managed-path policy.
     paths.add(".brain");
     const segments = effect.path.split("/");
-    for (let length = 2; length <= segments.length; length += 1) {
+    // From the first component: a host root and a root file are both
+    // destinations now, and an unobserved destination is one a second run
+    // rewrites instead of recognizing as already right.
+    for (let length = 1; length <= segments.length; length += 1) {
       paths.add(segments.slice(0, length).join("/"));
     }
   }
   return [...paths];
-}
-
-function isObservationCandidate(path: string): boolean {
-  if (path === "" || path.includes("\\") || /^[A-Za-z]:/u.test(path)) {
-    return false;
-  }
-  for (const character of path) {
-    const codePoint = character.codePointAt(0);
-    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
-      return false;
-    }
-  }
-  const segments = path.split("/");
-  return (
-    segments.length >= 2 &&
-    segments[0] === ".brain" &&
-    !segments.some(
-      (segment) => segment === "" || segment === "." || segment === "..",
-    ) &&
-    segments[1]?.toLowerCase() !== "transactions"
-  );
 }
 
 function durableEntryFingerprint(

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -15,6 +15,7 @@ import {
   assertPhaseTransition,
   decideRecovery,
   isManagedDestination,
+  isManagedDirectoryDestination,
   toPersistedManagedOperation,
   type ManagedMutationPlan,
   type ManagedOperation,
@@ -589,7 +590,7 @@ function freezeManagedOperation(
   if (value.operationId !== operationId || typeof value.path !== "string") {
     throw invalidPlan();
   }
-  assertCallerManagedDestination(value.path);
+  assertCallerManagedDestination(value.path, value.kind);
   const expected = freezeFingerprint(value.expected);
   const result = freezeFingerprint(value.result);
   if (sameFingerprint(expected, result)) throw invalidPlan();
@@ -758,15 +759,24 @@ function validateManagedRelationships(
 
 function managedPathPrefixes(path: string): readonly string[] {
   const segments = path.split("/");
-  return segments
-    .slice(1)
-    .map((_segment, index) => segments.slice(0, index + 2).join("/"));
+  return segments.map((_segment, index) =>
+    segments.slice(0, index + 1).join("/"),
+  );
 }
 
-function assertCallerManagedDestination(path: string): void {
-  if (!isManagedDestination(path)) {
-    throw new TransactionFailure("guard.outside_allow", []);
-  }
+/**
+ * Refuse a destination the caller may not target, by what it does to it.
+ *
+ * A plan may create a host root and may not write a file at one, so the
+ * question depends on the operation. An unknown kind fails the shape check
+ * below this call, which is where a malformed plan belongs.
+ */
+function assertCallerManagedDestination(path: string, kind: unknown): void {
+  const allowed =
+    kind === "create_directory"
+      ? isManagedDirectoryDestination(path)
+      : isManagedDestination(path);
+  if (!allowed) throw new TransactionFailure("guard.outside_allow", []);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1647,7 +1657,7 @@ function assertManifestSemantics(
     const operationId = `operation-${String(index + 1).padStart(4, "0")}`;
     if (
       operation.operationId !== operationId ||
-      !isManagedDestination(operation.path)
+      !isManagedDirectoryDestination(operation.path)
     ) {
       throw corrupt(`${root}/manifest.json`);
     }
@@ -2259,9 +2269,14 @@ function sameFingerprint(
   return left.size === right.size && left.sha256 === right.sha256;
 }
 
+/**
+ * The directory a destination sits in.
+ *
+ * A managed root file has no separator, and its parent is the project root --
+ * the sentinel `inspect` and `syncDirectory` both answer to.
+ */
 function parentOf(path: string): string {
   const separator = path.lastIndexOf("/");
-  /* v8 ignore next -- every managed destination begins with .brain/ */
   return separator === -1 ? "." : path.slice(0, separator);
 }
 

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -14,6 +14,7 @@ import {
 import {
   assertPhaseTransition,
   decideRecovery,
+  isManagedDestination,
   toPersistedManagedOperation,
   type ManagedMutationPlan,
   type ManagedOperation,
@@ -1693,33 +1694,6 @@ function assertManifestSemantics(
   if (manifest.planDigest !== planDigest) {
     throw corrupt(`${root}/manifest.json`);
   }
-}
-
-function isManagedDestination(path: string): boolean {
-  const segments = path.split("/");
-  return (
-    path !== "" &&
-    !path.includes("\\") &&
-    !/^[A-Za-z]:/u.test(path) &&
-    !hasControlCharacter(path) &&
-    segments.length >= 2 &&
-    segments[0] === ".brain" &&
-    segments[1]?.toLowerCase() !== "transactions" &&
-    segments.every(
-      (segment) => segment !== "" && segment !== "." && segment !== "..",
-    ) &&
-    segments.join("/") === path
-  );
-}
-
-function hasControlCharacter(value: string): boolean {
-  for (const character of value) {
-    const codePoint = character.codePointAt(0);
-    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 async function observeTransaction(

--- a/packages/runtime/src/domain/transactions/index.ts
+++ b/packages/runtime/src/domain/transactions/index.ts
@@ -16,4 +16,9 @@ export {
   normalizeManagedMutationPlan,
 } from "./normalize.js";
 export { decideRecovery } from "./recovery.js";
+export {
+  hasControlCharacter,
+  isManagedDestination,
+  isManagedPathShape,
+} from "./surface.js";
 export { assertPhaseTransition } from "./transition.js";

--- a/packages/runtime/src/domain/transactions/index.ts
+++ b/packages/runtime/src/domain/transactions/index.ts
@@ -19,6 +19,7 @@ export { decideRecovery } from "./recovery.js";
 export {
   hasControlCharacter,
   isManagedDestination,
+  isManagedDirectoryDestination,
   isManagedPathShape,
 } from "./surface.js";
 export { assertPhaseTransition } from "./transition.js";

--- a/packages/runtime/src/domain/transactions/normalize.ts
+++ b/packages/runtime/src/domain/transactions/normalize.ts
@@ -1,4 +1,5 @@
 import type { Effect, EffectPlan } from "../effects.js";
+import { isManagedDestination } from "./surface.js";
 import {
   TransactionPolicyError,
   type ManagedMutationPlan,
@@ -34,7 +35,6 @@ type DraftOperation =
 
 const missing = { kind: "missing" } as const;
 const directory = { kind: "directory" } as const;
-const driveQualified = /^[A-Za-z]:/u;
 const utf8 = new TextEncoder();
 
 export function normalizeManagedMutationPlan(
@@ -95,27 +95,7 @@ function selectManagedEffects(effectPlan: EffectPlan): ManagedEffect[] {
 }
 
 function assertManagedPath(path: string): void {
-  if (
-    path === "" ||
-    path.includes("\\") ||
-    hasControlCharacter(path) ||
-    driveQualified.test(path)
-  ) {
-    throw outsideAllowlist();
-  }
-
-  const segments = path.split("/");
-  if (
-    segments.length < 2 ||
-    segments[0] !== ".brain" ||
-    segments.some(
-      (segment) => segment === "" || segment === "." || segment === "..",
-    ) ||
-    segments.join("/") !== path ||
-    segments[1]?.toLowerCase() === "transactions"
-  ) {
-    throw outsideAllowlist();
-  }
+  if (!isManagedDestination(path)) throw outsideAllowlist();
 }
 
 function validateRelationships(effects: readonly ManagedEffect[]): void {
@@ -272,16 +252,6 @@ function collisionKey(path: string): string {
 export function managedPathCollisionKey(path: string): string {
   assertManagedPath(path);
   return collisionKey(path);
-}
-
-function hasControlCharacter(path: string): boolean {
-  for (const character of path) {
-    const codePoint = character.codePointAt(0);
-    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function isParent(parent: string, child: string): boolean {

--- a/packages/runtime/src/domain/transactions/normalize.ts
+++ b/packages/runtime/src/domain/transactions/normalize.ts
@@ -1,5 +1,8 @@
 import type { Effect, EffectPlan } from "../effects.js";
-import { isManagedDestination } from "./surface.js";
+import {
+  isManagedDestination,
+  isManagedDirectoryDestination,
+} from "./surface.js";
 import {
   TransactionPolicyError,
   type ManagedMutationPlan,
@@ -84,6 +87,9 @@ function selectManagedEffects(effectPlan: EffectPlan): ManagedEffect[] {
       case "append_event":
         throw invalidState();
       case "create_directory":
+        assertManagedDirectory(effect.path);
+        effects.push(effect);
+        break;
       case "delete_file":
       case "write_file":
         assertManagedPath(effect.path);
@@ -96,6 +102,11 @@ function selectManagedEffects(effectPlan: EffectPlan): ManagedEffect[] {
 
 function assertManagedPath(path: string): void {
   if (!isManagedDestination(path)) throw outsideAllowlist();
+}
+
+/** A plan may create a host root; it may not write a file at one. */
+function assertManagedDirectory(path: string): void {
+  if (!isManagedDirectoryDestination(path)) throw outsideAllowlist();
 }
 
 function validateRelationships(effects: readonly ManagedEffect[]): void {
@@ -129,10 +140,21 @@ function validateRelationships(effects: readonly ManagedEffect[]): void {
 function managedPathPrefixes(path: string): string[] {
   const segments = path.split("/");
   const prefixes: string[] = [];
-  for (let length = 2; length <= segments.length; length += 1) {
+  for (let length = 1; length <= segments.length; length += 1) {
     prefixes.push(segments.slice(0, length).join("/"));
   }
   return prefixes;
+}
+
+/**
+ * The first path component a plan is responsible for creating.
+ *
+ * `.brain` is bootstrapped by the transaction manager before any plan runs, so
+ * a plan must not also propose creating it. A host root has no bootstrap: a
+ * plan that writes inside `.claude` is the reason `.claude` exists.
+ */
+function firstOwnedDepth(path: string): number {
+  return path.startsWith(".brain/") ? 2 : 1;
 }
 
 function synthesizeMissingParents(
@@ -141,7 +163,11 @@ function synthesizeMissingParents(
   drafts: DraftOperation[],
 ): void {
   const segments = path.split("/");
-  for (let length = 2; length < segments.length; length += 1) {
+  for (
+    let length = firstOwnedDepth(path);
+    length < segments.length;
+    length += 1
+  ) {
     const parent = segments.slice(0, length).join("/");
     const expected = observedState.get(parent) ?? missing;
     if (expected.kind === "file") throw invalidState();

--- a/packages/runtime/src/domain/transactions/surface.ts
+++ b/packages/runtime/src/domain/transactions/surface.ts
@@ -62,6 +62,20 @@ function isManagedRoot(segment: string): boolean {
 }
 
 /**
+ * Whether a plan may create this directory.
+ *
+ * Everything a plan may write to, plus the host roots themselves. A host root
+ * has no bootstrap: the plan that writes inside `.claude` is the reason
+ * `.claude` exists. `.brain` is deliberately not here -- the transaction
+ * manager creates it before any plan runs, and a plan proposing to create it
+ * too would be two owners for one directory.
+ */
+export function isManagedDirectoryDestination(path: string): boolean {
+  if (isManagedDestination(path)) return true;
+  return isManagedRoot(path) && path !== ".brain";
+}
+
+/**
  * Whether a plan may target a path.
  *
  * The managed surface minus the namespace the transaction manager owns. One

--- a/packages/runtime/src/domain/transactions/surface.ts
+++ b/packages/runtime/src/domain/transactions/surface.ts
@@ -1,0 +1,99 @@
+/**
+ * The directories a plan may write inside.
+ *
+ * `.brain` is managed state. `.claude` and `.codex` are the host surfaces the
+ * frozen `init` inventory generates. A root itself is not a destination: a plan
+ * targets what is inside it.
+ */
+const MANAGED_DIRECTORY_ROOTS: readonly string[] = [
+  ".brain",
+  ".claude",
+  ".codex",
+];
+
+/**
+ * The files at the project root a plan may write, by exact spelling.
+ *
+ * A pattern over the root -- any `*.md`, say -- would accept files this runtime
+ * has no business writing. The inventory names exactly these two.
+ */
+const MANAGED_ROOT_FILES: readonly string[] = ["AGENTS.md", "CLAUDE.md"];
+
+/** The transaction manager's own namespace, matched without regard to case. */
+const RESERVED_STATE_NAMESPACE = "transactions";
+
+const driveQualified = /^[A-Za-z]:/u;
+
+/**
+ * Whether a path is one canonical spelling inside the managed surface.
+ *
+ * This is the question the Node adapter asks, and it is deliberately wider
+ * than the destination rule in two ways: the transaction manager writes
+ * `.brain/transactions/**` through this same adapter, and it creates and
+ * inspects the managed roots themselves. Neither is something a caller's plan
+ * may target.
+ */
+export function isManagedPathShape(path: string): boolean {
+  if (
+    path === "" ||
+    path.includes("\\") ||
+    driveQualified.test(path) ||
+    hasControlCharacter(path)
+  ) {
+    return false;
+  }
+  if (
+    path
+      .split("/")
+      .some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    return false;
+  }
+
+  const separator = path.indexOf("/");
+  if (separator < 0) {
+    return MANAGED_ROOT_FILES.includes(path) || isManagedRoot(path);
+  }
+  return isManagedRoot(path.slice(0, separator));
+}
+
+function isManagedRoot(segment: string): boolean {
+  return MANAGED_DIRECTORY_ROOTS.includes(segment);
+}
+
+/**
+ * Whether a plan may target a path.
+ *
+ * The managed surface minus the namespace the transaction manager owns. One
+ * rule, asked by the domain normalizer and the transaction manager alike:
+ * restating it was an opportunity for the layer that plans and the layer that
+ * writes to disagree, and that disagreement is the shape of a hole in the
+ * allowlist.
+ */
+export function isManagedDestination(path: string): boolean {
+  if (!isManagedPathShape(path)) return false;
+  const separator = path.indexOf("/");
+  // A root is a place, not a destination: a plan targets what is inside it.
+  if (separator < 0) return MANAGED_ROOT_FILES.includes(path);
+  return !(
+    path.slice(0, separator) === ".brain" &&
+    reservedNamespace(path.slice(separator + 1))
+  );
+}
+
+/** Whether what follows the managed root is the reserved namespace. */
+function reservedNamespace(rest: string): boolean {
+  const separator = rest.indexOf("/");
+  const segment = separator < 0 ? rest : rest.slice(0, separator);
+  return segment.toLowerCase() === RESERVED_STATE_NAMESPACE;
+}
+
+export function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint !== undefined && (codePoint <= 0x1f || codePoint === 0x7f)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/runtime/src/infra/fake/transactions.ts
+++ b/packages/runtime/src/infra/fake/transactions.ts
@@ -5,6 +5,7 @@ import type {
   FileStat,
   FileSystem,
 } from "../../ports/index.js";
+import { isManagedPathShape } from "../../domain/transactions/index.js";
 import { sha256Digests } from "../digests.js";
 
 export type DurableOperation =
@@ -80,17 +81,9 @@ function normalizePath(path: string): string {
 
 function normalizeDurablePath(path: string): string {
   const normalized = normalizePath(path);
-  const segments = path.split("/");
-  if (
-    segments[0] !== ".brain" ||
-    segments.some(
-      (segment) => segment === "" || segment === "." || segment === "..",
-    ) ||
-    segments.join("/") !== path ||
-    normalized !== path
-  ) {
-    rejectPath();
-  }
+  // The same surface rule the Node adapter enforces, so a test that passes
+  // against the fake is not passing against a friendlier filesystem.
+  if (!isManagedPathShape(path) || normalized !== path) rejectPath();
   return normalized;
 }
 
@@ -293,6 +286,11 @@ export function memoryTransactionStorage(
   const durableFileSystem: DurableFileSystem = {
     inspect: (path) =>
       deferred(() => {
+        if (path === ".") {
+          return boundary("inspect", (): DurableEntry => ({
+            kind: "directory",
+          }));
+        }
         const normalized = normalizeDurablePath(path);
         return boundary("inspect", (): DurableEntry => {
           const content = files.get(normalized);

--- a/packages/runtime/src/infra/node/transactions.ts
+++ b/packages/runtime/src/infra/node/transactions.ts
@@ -14,6 +14,7 @@ import {
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 
+import { isManagedPathShape } from "../../domain/transactions/index.js";
 import type { DurableEntry, DurableFileSystem } from "../../ports/index.js";
 
 export type DurableOperation =
@@ -117,34 +118,16 @@ function pathRefusal(): never {
   throw new Error("Runtime path escapes the project");
 }
 
+/**
+ * Refuse anything outside the managed surface before a syscall happens.
+ *
+ * The shape rule rather than the destination rule: the transaction manager
+ * writes `.brain/transactions/**` through this adapter, and that namespace is
+ * closed to callers by the planner, not by the filesystem.
+ */
 function normalizeManagedPath(path: string): NormalizedPath {
-  let hasControlCharacter = false;
-  for (const character of path) {
-    const code = character.charCodeAt(0);
-    if (code < 0x20 || code === 0x7f) hasControlCharacter = true;
-  }
-  if (
-    path.length === 0 ||
-    path.startsWith("/") ||
-    /^[A-Za-z]:[\\/]/u.test(path) ||
-    path.includes("\\") ||
-    hasControlCharacter
-  ) {
-    return pathRefusal();
-  }
-
-  const segments = path.split("/");
-  if (
-    segments.length === 0 ||
-    segments[0] !== ".brain" ||
-    segments.some(
-      (segment) => segment === "" || segment === "." || segment === "..",
-    ) ||
-    segments.join("/") !== path
-  ) {
-    return pathRefusal();
-  }
-  return { path, segments };
+  if (path.startsWith("/") || !isManagedPathShape(path)) return pathRefusal();
+  return { path, segments: path.split("/") };
 }
 
 function missing(error: unknown): boolean {

--- a/packages/runtime/src/infra/node/transactions.ts
+++ b/packages/runtime/src/infra/node/transactions.ts
@@ -331,6 +331,12 @@ export function nodeDurableFileSystem(
   return {
     inspect: (path) =>
       boundary("inspect", async () => {
+        // The project root is the parent of a managed root file, and it is
+        // reached through the same validated anchor every other operation uses.
+        if (path === ".") {
+          await validatedRoot();
+          return { kind: "directory" } as const;
+        }
         const observation = await scan(path);
         if (observation.details?.isFile() !== true) {
           return durableNonFileEntry(observation.details);

--- a/packages/runtime/src/ports/transactions.ts
+++ b/packages/runtime/src/ports/transactions.ts
@@ -8,7 +8,15 @@ export type DurableEntry =
       readonly sha256: string;
     };
 
-/** Narrow durable filesystem primitives driven one boundary at a time. */
+/**
+ * Narrow durable filesystem primitives driven one boundary at a time.
+ *
+ * `inspect` and `syncDirectory` accept the exact `.` project-root sentinel,
+ * because a managed file at the project root has the root as its parent and a
+ * publication asserts its parent is a directory. No other method does: the
+ * project root is not a file to read, a directory to create, or an entry to
+ * remove.
+ */
 export interface DurableFileSystem {
   inspect(path: string): Promise<DurableEntry>;
   list(path: string): Promise<readonly string[]>;
@@ -24,7 +32,6 @@ export interface DurableFileSystem {
   ): Promise<void>;
   removeFile(path: string): Promise<void>;
   removeEmptyDirectory(path: string): Promise<void>;
-  /** This method alone accepts the exact `.` project-root sentinel. */
   syncDirectory(path: string): Promise<"supported" | "unsupported">;
 }
 

--- a/tests/fake-transactions.test.ts
+++ b/tests/fake-transactions.test.ts
@@ -448,10 +448,17 @@ describe("memory transaction storage", () => {
     expect(storage.snapshot()).toEqual(before);
   });
 
-  it("rejects the project root as a durable entry path", async () => {
-    await expect(
-      memoryTransactionStorage().durableFileSystem.inspect("."),
-    ).rejects.toThrow("escapes the project");
+  it("reports the project root without materializing it", async () => {
+    const storage = memoryTransactionStorage();
+
+    // A managed file at the project root has the root as its parent, and
+    // publishing it asserts that parent is a directory. Answering the question
+    // does not make the root an entry the fake stores.
+    await expect(storage.durableFileSystem.inspect(".")).resolves.toEqual({
+      kind: "directory",
+    });
+
+    expect(storage.snapshot()).toEqual(empty);
   });
 
   it("synchronizes the implicit project root without materializing it", async () => {

--- a/tests/managed-surface.test.ts
+++ b/tests/managed-surface.test.ts
@@ -1,0 +1,149 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { planOf } from "@mestre-yoda/runtime/domain/effects";
+import {
+  isManagedDestination,
+  isManagedPathShape,
+  normalizeManagedMutationPlan,
+} from "@mestre-yoda/runtime/domain/transactions";
+import { nodeDurableFileSystem } from "@mestre-yoda/runtime/infra/node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/** Everything a plan may target, one entry per reason it is legal. */
+export const ACCEPTED: readonly string[] = [
+  ".brain/config.json",
+  ".brain/02-features/_template/state.json",
+  ".claude/settings.json",
+  ".codex/config.toml",
+  ".codex/agents/spec-planner.toml",
+  "AGENTS.md",
+  "CLAUDE.md",
+];
+
+/** Everything a plan may not target, and the reason it may not. */
+export const REFUSED: readonly (readonly [string, string])[] = [
+  ["an unmanaged root file", "state.json"],
+  ["an unmanaged root file with a managed extension", "readme.md"],
+  ["a root file off by its case", "claude.md"],
+  ["a managed root itself", ".brain"],
+  ["a host root itself", ".claude"],
+  ["an unmanaged directory", "src/index.ts"],
+  ["a root file used as a directory", "CLAUDE.md/nested.md"],
+  ["a near-miss root", ".claudex/settings.json"],
+  ["the reserved transaction namespace", ".brain/transactions/forbidden"],
+  ["the reserved namespace with a case alias", ".brain/TRANSACTIONS/x"],
+  ["an absolute path", "/.brain/state.json"],
+  ["a drive-qualified path", "C:/.brain/state.json"],
+  ["a backslash-bearing path", ".brain\\state.json"],
+  ["a traversing path", ".brain/../state.json"],
+  ["a dot segment", ".brain/./state.json"],
+  ["an empty segment", ".brain//state.json"],
+  ["a trailing separator", ".brain/state.json/"],
+  ["a control character", ".brain/state\n.json"],
+  ["an empty path", ""],
+];
+
+describe("the managed surface", () => {
+  it.each(ACCEPTED)("accepts %s", (path) => {
+    expect(isManagedDestination(path)).toBe(true);
+  });
+
+  it.each(REFUSED)("refuses %s", (_label, path) => {
+    // Every entry below the first four was refused before the surface widened.
+    // A rule that stops refusing what it refused is the regression this table
+    // exists to prevent.
+    expect(isManagedDestination(path)).toBe(false);
+  });
+
+  it("does not accept a host namespace the inventory never named", () => {
+    // The surface widened by exact spelling. A pattern over the project root
+    // would accept files this runtime has no business writing.
+    expect(isManagedDestination(".cursor/settings.json")).toBe(false);
+    expect(isManagedDestination("GEMINI.md")).toBe(false);
+  });
+
+  it("reserves the transaction namespace only inside the managed state root", () => {
+    // `.brain/transactions` belongs to the transaction manager. A directory of
+    // the same name under a host surface is just a directory.
+    expect(isManagedDestination(".codex/transactions/x.toml")).toBe(true);
+  });
+
+  it("closes the reserved namespace to callers without closing it to the manager", () => {
+    // The manager writes its own namespace through the same adapter, so the
+    // shape it may operate on is wider than the set a plan may target. That
+    // difference is the one place the two rules part company.
+    expect(isManagedPathShape(".brain/transactions/tx-1/manifest.json")).toBe(
+      true,
+    );
+    expect(isManagedDestination(".brain/transactions/tx-1/manifest.json")).toBe(
+      false,
+    );
+  });
+});
+
+/** Spellings close enough to a legal path to catch a rule that drifted. */
+const NEAR_MISSES: readonly string[] = [
+  ".brain/",
+  "./brain/state.json",
+  ".BRAIN/state.json",
+  ".Claude/settings.json",
+  "CLAUDE.MD",
+  "agents.md",
+  "AGENTS.md/",
+  ".brain/transactions",
+  ".brain/transactionsx/file.json",
+  "..",
+  ".",
+];
+
+describe("every layer answers alike", () => {
+  const sha256 = (text: string): string => `sha256:${text}`;
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "yoda-managed-surface-"));
+  });
+
+  afterAll(async () => {
+    await rm(root, { force: true, recursive: true });
+  });
+
+  it.each([
+    ...ACCEPTED,
+    ...REFUSED.map(([, path]) => path),
+    ...NEAR_MISSES,
+    ".brain/transactions/tx-1/manifest.json",
+  ])("gives the planner and the adapter one answer about %s", async (path) => {
+    const adapterAccepts = await nodeDurableFileSystem(root)
+      .inspect(path)
+      .then(
+        () => true,
+        (error: unknown) =>
+          !(
+            error instanceof Error &&
+            error.message.includes("Runtime path escapes the project")
+          ),
+      );
+    const plannerAccepts = (() => {
+      try {
+        normalizeManagedMutationPlan(
+          planOf({ kind: "write_file", path, content: "x" }),
+          new Map(),
+          sha256,
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+
+    // The adapter answers the shape question and the planner answers the
+    // destination question. Comparing each against its own rule is what proves
+    // the layers cannot drift apart: a hole opens when one accepts a path the
+    // other refuses.
+    expect(adapterAccepts).toBe(isManagedPathShape(path));
+    expect(plannerAccepts).toBe(isManagedDestination(path));
+  });
+});

--- a/tests/managed-surface.test.ts
+++ b/tests/managed-surface.test.ts
@@ -95,7 +95,6 @@ const NEAR_MISSES: readonly string[] = [
   ".brain/transactions",
   ".brain/transactionsx/file.json",
   "..",
-  ".",
 ];
 
 describe("every layer answers alike", () => {
@@ -145,5 +144,13 @@ describe("every layer answers alike", () => {
     // other refuses.
     expect(adapterAccepts).toBe(isManagedPathShape(path));
     expect(plannerAccepts).toBe(isManagedDestination(path));
+  });
+
+  it("treats the project root as a sentinel rather than as a path", () => {
+    // `.` is not a managed path and never becomes one. It is the name two
+    // adapter methods answer to so a root file has a parent, and the planner
+    // never emits it as a destination.
+    expect(isManagedPathShape(".")).toBe(false);
+    expect(isManagedDestination(".")).toBe(false);
   });
 });

--- a/tests/support/transaction-port-contract.ts
+++ b/tests/support/transaction-port-contract.ts
@@ -231,6 +231,18 @@ export function describeDurableFileSystemContract(
       });
     });
 
+    it("reports the project root through the sentinel it already synchronizes", async () => {
+      await withFileSystem(async (fileSystem) => {
+        await createBrain(fileSystem);
+
+        // A destination at the project root -- `CLAUDE.md` -- has the root as
+        // its parent, and publishing it asserts that parent is a directory the
+        // way every other operation does. One sentinel on two methods beats a
+        // second kind of path that every future operation has to reason about.
+        expect(await fileSystem.inspect(".")).toEqual({ kind: "directory" });
+      });
+    });
+
     it("classifies directory synchronization without hiding path errors", async () => {
       await withFileSystem(async (fileSystem) => {
         await createBrain(fileSystem);
@@ -296,9 +308,14 @@ export function describeDurableFileSystemContract(
       ],
     ];
 
-    it.each(durableEntryPathOperations)(
+    it.each(
+      durableEntryPathOperations.filter(([label]) => label !== "inspect"),
+    )(
       "%s refuses the project root sentinel as a managed entry",
       async (_operation, run) => {
+        // `inspect` and `syncDirectory` accept the sentinel because a root
+        // file's parent is the root. Nothing else does: the project root is
+        // not a file to read, a directory to create, or an entry to remove.
         await withFileSystem(async (fileSystem) => {
           await expect(run(fileSystem, ".")).rejects.toThrow(
             "escapes the project",

--- a/tests/transaction-normalization.test.ts
+++ b/tests/transaction-normalization.test.ts
@@ -330,6 +330,37 @@ describe("managed mutation plan normalization", () => {
     ).toThrow(expect.objectContaining({ reasonCode: "guard.outside_allow" }));
   });
 
+  it.each([
+    ["an unmanaged directory", "src"],
+    ["the managed state root the manager owns", ".brain"],
+    ["a traversal dressed as a directory", ".claude/.."],
+  ])("rejects creating %s", (_name, path) => {
+    // A plan creates the host root it is about to write inside, so
+    // `create_directory` asks a wider question than `write_file` does. Wider
+    // is not open: `.brain` belongs to the transaction manager, and two owners
+    // for one directory is one too many.
+    expect(() =>
+      normalizeManagedMutationPlan(
+        planOf({ kind: "create_directory", path }),
+        new Map(),
+        sha256,
+      ),
+    ).toThrow(expect.objectContaining({ reasonCode: "guard.outside_allow" }));
+  });
+
+  it("creates a host root a plan is about to write inside", () => {
+    const normalized = normalizeManagedMutationPlan(
+      planOf({ kind: "create_directory", path: ".claude" }),
+      new Map(),
+      sha256,
+    );
+
+    expect(normalized).toMatchObject({
+      kind: "ready",
+      plan: { operations: [{ kind: "create_directory", path: ".claude" }] },
+    });
+  });
+
   it("rejects an unexpanded append effect", () => {
     expect(() =>
       normalizeManagedMutationPlan(

--- a/tests/transaction-surface-campaign.test.ts
+++ b/tests/transaction-surface-campaign.test.ts
@@ -1,0 +1,159 @@
+import {
+  applyPlan,
+  createRuntime,
+  inspectManagedTransactions,
+  recoverManagedMutation,
+  type TransactionServices,
+} from "@mestre-yoda/runtime/composition";
+import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
+import { planOf } from "@mestre-yoda/runtime/domain/effects";
+import {
+  fixedClock,
+  memoryTransactionStorage,
+  recordingOutput,
+  sequentialIds,
+  type DurableOperation,
+} from "@mestre-yoda/runtime/infra/fake";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Enough room for the campaign under coverage instrumentation, which is where
+ * a limit measured on an uninstrumented run turns into a false failure.
+ */
+const campaignTimeoutMilliseconds = 180_000;
+
+type Storage = ReturnType<typeof memoryTransactionStorage>;
+
+/** One destination per zone of the widened surface. */
+const DESTINATIONS = {
+  ".brain/config.json": '{ "language": "en" }\n',
+  ".claude/settings.json": '{ "permissions": {} }\n',
+  "CLAUDE.md": "# Managed\n",
+} as const;
+
+interface Boundary {
+  readonly operation: DurableOperation;
+  readonly timing: "before" | "after";
+  readonly occurrence: number;
+}
+
+function fixture(): Storage {
+  return memoryTransactionStorage({
+    directories: [".brain", ".brain/transactions"],
+  });
+}
+
+function ports(storage: Storage) {
+  return createRuntime({
+    clock: fixedClock("2026-08-14T00:00:00.000Z"),
+    ids: sequentialIds("transaction"),
+    durableFileSystem: storage.durableFileSystem,
+    digests: storage.digests,
+    fileSystem: storage.fileSystem,
+    output: recordingOutput(),
+  });
+}
+
+function services(storage: Storage): TransactionServices {
+  return {
+    clock: fixedClock("2026-08-14T00:00:00.000Z"),
+    ids: sequentialIds("recovery"),
+    digests: storage.digests,
+    durableFileSystem: storage.durableFileSystem,
+    schemaRegistry: createSchemaRegistry(),
+  };
+}
+
+function crossSurfacePlan() {
+  return planOf(
+    ...Object.entries(DESTINATIONS).map(
+      ([path, content]) => ({ kind: "write_file", path, content }) as const,
+    ),
+  );
+}
+
+function enumerateBoundaries(calls: readonly DurableOperation[]): Boundary[] {
+  const occurrences = new Map<DurableOperation, number>();
+  const boundaries: Boundary[] = [];
+  for (const operation of calls) {
+    const occurrence = (occurrences.get(operation) ?? 0) + 1;
+    occurrences.set(operation, occurrence);
+    boundaries.push(
+      { operation, timing: "before", occurrence },
+      { operation, timing: "after", occurrence },
+    );
+  }
+  return boundaries;
+}
+
+/**
+ * The property the widened surface exists to preserve.
+ *
+ * Every destination is present with the bytes the plan named, or none of them
+ * is. A project holding a `.claude` the plan created and a `CLAUDE.md` it never
+ * published is exactly the half-initialized state one transaction rules out.
+ */
+function expectUntouchedOrComplete(storage: Storage, label: string): void {
+  const snapshot = storage.snapshot();
+  const written = Object.entries(DESTINATIONS).filter(
+    ([path, content]) => snapshot.files[path] === content,
+  );
+  const present = Object.keys(DESTINATIONS).filter(
+    (path) => snapshot.files[path] !== undefined,
+  );
+
+  expect(present, label).toEqual(written.map(([path]) => path));
+  expect([0, Object.keys(DESTINATIONS).length], label).toContain(
+    written.length,
+  );
+  // No staged payload and no staging directory survives either outcome.
+  expect(
+    Object.keys(snapshot.files).filter((path) => path.endsWith(".payload")),
+    label,
+  ).toEqual([]);
+  expect(
+    snapshot.directories.filter((path) => path.endsWith("/staging")),
+    label,
+  ).toEqual([]);
+}
+
+describe("fault campaign across the managed surface", () => {
+  // prettier-ignore
+  it("leaves a project untouched or complete at every durable boundary", async () => {
+    const baseline = fixture();
+    await applyPlan(crossSurfacePlan(), ports(baseline));
+    expectUntouchedOrComplete(baseline, "baseline");
+    const boundaries = enumerateBoundaries(baseline.calls());
+
+    // The campaign is worth running only if it reaches the operations that
+    // publish outside `.brain`, so the baseline count is asserted rather than
+    // assumed.
+    expect(boundaries.length).toBeGreaterThan(100);
+
+    for (const boundary of boundaries) {
+      const label = `${boundary.operation}:${boundary.timing}:${String(boundary.occurrence)}`;
+      const storage = fixture();
+      storage.fail(boundary);
+      const recovery = services(storage);
+
+      try {
+        await applyPlan(crossSurfacePlan(), ports(storage));
+      } catch {
+        // A failure is one of the two outcomes under test; what it leaves
+        // behind is the assertion.
+      }
+
+      for (const summary of await inspectManagedTransactions(recovery)) {
+        await recoverManagedMutation(
+          {
+            transactionId: summary.transactionId,
+            recoveryToken: summary.recoveryToken,
+          },
+          recovery,
+        );
+      }
+
+      expectUntouchedOrComplete(storage, label);
+    }
+  }, campaignTimeoutMilliseconds);
+});

--- a/tests/transaction-surface.test.ts
+++ b/tests/transaction-surface.test.ts
@@ -1,0 +1,106 @@
+import {
+  applyPlan,
+  createRuntime,
+  previewPlan,
+  TransactionFailure,
+} from "@mestre-yoda/runtime/composition";
+import { planOf } from "@mestre-yoda/runtime/domain/effects";
+import {
+  fixedClock,
+  memoryTransactionStorage,
+  recordingOutput,
+  sequentialIds,
+} from "@mestre-yoda/runtime/infra/fake";
+import { describe, expect, it } from "vitest";
+
+type Storage = ReturnType<typeof memoryTransactionStorage>;
+
+function storage(): Storage {
+  return memoryTransactionStorage({
+    directories: [".brain", ".brain/transactions"],
+  });
+}
+
+function ports(subject: Storage) {
+  return createRuntime({
+    clock: fixedClock("2026-08-14T00:00:00.000Z"),
+    ids: sequentialIds("transaction"),
+    durableFileSystem: subject.durableFileSystem,
+    digests: subject.digests,
+    fileSystem: subject.fileSystem,
+    output: recordingOutput(),
+  });
+}
+
+/** One plan spanning managed state, a host directory, and the project root. */
+function initializationPlan() {
+  return planOf(
+    { kind: "write_file", path: ".brain/config.json", content: "{}\n" },
+    {
+      kind: "write_file",
+      path: ".claude/settings.json",
+      content: '{ "permissions": {} }\n',
+    },
+    { kind: "write_file", path: "CLAUDE.md", content: "# Managed\n" },
+  );
+}
+
+describe("the managed surface under a real transaction", () => {
+  it("commits state, a host directory, and a root file as one transaction", async () => {
+    const subject = storage();
+
+    const outcome = await applyPlan(initializationPlan(), ports(subject));
+
+    expect(outcome.kind).toBe("committed");
+    const files = subject.snapshot().files;
+    expect(files[".brain/config.json"]).toBe("{}\n");
+    expect(files[".claude/settings.json"]).toBe('{ "permissions": {} }\n');
+    expect(files["CLAUDE.md"]).toBe("# Managed\n");
+    // The host directory was created by the plan rather than required of the
+    // project, the way every other missing parent is.
+    expect(subject.snapshot().directories).toContain(".claude");
+  });
+
+  it("decides there is nothing to do the second time", async () => {
+    const subject = storage();
+    await applyPlan(initializationPlan(), ports(subject));
+
+    // The proof that a root file participates in the same decision as managed
+    // state: the whole plan collapses, not just the `.brain` part of it.
+    expect(
+      await previewPlan(initializationPlan(), ports(subject)),
+    ).toMatchObject({ kind: "noop" });
+    expect(await applyPlan(initializationPlan(), ports(subject))).toEqual({
+      kind: "noop",
+    });
+  });
+
+  it("still refuses a root file the inventory never named", async () => {
+    const subject = storage();
+
+    await expect(
+      applyPlan(
+        planOf({ kind: "write_file", path: "state.json", content: "{}" }),
+        ports(subject),
+      ),
+    ).rejects.toThrow(
+      expect.objectContaining({ reasonCode: "guard.outside_allow" }),
+    );
+    expect(subject.snapshot().files["state.json"]).toBeUndefined();
+  });
+
+  it("refuses the reserved namespace through the widened surface", async () => {
+    const subject = storage();
+
+    await expect(
+      applyPlan(
+        planOf({
+          kind: "write_file",
+          path: ".brain/transactions/forged/manifest.json",
+          content: "{}",
+        }),
+        ports(subject),
+      ),
+    ).rejects.toBeInstanceOf(TransactionFailure);
+  });
+});


### PR DESCRIPTION
Closes #101.

## What this changes

The managed transaction accepted destinations below `.brain/` and nothing else.
`SDD-01` (#25) needs four more -- `.claude/`, `.codex/`, `CLAUDE.md`, and
`AGENTS.md` -- committed in the one transaction that makes an interrupted
initialization leave a project untouched or complete.

## The rule was in five places, not three

The issue named three restatements. Writing the rule down once turned up two
more: the observation-candidate filter in the composition root, and the fake
durable filesystem's own path normalizer. The fake's was the one worth finding
-- it was more permissive than production in one direction and stricter in
another, so a test passing against it was not passing against the filesystem
the runtime actually writes to.

All of them now read `domain/transactions/surface.ts`, which asks two questions
rather than one:

| Question | Asked by | Accepts |
| --- | --- | --- |
| `isManagedPathShape` | the Node adapter and the fake | one canonical spelling inside the surface, including the roots themselves and `.brain/transactions/**` |
| `isManagedDestination` | the normalizer and the transaction manager | that surface minus the reserved namespace and minus the roots |
| `isManagedDirectoryDestination` | both, for `create_directory` | a plan may create `.claude`; it may not create `.brain`, which the manager owns |

Collapsing them would either close the reserved namespace to its owner or open
it to every caller.

## Three assumptions that only held inside `.brain/`

- **Parent synthesis** started at the second path component, because the first
  was invariably `.brain` and the manager bootstraps it. Nothing created
  `.claude`.
- **Prefix observation** did the same, so a root file was never observed --
  which made a second run rewrite `CLAUDE.md` instead of recognizing it as
  already right.
- **`parentOf`** returned `"."` on a path with no separator, marked unreachable
  with a coverage ignore. `inspect` now accepts the exact project-root sentinel
  `syncDirectory` already took, resolved through the same anchored-root
  validation, so publishing a root file asserts its parent the way every other
  operation does. No port method appears.

## Compatibility

No refusal weakened. The refuse table from `transaction-normalization` is
carried into `tests/managed-surface.test.ts` item by item, `state.json` at the
project root included, and a property walks the accept table, the refuse table,
and eleven near-misses asserting each layer answers its own question about
every one of them.

Two assertions changed meaning deliberately: the port contract's "inspect
refuses the project root" and the fake's equivalent. Both now assert the
sentinel is answered, which is the behavior this issue exists to add.

No inventory row moves and parity stays `0 / 400 (0.00%)`.

## Verification

```
npx vitest run tests/managed-surface.test.ts            # 67 tests
npx vitest run tests/transaction-surface.test.ts        # 4 tests
npx vitest run tests/transaction-surface-campaign.test.ts  # 118 boundaries
npm test                                                # 3427 tests, 114 files
npm run test:coverage                                   # 100% on all four measures
npm run verify
```

The first `npm run verify` on this branch failed four tests on their timers --
`differential-cli`, `differential-runner`, `result-renderer-equivalence`, and
`transaction-fault-campaign` -- while another suite and an unrelated container
build shared the machine; that run took 977s against ~550s normal. Every one of
them passes alone on this branch, and no assertion failed in either run. CI is
the arbiter here rather than a loaded laptop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
