### PR TITLE
fix: stop reading concurrent lock publishers as damage

### DIFF
--- a/docs/architecture/concurrency-locks.md
+++ b/docs/architecture/concurrency-locks.md
@@ -164,10 +164,26 @@ machine. It is not an authentication mechanism. Anything that can write to
 `.brain/locks/**` outside the protocol can forge a lease, and the durable
 integrity checks make that visible rather than impossible.
 
-Concurrent observers are a live boundary. The protocol was hardened where a
-lost race was reported as corruption, but real multi-process contention can
-still misclassify a worker that loses the admission election. Issue
-[#99](https://github.com/thiagocorreanet/mestre-yoda/issues/99) owns finishing
-that work; until it lands, treat a `runtime.state_corrupt` naming an entry
-under `.brain/locks/.admission` as possible contention rather than as proof of
-damage.
+Concurrent observers are a live boundary, and `tests/lock-process-contention`
+holds it with eight real processes rather than one simulated one.
+
+Every read below `.brain/locks` races a publisher. The rule the readers apply
+is that a path which is *gone* was published or reclaimed by whoever owned it,
+while a path which *exists* and holds something no protocol can interpret is
+damage. The distinction matters at the ancestor too: a retirement removes a
+generation directory out from under a read that never reaches its target, so
+the readers walk the chain up to the namespace before deciding. A record beside
+its own tombstone is likewise a retirement in flight — the tombstone is linked
+before the record it retires is removed — and only a tombstone naming a
+different claim is uninterpretable.
+
+Two gaps remain, tracked by
+[#99](https://github.com/thiagocorreanet/mestre-yoda/issues/99) and owned by
+[#106](https://github.com/thiagocorreanet/mestre-yoda/issues/106). A contender
+that loses the admission election is still reported rather
+than re-elected, so a round can end with no winner at all even though no lease
+was published. And because `.brain/locks/.admission` serializes administration
+for the whole project, a contender for one run can be refused on account of a
+worker administering a different one, which the scope rules above say must
+never conflict. Until that lands, treat a conflict naming `admission` as a
+report about the administration rather than about the resource.

--- a/docs/verification/issue-22-lock-evidence.md
+++ b/docs/verification/issue-22-lock-evidence.md
@@ -101,19 +101,31 @@ between these classes has to be acknowledged rather than passing unnoticed.
 
 ## Known boundary
 
-Multi-process contention is not proven here. Writing that suite exposed two
-defects the single-threaded fake could not reach, both fixed in
-`fix: stop reading concurrent cleanup as corruption`: `createDirectory` losing
-an `EEXIST` race, and candidate validation reading a vanished entry as
-corruption.
+Multi-process contention is now exercised by `tests/lock-process-contention`
+over eight real processes. `RUN-07a` closed the misclassification half of the
+gap: no contender is told that a sibling's in-flight candidate is corrupt
+state, and the fault campaign moved two crash boundaries out of `repair` and
+into `unchanged` because the residue they left was a concurrent removal rather
+than uninterpretable bytes.
 
-What remains is that real OS-level interleaving can still misclassify a worker
-that loses the admission election, reporting `runtime.internal_failure` instead
-of a conflict. Mutual exclusion is not affected — exactly one contender
-acquires in every observed round — but the losers' classification is.
-Issue [#99](https://github.com/thiagocorreanet/mestre-yoda/issues/99) owns
-finishing that work, and the worker and harness it will build on are preserved
-on the `spike/multi-process-lock-harness` branch.
+Two behaviours remain open on
+[#99](https://github.com/thiagocorreanet/mestre-yoda/issues/99) and are carried
+into [#106](https://github.com/thiagocorreanet/mestre-yoda/issues/106), both
+recorded by that suite rather than assumed away:
+
+- A contender that loses the admission election is reported instead of
+  re-elected. Rounds therefore exist in which no worker acquires and no lease
+  is published, while the losers still receive a conflict. Mutual exclusion is
+  unaffected — no observed round admitted two writers, and the winner always
+  opens fencing token 1.
+- `.brain/locks/.admission` serializes administration project-wide, so two
+  processes acquiring independent runs concurrently do not both succeed, which
+  the scope rules require.
+
+A retry at the admission layer was tried and rejected: `lost` legitimately
+means both "a sibling is administering" and "this operation faulted", so
+re-electing on it masked injected storage faults and weakened the crash-safety
+the campaign proves.
 
 Seven concurrency branches in `composition/locks.ts` carry coverage directives
 rather than tests. An entry whose name a listing just returned always still

--- a/packages/runtime/src/composition/locks.ts
+++ b/packages/runtime/src/composition/locks.ts
@@ -370,6 +370,10 @@ async function admissionRecoveryMarkers(
         continue;
       }
       const entry = await services.durableFileSystem.inspect(marker.path);
+      // A recovery that completed between the listing above and this
+      // inspection removed its own marker.
+      /* v8 ignore next -- only a concurrent recovery removes a marker a listing just reported */
+      if (entry.kind === "missing") continue;
       if (entry.kind !== "directory") throw corrupt(marker.path);
       if ((await services.durableFileSystem.list(marker.path)).length !== 0)
         throw corrupt(marker.path);
@@ -425,6 +429,8 @@ async function assertAdmissionClaimChildren(
     }
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    // An admission retired mid-listing has no children left to validate.
+    if (await vanishedUnderLocks(admissionClaim, services)) return;
     throw internal();
   }
 }
@@ -492,7 +498,11 @@ async function inspectLockNamespace(
     }
     const holder = await readAdmissionClaim(services);
     const retired = await readAdmissionTombstone(services);
-    if (holder !== null && retired !== null) throw corrupt(admissionClaim);
+    // A retirement links the tombstone before removing the record it retires,
+    // so an observer between the two publications legitimately sees both. Only
+    // a tombstone that retires a different claim is uninterpretable, which is
+    // the rule every other admission reader already applies.
+    assertCompatibleAdmissionRecords(holder, retired);
     await validateAdmissionRecoveryMarkers(holder, retired, services);
   }
   const runs = await inspect(`${locksRoot}/runs`);
@@ -840,9 +850,15 @@ async function assertScopeCandidate(
   } catch (error) {
     if (error instanceof LockFailure) throw error;
     // A listing or read can fail because the entry went away mid-inspection,
-    // which the explicit checks above cannot observe on their own.
+    // which the explicit checks above cannot observe on their own. The
+    // generation and the record disappear ahead of the candidate that holds
+    // them, so a check confined to the candidate would miss the common shape.
     /* v8 ignore next -- only a concurrent cleanup makes a just-listed entry unreadable */
-    if (await vanished(candidate.path, services)) return false;
+    if (await vanishedUnderLocks(candidate.path, services)) return false;
+    if (await vanishedUnderLocks(candidate.location.directory, services))
+      return false;
+    if (await vanishedUnderLocks(candidate.location.recordPath, services))
+      return false;
     throw internal();
   }
 }
@@ -1048,6 +1064,7 @@ async function readAdmissionClaim(
     entry = await services.durableFileSystem.inspect(location.recordPath);
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    if (await vanishedUnderLocks(location.recordPath, services)) return null;
     throw internal();
   }
   if (entry.kind === "missing") return null;
@@ -1057,6 +1074,7 @@ async function readAdmissionClaim(
     text = await services.durableFileSystem.readText(location.recordPath);
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    if (await vanishedUnderLocks(location.recordPath, services)) return null;
     throw internal();
   }
   try {
@@ -1098,6 +1116,9 @@ async function locateAdmission(
     names = await services.durableFileSystem.list(admissionClaim);
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    // A published admission that its own holder retired between the
+    // inspection and the listing is gone, and nothing locates it.
+    if (await vanishedUnderLocks(admissionClaim, services)) return null;
     throw internal();
   }
   const generations = names
@@ -1114,10 +1135,14 @@ async function locateAdmission(
   const location = generations[0]!;
   try {
     const entry = await services.durableFileSystem.inspect(location.directory);
+    // A generation retired between the listing above and this inspection is
+    // gone, and nothing locates an admission that is no longer published.
+    if (entry.kind === "missing") return null;
     if (entry.kind !== "directory") throw corrupt(location.directory);
     await assertAdmissionGenerationChildren(location, services);
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    if (await vanishedUnderLocks(location.directory, services)) return null;
     throw internal();
   }
   return location;
@@ -1135,9 +1160,16 @@ async function assertAdmissionGenerationChildren(
   if (generation === null) throw corrupt(location.directory);
   const [, generationSha256] = generation as unknown as [string, string];
   const markers: AdmissionCleanupMarker[] = [];
-  for (const name of await services.durableFileSystem.list(
-    location.directory,
-  )) {
+  let names: readonly string[];
+  try {
+    names = await services.durableFileSystem.list(location.directory);
+  } catch (error) {
+    if (error instanceof LockFailure) throw error;
+    // A generation its own retirement removed has no children left to check.
+    if (await vanishedUnderLocks(location.directory, services)) return;
+    throw internal();
+  }
+  for (const name of names) {
     const marker = parseAdmissionCleanupMarker(location, name);
     if (marker !== null) {
       markers.push(marker);
@@ -1154,9 +1186,23 @@ async function assertAdmissionGenerationChildren(
   for (const marker of markers) {
     if (marker.claimSha256 !== generationSha256) throw corrupt(marker.path);
     const entry = await services.durableFileSystem.inspect(marker.path);
+    // The cleanup this marker elects takes the marker with it when it
+    // finishes, so a listing can name one that no longer exists.
+    /* v8 ignore next -- only a concurrent cleanup removes a marker a listing just reported */
+    if (entry.kind === "missing") continue;
     if (entry.kind !== "directory") throw corrupt(marker.path);
-    if ((await services.durableFileSystem.list(marker.path)).length !== 0)
-      throw corrupt(marker.path);
+    let children: readonly string[];
+    try {
+      children = await services.durableFileSystem.list(marker.path);
+    } catch (error) {
+      /* v8 ignore next -- the listing above rejects raw port errors only */
+      if (error instanceof LockFailure) throw error;
+      /* v8 ignore next -- only a concurrent cleanup unlists a just-inspected marker */
+      if (await vanishedUnderLocks(marker.path, services)) continue;
+      /* v8 ignore next -- storage that fails a listing it just inspected */
+      throw internal();
+    }
+    if (children.length !== 0) throw corrupt(marker.path);
   }
 }
 
@@ -1171,6 +1217,8 @@ async function readAdmissionCandidate(
     );
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    if (await vanishedUnderLocks(candidate.location.recordPath, services))
+      return null;
     throw internal();
   }
   if (entry.kind === "missing") return null;
@@ -1199,6 +1247,12 @@ async function readAdmissionCandidate(
     });
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    // The record can go away between the inspection above and this read: its
+    // owner publishes the candidate or reclaims it. A path that is gone was
+    // never damaged, and reading it as corruption blames a sibling for
+    // finishing.
+    if (await vanishedUnderLocks(candidate.location.recordPath, services))
+      return null;
     throw corrupt(candidate.location.recordPath);
   }
 }
@@ -1223,6 +1277,31 @@ async function vanished(
     return false;
   }
   /* v8 ignore stop */
+}
+
+/**
+ * Whether a lock path lost itself or an ancestor to a concurrent publisher.
+ *
+ * A read below `.brain/locks` fails in two shapes when a sibling retires an
+ * admission or a claim: the path itself disappears, or a directory above it
+ * does and the port rejects before ever reaching the path. Both mean the state
+ * is gone rather than damaged, and only a walk up the chain observes the
+ * second. The walk stops at the lock namespace, which the protocol creates and
+ * never removes.
+ */
+async function vanishedUnderLocks(
+  path: string,
+  services: LockServices,
+): Promise<boolean> {
+  let current = path;
+  while (current.length > locksRoot.length && current.startsWith(locksRoot)) {
+    if (await vanished(current, services)) return true;
+    const cut = current.lastIndexOf("/");
+    /* v8 ignore next -- every lock path below the namespace has a separator */
+    if (cut < 0) return false;
+    current = current.slice(0, cut);
+  }
+  return false;
 }
 
 /** Validate one candidate, or report that it is no longer there to validate. */
@@ -1260,9 +1339,15 @@ async function assertAdmissionCandidate(
   } catch (error) {
     if (error instanceof LockFailure) throw error;
     // A listing or read can fail because the entry went away mid-inspection,
-    // which the explicit checks above cannot observe on their own.
+    // which the explicit checks above cannot observe on their own. The
+    // generation and the record disappear ahead of the candidate that holds
+    // them, so a check confined to the candidate would miss the common shape.
     /* v8 ignore next -- only a concurrent cleanup makes a just-listed entry unreadable */
-    if (await vanished(candidate.path, services)) return false;
+    if (await vanishedUnderLocks(candidate.path, services)) return false;
+    if (await vanishedUnderLocks(candidate.location.directory, services))
+      return false;
+    if (await vanishedUnderLocks(candidate.location.recordPath, services))
+      return false;
     throw internal();
   }
 }
@@ -1326,6 +1411,7 @@ async function admissionCleanupMarker(
   location: AdmissionLocation,
   services: LockServices,
 ): Promise<AdmissionCleanupMarker | null> {
+  let markerPath: string | null = null;
   try {
     const markers = (await services.durableFileSystem.list(location.directory))
       .map((name) => parseAdmissionCleanupMarker(location, name))
@@ -1336,7 +1422,12 @@ async function admissionCleanupMarker(
     // Cardinality was established immediately above.
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const marker = markers[0]!;
+    markerPath = marker.path;
     const entry = await services.durableFileSystem.inspect(marker.path);
+    // A cleanup that completed while this lookup ran took its own marker with
+    // it, which leaves nothing to report rather than something to repair.
+    /* v8 ignore next -- only a concurrent cleanup removes a marker a listing just reported */
+    if (entry.kind === "missing") return null;
     /* v8 ignore next -- generation validation already closed this exact nested marker */
     if (entry.kind !== "directory") throw corrupt(marker.path);
     /* v8 ignore next -- generation validation already proved this marker empty */
@@ -1346,7 +1437,9 @@ async function admissionCleanupMarker(
   } catch (error) {
     /* v8 ignore next -- typed propagation is exercised at the enclosing generation validator */
     if (error instanceof LockFailure) throw error;
-    /* v8 ignore next -- raw normalization is exercised at the enclosing generation validator */
+    if (await vanishedUnderLocks(location.directory, services)) return null;
+    if (markerPath !== null && (await vanishedUnderLocks(markerPath, services)))
+      return null;
     throw internal();
   }
 }
@@ -1410,6 +1503,7 @@ async function readAdmissionTombstone(
     names = await services.durableFileSystem.list(location.directory);
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    if (await vanishedUnderLocks(location.directory, services)) return null;
     throw internal();
   }
   const tombstones = names
@@ -1424,10 +1518,14 @@ async function readAdmissionTombstone(
   let text: string;
   try {
     entry = await services.durableFileSystem.inspect(tombstone.path);
+    // A tombstone its own cleanup removed between the listing above and this
+    // inspection is gone, not damaged.
+    if (entry.kind === "missing") return null;
     if (entry.kind !== "file") throw corrupt(tombstone.path);
     text = await services.durableFileSystem.readText(tombstone.path);
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    if (await vanishedUnderLocks(tombstone.path, services)) return null;
     throw internal();
   }
   try {
@@ -2231,6 +2329,12 @@ async function resolveAdmissionRecovery(
       const current = await services.durableFileSystem.inspect(admissionClaim);
       if (current.kind === "missing") return { kind: "clear" };
       if (current.kind !== "directory") throw corrupt(admissionClaim);
+      // An empty-directory removal only fails on a directory that stopped
+      // being empty, which happens when another contender published into it
+      // mid-clear. One that is still empty refused for a reason no sibling
+      // explains, and that is a fault rather than contention.
+      if ((await services.durableFileSystem.list(admissionClaim)).length > 0)
+        return { kind: "lost" };
       throw internal();
     }
   }
@@ -2341,6 +2445,9 @@ async function helpAdmissionCleanup(
       : "lost";
   } catch (error) {
     if (error instanceof LockFailure) throw error;
+    // Another contender finished this cleanup while we were performing it. A
+    // marker that is gone is the election resolving, not storage failing.
+    if (await vanishedUnderLocks(marker.path, services)) return "lost";
     throw internal();
   }
 }
@@ -2351,10 +2458,16 @@ async function retireAdmissionRecord(
 ): Promise<void> {
   const marker = admissionCleanupMarkerFor(admission, services);
   try {
-    await services.durableFileSystem.createDirectoryExclusive(marker.path);
-    await services.durableFileSystem.syncDirectory(
-      admission.location.directory,
-    );
+    // The marker is content-addressed from this same record, so one standing
+    // at that path is this retirement's own marker, elected by whichever
+    // worker got there first. Creating it again would only race a helper.
+    const elected = await services.durableFileSystem.inspect(marker.path);
+    if (elected.kind === "missing") {
+      await services.durableFileSystem.createDirectoryExclusive(marker.path);
+      await services.durableFileSystem.syncDirectory(
+        admission.location.directory,
+      );
+    }
     const outcome = await helpAdmissionCleanup(admission, marker, services);
     if (outcome !== "cleared")
       throw new LockFailure("runtime.recovery_required", [
@@ -2369,6 +2482,15 @@ async function retireAdmissionRecord(
     ]);
   }
 }
+
+/**
+ * How many times an observer re-reads a lease that its trail says is coming.
+ *
+ * The two publications are consecutive durable writes, so an observer that
+ * yields between reads sees the second one land. The bound turns a publisher
+ * that never finishes into a recovery report rather than a spin.
+ */
+const MAX_LEASE_OBSERVATIONS = 16;
 
 async function withAdmission<T>(
   owner: string,
@@ -2786,17 +2908,36 @@ async function inspectLeaseHeld(
   const paths = lockPaths(resource);
   let leaseEntry: DurableEntry;
   let eventsEntry: DurableEntry;
-  try {
-    [leaseEntry, eventsEntry] = await Promise.all([
-      services.durableFileSystem.inspect(paths.lease),
-      services.durableFileSystem.inspect(paths.events),
-    ]);
-  } catch (error) {
-    if (error instanceof LockFailure) throw error;
-    throw internal();
-  }
+  // A guarded transaction publishes the trail before the lease it seals, so an
+  // observer between the two publications sees a trail with no lease. That
+  // pair is a publication in flight, not damage, and re-observing lets the
+  // publisher finish rather than blaming it. The bound keeps a genuinely
+  // stalled publication from spinning here.
+  let observation = 0;
+  do {
+    try {
+      [leaseEntry, eventsEntry] = await Promise.all([
+        services.durableFileSystem.inspect(paths.lease),
+        services.durableFileSystem.inspect(paths.events),
+      ]);
+    } catch (error) {
+      if (error instanceof LockFailure) throw error;
+      throw internal();
+    }
+    observation += 1;
+  } while (
+    leaseEntry.kind === "missing" &&
+    eventsEntry.kind === "file" &&
+    observation < MAX_LEASE_OBSERVATIONS
+  );
   if (leaseEntry.kind === "missing" && eventsEntry.kind === "missing")
     return { kind: "empty", lease: null, guard: null, claim };
+  // A trail that still has no lease after the bound is stalled mid-publication,
+  // which is recoverable rather than uninterpretable.
+  if (leaseEntry.kind === "missing" && eventsEntry.kind === "file")
+    throw new LockFailure("runtime.recovery_required", [
+      { kind: "artifact", ref: paths.lease },
+    ]);
   if (leaseEntry.kind !== "file") throw corrupt(paths.lease);
   if (eventsEntry.kind !== "file") throw corrupt(paths.events);
   let eventsText: string;

--- a/tests/fixtures/locks/worker.ts
+++ b/tests/fixtures/locks/worker.ts
@@ -1,0 +1,261 @@
+import {
+  createLocks,
+  executeManagedMutation,
+  prepareLeaseGuard,
+  type TransactionServices,
+} from "@mestre-yoda/runtime/composition";
+import { createSchemaRegistry } from "@mestre-yoda/runtime/composition/schema";
+import type {
+  LeaseGuard,
+  LeaseResource,
+} from "@mestre-yoda/runtime/domain/locks";
+import {
+  nodeDurableFileSystem,
+  sha256Digests,
+  type DurableOperation,
+  type DurableOperationEvent,
+} from "@mestre-yoda/runtime/infra/node";
+
+interface Barrier {
+  readonly name: string;
+  readonly operation: DurableOperation;
+  readonly timing: DurableOperationEvent["timing"];
+  readonly occurrence: number;
+}
+
+const handshakeTimeoutMilliseconds = 10_000;
+const observedIdentity = { host: "codex", model: null } as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBarrier(encoded: string): Barrier | null {
+  const value: unknown = JSON.parse(encoded);
+  if (value === null) return null;
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    typeof value.operation !== "string" ||
+    (value.timing !== "before" && value.timing !== "after") ||
+    typeof value.occurrence !== "number" ||
+    !Number.isInteger(value.occurrence) ||
+    value.occurrence <= 0
+  ) {
+    throw new Error("Invalid worker barrier");
+  }
+  return value as unknown as Barrier;
+}
+
+async function send(message: unknown): Promise<void> {
+  if (process.send === undefined) throw new Error("Worker IPC is unavailable");
+  await new Promise<void>((resolve, reject) => {
+    process.send?.(message, (error) => {
+      if (error === null) resolve();
+      else reject(error);
+    });
+  });
+}
+
+async function waitForStart(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      finish(new Error("Worker start handshake timed out"));
+    }, handshakeTimeoutMilliseconds);
+    const onDisconnect = () => {
+      finish(new Error("Worker IPC disconnected"));
+    };
+    const onMessage = (message: unknown) => {
+      if (isRecord(message) && message.kind === "start") finish(null);
+      else finish(new Error("Worker received an invalid start message"));
+    };
+    function finish(error: Error | null): void {
+      clearTimeout(timer);
+      process.off("disconnect", onDisconnect);
+      process.off("message", onMessage);
+      if (error === null) resolve();
+      else reject(error);
+    }
+    process.once("disconnect", onDisconnect);
+    process.once("message", onMessage);
+  });
+}
+
+/**
+ * One worker's services.
+ *
+ * Time is supplied per command rather than read from the host clock: a
+ * contention test that had to sleep through a real thirty-second lease would
+ * trade determinism for wall time and still prove less.
+ */
+function services(
+  root: string,
+  now: string,
+  idPrefix: string,
+  barrier: Barrier | null,
+): TransactionServices {
+  const occurrences = new Map<DurableOperation, number>();
+  let sequence = 0;
+  return {
+    clock: { now: () => new Date(now) },
+    ids: {
+      next: () => {
+        sequence += 1;
+        return `${idPrefix}-${String(sequence)}`;
+      },
+    },
+    digests: sha256Digests(),
+    durableFileSystem: nodeDurableFileSystem(root, async (event) => {
+      let occurrence = occurrences.get(event.operation) ?? 0;
+      if (event.timing === "before") {
+        occurrence += 1;
+        occurrences.set(event.operation, occurrence);
+      }
+      if (
+        barrier !== null &&
+        event.operation === barrier.operation &&
+        event.timing === barrier.timing &&
+        occurrence === barrier.occurrence
+      ) {
+        await send({ kind: "barrier", name: barrier.name });
+        await new Promise<void>(() => undefined);
+      }
+    }),
+    schemaRegistry: createSchemaRegistry(),
+  };
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error("Invalid worker payload");
+  return value;
+}
+
+function requireString(value: unknown): string {
+  if (typeof value !== "string") throw new Error("Invalid worker payload");
+  return value;
+}
+
+function requireNumber(value: unknown): number {
+  if (typeof value !== "number") throw new Error("Invalid worker payload");
+  return value;
+}
+
+async function main(): Promise<void> {
+  const [command, root, barrierEncoded, payloadEncoded] = process.argv.slice(2);
+  if (
+    command === undefined ||
+    root === undefined ||
+    barrierEncoded === undefined ||
+    payloadEncoded === undefined
+  ) {
+    throw new Error("Invalid worker arguments");
+  }
+  const barrier = parseBarrier(barrierEncoded);
+  const payload = requireRecord(JSON.parse(payloadEncoded));
+  await send({ kind: "ready" });
+  await waitForStart();
+
+  const lockServices = services(
+    root,
+    requireString(payload.now),
+    requireString(payload.idPrefix),
+    barrier,
+  );
+  const locks = createLocks(lockServices);
+  const guard = payload.guard as LeaseGuard | undefined;
+
+  let result: unknown;
+  switch (command) {
+    case "inspect":
+      result = await locks.inspect(payload.resource as LeaseResource);
+      break;
+    case "acquire":
+      result = await locks.acquire({
+        resource: payload.resource as LeaseResource,
+        owner: requireString(payload.owner),
+        ttlMs: requireNumber(payload.ttlMs),
+        stateRevision: requireNumber(payload.stateRevision),
+        observedIdentity,
+      });
+      break;
+    case "renew":
+      if (guard === undefined) throw new Error("Invalid worker payload");
+      result = await locks.renew({
+        observed: guard,
+        ttlMs: requireNumber(payload.ttlMs),
+        resultingStateRevision: requireNumber(payload.resultingStateRevision),
+        observedIdentity,
+      });
+      break;
+    case "takeover":
+      if (guard === undefined) throw new Error("Invalid worker payload");
+      result = await locks.takeover({
+        observed: guard,
+        owner: requireString(payload.owner),
+        ttlMs: requireNumber(payload.ttlMs),
+        stateRevision: requireNumber(payload.stateRevision),
+        observedIdentity,
+      });
+      break;
+    case "commit": {
+      if (guard === undefined) throw new Error("Invalid worker payload");
+      const content = requireString(payload.content);
+      try {
+        const binding = await prepareLeaseGuard(
+          {
+            observed: guard,
+            ttlMs: requireNumber(payload.ttlMs),
+            resultingStateRevision: guard.stateRevision + 1,
+            observedIdentity,
+          },
+          lockServices,
+        );
+        await executeManagedMutation(
+          {
+            operations: [
+              {
+                operationId: "operation-0001",
+                kind: "write_file",
+                path: requireString(payload.destination),
+                expected: { kind: "missing" },
+                result: {
+                  kind: "file",
+                  size: Buffer.byteLength(content, "utf8"),
+                  sha256: lockServices.digests.sha256(content),
+                },
+                stagedPath: "staging/operation-0001.payload",
+                content,
+              },
+            ],
+          },
+          { rootMode: "existing", leaseGuard: binding },
+          lockServices,
+        );
+        result = { kind: "committed" };
+      } catch (failure) {
+        result = {
+          kind: "refused",
+          reasonCode:
+            failure instanceof Error && "reasonCode" in failure
+              ? String((failure as { readonly reasonCode: unknown }).reasonCode)
+              : "untyped",
+        };
+      }
+      break;
+    }
+    default:
+      throw new Error("Invalid worker command");
+  }
+  await send({ kind: "result", value: result });
+}
+
+void main().then(
+  () => {
+    process.disconnect();
+  },
+  async () => {
+    await send({ kind: "error" }).catch(() => undefined);
+    process.disconnect();
+    process.exitCode = 1;
+  },
+);

--- a/tests/lock-claims.test.ts
+++ b/tests/lock-claims.test.ts
@@ -4838,7 +4838,10 @@ describe("durable lock claims", () => {
     },
   );
 
-  it("rejects an overlapping but otherwise valid legacy admission layout on inspection", async () => {
+  it("accepts a legacy admission record beside its own tombstone on inspection", async () => {
+    // Retirement links the tombstone before removing the record it retires, so
+    // an observer between the two publications sees both. That pair is a
+    // retirement in flight rather than a namespace nothing can interpret.
     const stale: LockClaimRecord = {
       ...observedRecord,
       claimId: "legacy-inspection-overlap",
@@ -4850,6 +4853,29 @@ describe("durable lock claims", () => {
         [lockPaths("project").admissionRecord]: canonicalizeJson(stale),
         [`${lockPaths("project").admissionClaim}/.retired-${digest}.json`]:
           canonicalizeJson(stale),
+      },
+    });
+    await expect(
+      inspectLease("project", services(storage)),
+    ).resolves.toMatchObject({ kind: "empty" });
+  });
+
+  it("rejects a legacy admission record beside a tombstone for another claim", async () => {
+    const holder: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "legacy-inspection-holder",
+      resource: "admission",
+    };
+    const other: LockClaimRecord = {
+      ...holder,
+      claimId: "legacy-inspection-other",
+    };
+    const digest = sha256Digests().sha256(canonicalizeJson(other));
+    const storage = lockStorage({
+      files: {
+        [lockPaths("project").admissionRecord]: canonicalizeJson(holder),
+        [`${lockPaths("project").admissionClaim}/.retired-${digest}.json`]:
+          canonicalizeJson(other),
       },
     });
     await expect(
@@ -7005,5 +7031,684 @@ describe("durable lock claims", () => {
       acquireClaim(projectClaim, services(storage)),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
     expect(storage.snapshot()).toEqual(before);
+  });
+
+  it("keeps acquiring when the admission parent retires while its children are listed", async () => {
+    const parent = lockPaths("project").admissionClaim;
+    const storage = lockStorage({ directories: [parent] });
+    const baseList = storage.durableFileSystem.list;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let listings = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          list: async (path) => {
+            if (path !== parent || ++listings !== 1) return baseList(path);
+            await baseRemoveDirectory(parent);
+            throw new Error("parent retired mid-listing");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+  });
+
+  it("locates no admission when its parent retires between the inspection and the listing", async () => {
+    const held: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-parent-listing",
+      resource: "admission",
+      expiresAt: "2026-08-11T00:05:00.000Z",
+    };
+    const record = publishedAdmissionRecord(held);
+    const generation = parentDirectory(record);
+    const parent = lockPaths("project").admissionClaim;
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(held) },
+    });
+    const baseList = storage.durableFileSystem.list;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let listings = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          list: async (path) => {
+            if (path !== parent || ++listings !== 2) return baseList(path);
+            await baseRemove(record);
+            await baseRemoveDirectory(generation);
+            await baseRemoveDirectory(parent);
+            throw new Error("admission retired mid-listing");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("locates no admission generation a stale parent listing still names", async () => {
+    const held: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-generation-stale",
+      resource: "admission",
+      expiresAt: "2026-08-11T00:05:00.000Z",
+    };
+    const record = publishedAdmissionRecord(held);
+    const generation = parentDirectory(record);
+    const parent = lockPaths("project").admissionClaim;
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(held) },
+    });
+    const baseList = storage.durableFileSystem.list;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let listings = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          list: async (path) => {
+            if (path !== parent || ++listings !== 2) return baseList(path);
+            const names = await baseList(path);
+            await baseRemove(record);
+            await baseRemoveDirectory(generation);
+            return names;
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("validates no children of an admission generation its own retirement removed", async () => {
+    const held: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-generation-children",
+      resource: "admission",
+      expiresAt: "2026-08-11T00:05:00.000Z",
+    };
+    const record = publishedAdmissionRecord(held);
+    const generation = parentDirectory(record);
+    const parent = lockPaths("project").admissionClaim;
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(held) },
+    });
+    const baseList = storage.durableFileSystem.list;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let listings = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          list: async (path) => {
+            if (path !== parent || ++listings !== 1) return baseList(path);
+            const names = await baseList(path);
+            await baseRemove(record);
+            await baseRemoveDirectory(generation);
+            return names;
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("locates no admission generation that vanishes as it is inspected", async () => {
+    const held: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-generation-inspect",
+      resource: "admission",
+      expiresAt: "2026-08-11T00:05:00.000Z",
+    };
+    const record = publishedAdmissionRecord(held);
+    const generation = parentDirectory(record);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(held) },
+    });
+    const baseInspect = storage.durableFileSystem.inspect;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let inspections = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          inspect: async (path) => {
+            if (path !== generation || ++inspections !== 1)
+              return baseInspect(path);
+            await baseRemove(record);
+            await baseRemoveDirectory(generation);
+            throw new Error("generation retired mid-inspection");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("reads no admission record retired before its inspection", async () => {
+    const held: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-record-inspect",
+      resource: "admission",
+      expiresAt: "2026-08-11T00:05:00.000Z",
+    };
+    const record = publishedAdmissionRecord(held);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(held) },
+    });
+    const baseInspect = storage.durableFileSystem.inspect;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    let inspections = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          inspect: async (path) => {
+            if (path !== record || ++inspections !== 1)
+              return baseInspect(path);
+            await baseRemove(record);
+            throw new Error("record retired mid-inspection");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("reads no admission record retired between its inspection and its read", async () => {
+    const held: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-record-read",
+      resource: "admission",
+      expiresAt: "2026-08-11T00:05:00.000Z",
+    };
+    const record = publishedAdmissionRecord(held);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(held) },
+    });
+    const baseReadText = storage.durableFileSystem.readText;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          readText: async (path) => {
+            if (path !== record) return baseReadText(path);
+            await baseRemove(record);
+            throw new Error("record retired mid-read");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("reads no admission candidate record published away before its inspection", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "candidate-record-inspect",
+      resource: "admission",
+    };
+    const record = candidateAdmissionRecord(stale);
+    const root = parentDirectory(parentDirectory(record));
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+    });
+    const baseInspect = storage.durableFileSystem.inspect;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    let inspections = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          inspect: async (path) => {
+            if (path !== record || ++inspections !== 1)
+              return baseInspect(path);
+            await baseRemove(record);
+            throw new Error("candidate published mid-inspection");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().directories).not.toContain(root);
+  });
+
+  it("reads no admission candidate record published away before its read", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "candidate-record-read",
+      resource: "admission",
+    };
+    const record = candidateAdmissionRecord(stale);
+    const root = parentDirectory(parentDirectory(record));
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+    });
+    const baseReadText = storage.durableFileSystem.readText;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          readText: async (path) => {
+            if (path !== record) return baseReadText(path);
+            await baseRemove(record);
+            throw new Error("candidate published mid-read");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().directories).not.toContain(root);
+  });
+
+  it("drops an admission candidate whose generation vanished mid-validation", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "candidate-generation-vanished",
+      resource: "admission",
+    };
+    const record = candidateAdmissionRecord(stale);
+    const generation = parentDirectory(record);
+    const root = parentDirectory(generation);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+    });
+    const baseInspect = storage.durableFileSystem.inspect;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let inspections = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          inspect: async (path) => {
+            if (path !== generation || ++inspections !== 3)
+              return baseInspect(path);
+            await baseRemove(record);
+            await baseRemoveDirectory(generation);
+            throw new Error("candidate generation published mid-validation");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().directories).toContain(root);
+  });
+
+  it("drops an admission candidate whose record vanished mid-validation", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "candidate-record-vanished",
+      resource: "admission",
+    };
+    const record = candidateAdmissionRecord(stale);
+    const generation = parentDirectory(record);
+    const root = parentDirectory(generation);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+    });
+    const baseList = storage.durableFileSystem.list;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    let listings = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          list: async (path) => {
+            if (path !== generation || ++listings !== 3) return baseList(path);
+            await baseRemove(record);
+            throw new Error("candidate record published mid-validation");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().directories).toContain(root);
+  });
+
+  it("drops a scope candidate whose generation vanished mid-validation", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "scope-candidate-generation-vanished",
+    };
+    const record = candidateScopeRecord(stale);
+    const generation = parentDirectory(record);
+    const root = parentDirectory(generation);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+    });
+    const baseInspect = storage.durableFileSystem.inspect;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    const baseRename = storage.durableFileSystem.renameDirectoryExclusive;
+    let admitted = false;
+    let raced = false;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          renameDirectoryExclusive: async (source, target) => {
+            await baseRename(source, target);
+            if (target === lockPaths("project").admissionClaim) admitted = true;
+          },
+          inspect: async (path) => {
+            if (path !== generation || !admitted || raced)
+              return baseInspect(path);
+            raced = true;
+            await baseRemove(record);
+            await baseRemoveDirectory(generation);
+            throw new Error("scope generation published mid-validation");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().directories).toContain(root);
+  });
+
+  it("drops a scope candidate whose record vanished mid-validation", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "scope-candidate-record-vanished",
+    };
+    const record = candidateScopeRecord(stale);
+    const root = parentDirectory(parentDirectory(record));
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+    });
+    const baseReadText = storage.durableFileSystem.readText;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRename = storage.durableFileSystem.renameDirectoryExclusive;
+    let admitted = false;
+    let raced = false;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          renameDirectoryExclusive: async (source, target) => {
+            await baseRename(source, target);
+            if (target === lockPaths("project").admissionClaim) admitted = true;
+          },
+          readText: async (path) => {
+            if (path !== record || !admitted || raced)
+              return baseReadText(path);
+            raced = true;
+            await baseRemove(record);
+            throw new Error("scope record published mid-validation");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().directories).toContain(root);
+  });
+
+  it("reports no cleanup marker after a concurrent cleanup removed the one just listed", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-marker-vanished",
+      resource: "admission",
+    };
+    const record = publishedAdmissionRecord(stale);
+    const marker = admissionCleanupMarker(stale);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+      directories: [marker],
+    });
+    const baseInspect = storage.durableFileSystem.inspect;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let inspections = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          inspect: async (path) => {
+            if (path !== marker || ++inspections !== 6)
+              return baseInspect(path);
+            await baseRemoveDirectory(marker);
+            throw new Error("marker cleaned mid-lookup");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("normalizes a cleanup marker lookup fault its own marker survives", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-marker-lookup-fault",
+      resource: "admission",
+    };
+    const record = publishedAdmissionRecord(stale);
+    const marker = admissionCleanupMarker(stale);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+      directories: [marker],
+    });
+    const baseInspect = storage.durableFileSystem.inspect;
+    let inspections = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          inspect: async (path) => {
+            if (path !== marker || ++inspections !== 6)
+              return baseInspect(path);
+            throw new Error("marker lookup fault");
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ reasonCode: "runtime.internal_failure" });
+    expect(storage.snapshot().directories).toContain(marker);
+    expect(storage.snapshot().files[record]).toBe(canonicalizeJson(stale));
+  });
+
+  it("reads no tombstone from a generation retired before the tombstone listing", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "tombstone-generation-retired",
+      resource: "admission",
+    };
+    const record = publishedAdmissionRecord(stale);
+    const generation = parentDirectory(record);
+    const storage = lockStorage({
+      files: { [record]: canonicalizeJson(stale) },
+    });
+    const baseList = storage.durableFileSystem.list;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    let listings = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          list: async (path) => {
+            if (path !== generation || ++listings !== 4) return baseList(path);
+            await baseRemove(record);
+            await baseRemoveDirectory(generation);
+            throw new Error("generation retired mid-listing");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("reads no tombstone a concurrent cleanup removed after listing it", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "tombstone-listed-then-removed",
+      resource: "admission",
+    };
+    const record = publishedAdmissionRecord(stale);
+    const generation = parentDirectory(record);
+    const tombstone = admissionTombstone(stale);
+    const storage = lockStorage({
+      files: {
+        [record]: canonicalizeJson(stale),
+        [tombstone]: canonicalizeJson(stale),
+      },
+    });
+    const baseList = storage.durableFileSystem.list;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    let listings = 0;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          list: async (path) => {
+            if (path !== generation || ++listings !== 4) return baseList(path);
+            const names = await baseList(path);
+            await baseRemove(tombstone);
+            return names;
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("reads no tombstone whose file vanishes during the read", async () => {
+    const stale: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "tombstone-read-vanished",
+      resource: "admission",
+    };
+    const record = publishedAdmissionRecord(stale);
+    const tombstone = admissionTombstone(stale);
+    const storage = lockStorage({
+      files: {
+        [record]: canonicalizeJson(stale),
+        [tombstone]: canonicalizeJson(stale),
+      },
+    });
+    const baseReadText = storage.durableFileSystem.readText;
+    const baseRemove = storage.durableFileSystem.removeFile;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          readText: async (path) => {
+            if (path !== tombstone) return baseReadText(path);
+            await baseRemove(tombstone);
+            throw new Error("tombstone cleaned mid-read");
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().files[record]).toBeUndefined();
+  });
+
+  it("reports a lost admission clear when a contender publishes into the parent", async () => {
+    const contender: LockClaimRecord = {
+      ...observedRecord,
+      claimId: "admission-parent-contender",
+      resource: "admission",
+      expiresAt: "2026-08-11T00:05:00.000Z",
+    };
+    const parent = lockPaths("project").admissionClaim;
+    const published = parentDirectory(publishedAdmissionRecord(contender));
+    const storage = lockStorage({ directories: [parent] });
+    const baseRemoveDirectory = storage.durableFileSystem.removeEmptyDirectory;
+    const baseCreate = storage.durableFileSystem.createDirectoryExclusive;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          removeEmptyDirectory: async (path) => {
+            if (path !== parent) return baseRemoveDirectory(path);
+            await baseCreate(published);
+            throw new Error("parent claimed mid-clear");
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      reasonCode: "runtime.recovery_required",
+      evidence: [{ kind: "artifact", ref: ".brain/locks/.admission" }],
+    });
+  });
+
+  it("retires an admission through a cleanup marker another worker already elected", async () => {
+    const admission: LockClaimRecord = {
+      claimId: "claim-1",
+      resource: "admission",
+      owner: "codex:session-01",
+      leaseId: null,
+      fencingToken: null,
+      acquiredAt: "2026-08-11T00:01:00.000Z",
+      expiresAt: "2026-08-11T00:01:30.000Z",
+    };
+    const marker = admissionCleanupMarker(admission);
+    const storage = lockStorage();
+    const baseWrite = storage.durableFileSystem.writeSynced;
+    const baseCreate = storage.durableFileSystem.createDirectoryExclusive;
+    await expect(
+      acquireClaim(
+        projectClaim,
+        withDurable(storage, {
+          writeSynced: async (path, content) => {
+            await baseWrite(path, content);
+            if (isScopeRecordPath(path)) await baseCreate(marker);
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      resource: "project",
+      owner: "codex:session-01",
+    });
+    expect(storage.snapshot().directories).not.toContain(
+      lockPaths("project").admissionClaim,
+    );
   });
 });

--- a/tests/lock-fault-campaign.test.ts
+++ b/tests/lock-fault-campaign.test.ts
@@ -252,16 +252,23 @@ describe("lock fault campaign", () => {
       }
 
       // Pinned so that a protocol change moving boundaries between these
-      // classes has to be acknowledged rather than passing unnoticed. Twelve of
+      // classes has to be acknowledged rather than passing unnoticed. Ten of
       // the 328 crashes need a person: eight ask for the explicit recovery this
-      // subsystem already offers, and four leave claim bytes no protocol can
-      // interpret, which is the repair `OBS-02` exists to build.
+      // subsystem already offers, and two leave claim bytes no protocol can
+      // interpret, which is the repair `OBS-02` exists to build. Those two are
+      // `write_file:before:2` and `remove_empty_directory:before:8`.
+      //
+      // `RUN-07a` moved two boundaries out of `repair` and into `unchanged`:
+      // both stranded state that a concurrent publisher had already removed,
+      // which the protocol used to read as uninterpretable claim bytes and now
+      // recovers from. Nothing moved the other way, and neither `published` nor
+      // `explicit_recovery` changed.
       expect(tally).toEqual({
         inert: 2,
         published: 74,
-        unchanged: 240,
+        unchanged: 242,
         explicit_recovery: 8,
-        repair: 4,
+        repair: 2,
       });
     },
     campaignTimeoutMilliseconds,

--- a/tests/lock-process-contention.test.ts
+++ b/tests/lock-process-contention.test.ts
@@ -1,0 +1,171 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  bundleLockWorker,
+  disposeLockWorker,
+  runWorker,
+  temporaryProject,
+} from "./support/lock-workers.js";
+
+const instant = "2026-08-11T00:00:00.000Z";
+const expiry = "2026-08-11T00:00:30.000Z";
+const contenders = 8;
+const rounds = 4;
+const testTimeoutMilliseconds = 120_000;
+
+interface Conflict {
+  readonly owner: string;
+  readonly resource: string;
+  readonly expiresAt: string;
+  readonly retryable: boolean;
+  readonly recovery: string;
+}
+
+interface Outcome {
+  readonly kind: string;
+  readonly conflict?: Conflict;
+  readonly evidence?: readonly string[];
+  readonly lease?: { readonly owner: string; readonly fencingToken: number };
+}
+
+interface Round {
+  readonly outcomes: readonly Outcome[];
+  readonly output: string;
+  readonly root: string;
+}
+
+function acquisition(index: number, resource: string): unknown {
+  return {
+    idPrefix: `worker-${String(index)}`,
+    now: instant,
+    owner: `codex:worker-${String(index)}`,
+    resource,
+    stateRevision: 0,
+    ttlMs: 30_000,
+  };
+}
+
+/** One round of simultaneous acquisitions of the same resource. */
+async function contend(resource: string): Promise<Round> {
+  return await temporaryProject(async (root) => {
+    const results = await Promise.all(
+      Array.from(
+        { length: contenders },
+        async (_unused, index) =>
+          await runWorker("acquire", root, acquisition(index, resource)),
+      ),
+    );
+    return {
+      outcomes: results.map(({ value }) => value as Outcome),
+      output: results.map(({ output }) => output).join(""),
+      root,
+    };
+  });
+}
+
+async function contendRepeatedly(resource: string): Promise<readonly Round[]> {
+  const collected: Round[] = [];
+  for (let round = 0; round < rounds; round += 1) {
+    collected.push(await contend(resource));
+  }
+  return collected;
+}
+
+beforeAll(async () => {
+  await bundleLockWorker();
+});
+
+afterAll(async () => {
+  await disposeLockWorker();
+});
+
+describe("lock admission under real process contention", () => {
+  it(
+    "never admits two contenders to the same resource",
+    async () => {
+      const played = await contendRepeatedly("run:run-01");
+      for (const { outcomes } of played) {
+        const acquired = outcomes.filter(({ kind }) => kind === "acquired");
+        expect(acquired.length).toBeLessThanOrEqual(1);
+        // A winner opens exactly one fencing epoch. A second acquisition over
+        // the same empty history would also open token 1, so the token is what
+        // proves the exclusion rather than the count on its own.
+        for (const outcome of acquired)
+          expect(outcome.lease?.fencingToken).toBe(1);
+      }
+      // Rounds where nobody wins are a liveness gap this suite records rather
+      // than tolerates silently; issue #99 leaves the admission re-election
+      // that closes it undone.
+      expect(
+        played.filter(({ outcomes }) =>
+          outcomes.some(({ kind }) => kind === "acquired"),
+        ).length,
+      ).toBeGreaterThan(0);
+    },
+    testTimeoutMilliseconds,
+  );
+
+  it(
+    "never reports a concurrent publisher as corrupt state",
+    async () => {
+      // `RUN-07` shipped with losing contenders receiving
+      // `runtime.state_corrupt` naming another worker's in-flight candidate
+      // directory. Nothing a sibling does inside the protocol may be reported
+      // as damage.
+      const played = await contendRepeatedly("run:run-01");
+      expect(
+        played.flatMap(({ outcomes }) =>
+          outcomes.filter(({ kind }) => kind === "corrupt"),
+        ),
+      ).toEqual([]);
+    },
+    testTimeoutMilliseconds,
+  );
+
+  it(
+    "refuses losing contenders with a complete, actionable conflict",
+    async () => {
+      const played = await contendRepeatedly("run:run-01");
+      const conflicts = played.flatMap(({ outcomes }) =>
+        outcomes.filter(({ kind }) => kind === "conflict"),
+      );
+      expect(conflicts.length).toBeGreaterThan(0);
+      for (const outcome of conflicts) {
+        const conflict = outcome.conflict;
+        // Owner, scope, expiry, retryability, and the safe next action, with
+        // nothing else and nothing missing.
+        expect(Object.keys(conflict ?? {}).sort()).toEqual([
+          "expiresAt",
+          "owner",
+          "recovery",
+          "resource",
+          "retryable",
+        ]);
+        expect(conflict?.owner).toMatch(/^codex:worker-\d$/u);
+        expect(conflict?.expiresAt).toBe(expiry);
+        expect(conflict?.retryable).toBe(true);
+        expect(conflict?.recovery).toBe("wait_or_takeover");
+      }
+    },
+    testTimeoutMilliseconds,
+  );
+
+  it(
+    "keeps worker output silent and evidence free of the project root",
+    async () => {
+      const played = await contendRepeatedly("run:run-01");
+      for (const { outcomes, output, root } of played) {
+        // Anything printed would be port text or a project path escaping into
+        // a channel the protocol does not control.
+        expect(output).toBe("");
+        expect(JSON.stringify(outcomes)).not.toContain(root);
+        for (const outcome of outcomes) {
+          for (const ref of outcome.evidence ?? []) {
+            expect(ref).toMatch(/^\.brain\/(locks|transactions)\//u);
+          }
+        }
+      }
+    },
+    testTimeoutMilliseconds,
+  );
+});

--- a/tests/support/lock-workers.ts
+++ b/tests/support/lock-workers.ts
@@ -1,0 +1,229 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { build } from "esbuild";
+import { expect } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "../..");
+const workerSource = join(repositoryRoot, "tests/fixtures/locks/worker.ts");
+const workerTimeoutMilliseconds = 15_000;
+
+export interface Barrier {
+  readonly name: string;
+  readonly operation: string;
+  readonly timing: "before" | "after";
+  readonly occurrence: number;
+}
+
+export interface WorkerMessage {
+  readonly kind: "barrier" | "error" | "ready" | "result";
+  readonly name?: string;
+  readonly value?: unknown;
+}
+
+export interface WorkerSession {
+  readonly child: ChildProcess;
+  readonly exit: Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>;
+  readonly output: { stderr: string; stdout: string };
+}
+
+let bundleRoot = "";
+let workerBundle = "";
+
+/** Bundle the worker once per test file, the way the transaction suite does. */
+export async function bundleLockWorker(): Promise<void> {
+  bundleRoot = await mkdtemp(join(tmpdir(), "yoda-lock-worker-"));
+  workerBundle = join(bundleRoot, "lock-worker.mjs");
+  await build({
+    bundle: true,
+    entryPoints: [workerSource],
+    format: "esm",
+    logLevel: "silent",
+    outfile: workerBundle,
+    platform: "node",
+    sourcemap: false,
+    target: "node24",
+  });
+}
+
+export async function disposeLockWorker(): Promise<void> {
+  if (bundleRoot !== "") await rm(bundleRoot, { force: true, recursive: true });
+  bundleRoot = "";
+}
+
+export function spawnWorker(
+  command: string,
+  root: string,
+  payload: unknown,
+  barrier: Barrier | null = null,
+): WorkerSession {
+  const child = fork(
+    workerBundle,
+    [command, root, JSON.stringify(barrier), JSON.stringify(payload)],
+    { stdio: ["ignore", "pipe", "pipe", "ipc"] },
+  );
+  const output = { stderr: "", stdout: "" };
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    output.stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    output.stderr += chunk;
+  });
+  const exit = new Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>((resolve) => {
+    child.once("exit", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+  return { child, exit, output };
+}
+
+export async function waitForWorker(
+  session: WorkerSession,
+  expected: "barrier" | "result",
+): Promise<WorkerMessage> {
+  return new Promise<WorkerMessage>((resolve, reject) => {
+    let ready = false;
+    const timer = setTimeout(() => {
+      finish(new Error(`Worker timed out before ${expected}`));
+    }, workerTimeoutMilliseconds);
+    const onError = (error: Error) => {
+      finish(error);
+    };
+    const onExit = () => {
+      finish(new Error(`Worker exited before ${expected}`));
+    };
+    const onMessage = (candidate: unknown) => {
+      if (!isWorkerMessage(candidate)) {
+        finish(new Error("Worker sent an invalid IPC message"));
+        return;
+      }
+      if (!ready) {
+        if (candidate.kind !== "ready") {
+          finish(new Error("Worker skipped the ready handshake"));
+          return;
+        }
+        ready = true;
+        session.child.send({ kind: "start" }, (error) => {
+          if (error !== null) finish(error);
+        });
+        return;
+      }
+      if (candidate.kind === "error") {
+        finish(new Error("Worker reported a sanitized failure"));
+        return;
+      }
+      if (candidate.kind === expected) finish(null, candidate);
+    };
+    function finish(error: Error | null, message?: WorkerMessage): void {
+      clearTimeout(timer);
+      session.child.off("error", onError);
+      session.child.off("exit", onExit);
+      session.child.off("message", onMessage);
+      if (error !== null) reject(error);
+      else if (message !== undefined) resolve(message);
+    }
+    session.child.on("error", onError);
+    session.child.on("exit", onExit);
+    session.child.on("message", onMessage);
+  });
+}
+
+function isWorkerMessage(value: unknown): value is WorkerMessage {
+  if (typeof value !== "object" || value === null || !("kind" in value)) {
+    return false;
+  }
+  return ["barrier", "error", "ready", "result"].includes(String(value.kind));
+}
+
+async function waitForExit(session: WorkerSession): Promise<{
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("Worker timed out while exiting"));
+    }, workerTimeoutMilliseconds);
+    session.exit.then(
+      (exit) => {
+        clearTimeout(timer);
+        resolve(exit);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+export async function terminateIfRunning(
+  session: WorkerSession,
+): Promise<void> {
+  if (session.child.exitCode !== null || session.child.signalCode !== null) {
+    return;
+  }
+  if (process.platform === "win32") session.child.kill();
+  else session.child.kill("SIGKILL");
+  await waitForExit(session);
+}
+
+/**
+ * Kill a paused worker the way a crash does.
+ *
+ * Node maps `kill()` to forced termination on Windows; POSIX uses an explicit
+ * uncatchable signal, so neither branch asks the worker to unwind.
+ */
+export async function forceTerminate(session: WorkerSession): Promise<void> {
+  const killed =
+    process.platform === "win32"
+      ? session.child.kill()
+      : session.child.kill("SIGKILL");
+  expect(killed).toBe(true);
+  const exited = await waitForExit(session);
+  if (process.platform !== "win32") {
+    expect(exited).toEqual({ code: null, signal: "SIGKILL" });
+  }
+}
+
+/** Run one worker command to completion and return what it reported. */
+export async function runWorker(
+  command: string,
+  root: string,
+  payload: unknown,
+): Promise<{ readonly value: unknown; readonly output: string }> {
+  const session = spawnWorker(command, root, payload);
+  try {
+    const message = await waitForWorker(session, "result");
+    expect(await waitForExit(session)).toEqual({ code: 0, signal: null });
+    return {
+      value: message.value,
+      output: `${session.output.stdout}${session.output.stderr}`,
+    };
+  } finally {
+    await terminateIfRunning(session);
+  }
+}
+
+export async function temporaryProject<T>(
+  body: (root: string) => Promise<T>,
+  prefix = "yoda-lock-process-",
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    await mkdir(join(root, ".brain/transactions"), { recursive: true });
+    await mkdir(join(root, ".brain/runs/run-01"), { recursive: true });
+    return await body(root);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
Refs #99. Does not close it: two of its four deliverables are done, one is partially done, and the remaining behaviour is carried into #106 with evidence.

## What this changes

`RUN-07` was validated against a single-threaded fake, where every observation is the only one in flight. This branch lands the multi-process harness preserved on `spike/multi-process-lock-harness` and fixes what running it exposed.

Every read below `.brain/locks` races a publisher. The rule now applied at each of them: a path that is **gone** was published or reclaimed by whoever owned it; a path that **exists** and holds something no protocol can interpret is damage. Only the second is `runtime.state_corrupt`.

The distinction matters at the ancestor too, which is what the earlier fix in `#93`'s successor branch could not see. A retirement removes a generation directory out from under a read that never reaches its target, so the new `vanishedUnderLocks` walks the path chain up to the namespace before deciding. A confined check on the target alone misses the common shape.

Reclassified, per call site:

- `readAdmissionClaim`, `readAdmissionCandidate`, `readAdmissionTombstone`, `locateAdmission`, `admissionCleanupMarker` — a read that fails on a path a sibling removed returns "not there" rather than `state_corrupt` or `internal_failure`.
- `assertAdmissionClaimChildren`, `assertAdmissionGenerationChildren`, `admissionRecoveryMarkers` — a marker or generation that a listing named and a cleanup then removed is skipped, not refused.
- `assertAdmissionCandidate` / `assertScopeCandidate` — the vanished check now covers the generation and the record, not only the candidate that holds them.
- `inspectLockNamespace` — a record beside its **own** tombstone is a retirement in flight, because retirement links the tombstone before removing the record it retires. It now applies `assertCompatibleAdmissionRecords`, the same rule every other admission reader already used; a tombstone naming a *different* claim is still corrupt.
- `inspectLeaseHeld` — a guarded transaction publishes the trail before the lease it seals, so an observer between the two saw a trail with no lease and called it corrupt. It now re-observes within a bound and reports `runtime.recovery_required` only if the pair still disagrees.
- `resolveAdmissionRecovery` — an empty-directory removal only fails on a directory that stopped being empty, which means another contender published into it. Still-empty is a fault and stays `internal_failure`.

## Evidence

`tests/lock-process-contention.test.ts` (new) drives eight real forked processes over the production `createLocks` and the real Node adapter, four rounds per assertion. Time is supplied per worker command rather than slept through.

Before: contenders received `runtime.state_corrupt` naming another worker's in-flight candidate directory (`.brain/locks/.admission/.candidate-…/.claim-…/claim.json`) and `runtime.internal_failure`. Reproduced on the first RED run.

After, stable across ten consecutive runs:

- No contender is ever told a concurrent publisher is corrupt state.
- No round admits two writers; a winner always opens fencing token 1.
- Every conflict carries exactly owner, scope, expiry, retryability, and the safe next action, and nothing else.
- Worker stdout and stderr stay empty; no evidence ref contains the project root.

`tests/lock-fault-campaign` moved two of the 328 crash boundaries out of `repair` and into `unchanged`: both stranded state a concurrent removal had already taken, which the protocol used to read as uninterpretable claim bytes. Nothing moved the other way; `published` (74) and `explicit_recovery` (8) are unchanged. The pin and its comment are updated with that derivation. The two boundaries still needing repair are `write_file:before:2` and `remove_empty_directory:before:8`.

`tests/lock-claims` gains a case and changes one. `rejects an overlapping but otherwise valid legacy admission layout on inspection` asserted that a record beside its own tombstone is corrupt; a real observer hit exactly that line during a legitimate retirement, so it is now `accepts a legacy admission record beside its own tombstone on inspection`, and a new sibling test keeps the mismatched-tombstone case corrupt.

## What this does not fix, and why

Two behaviours remain, both now recorded by the suite rather than assumed away, and both owned by #106:

- A contender that loses the admission election is reported rather than re-elected. Rounds exist in which no worker acquires and no lease is published, while the losers still receive a conflict.
- `.brain/locks/.admission` serializes administration project-wide, so two processes acquiring independent runs concurrently do not both succeed, which the documented scope rules require.

A retry at the admission layer was implemented and then rejected. It does produce one winner and seven typed conflicts, but `resolveAdmissionRecovery` returning `lost` legitimately means both "a sibling is administering" and "this operation faulted". Re-electing on it stopped seven deliberately-constructed `lock-claims` fault tests from rejecting and moved 62 fault-campaign boundaries from `unchanged` into `published`, weakening the crash-safety `RUN-07` proves. Fixing this needs a discriminator the protocol does not carry, which is #106's first deliverable rather than a retry bolted on here.

`tests/node-lock-security.test.ts`, also listed on #99, is not in this branch.

## Compatibility

No public command or contract shape changes. Reason codes move only in the direction the issue asks for: states that were reported as `runtime.state_corrupt` or `runtime.internal_failure` while merely mid-flight are now reported as what they are. No state that a protocol cannot interpret stopped being `runtime.state_corrupt`.

## Verification

```
npm run verify
npx vitest run tests/lock-process-contention.test.ts   # repeated ten times
```

Made with [Orca](https://github.com/stablyai/orca) 🐋
