### PR TITLE
feat: give hosts one adapter protocol and a shared conformance suite

### DIFF
--- a/docs/architecture/host-adapter-protocol.md
+++ b/docs/architecture/host-adapter-protocol.md
@@ -1,0 +1,127 @@
+# The Host Adapter Protocol
+
+Issue [#35](https://github.com/thiagocorreanet/mestre-yoda/issues/35)
+(`ADP-01`) gives Claude Code and Codex one way to reach the runtime.
+[ADR-0004](../adr/0004-host-adapter-boundary.md) already decided the shape: an
+adapter translates and relays, it never owns transition policy, and every host
+passes one shared conformance suite. This document states the half of that
+protocol the runtime carries today.
+
+## What an adapter is
+
+```ts
+interface HostAdapter {
+  readonly name: string;
+  describe(): HostDescriptor;
+  translate(invocation: HostInvocation): AdapterMessageV1;
+  relay(response: AdapterMessageV1): HostRendering;
+}
+```
+
+Three methods, and deliberately no fourth. There is no method here that could
+advance a phase, resolve a gate, or write state, and the conformance suite
+asserts the exact method set rather than the absence of names somebody thought
+to forbid. A method nobody anticipated is how an adapter grows a decision.
+
+The same boundary is enforced statically: `packages/adapters` may import the
+contracts package and nothing else. It cannot reach the runtime's domain,
+ports, infrastructure, or composition, so it cannot call a decision even by
+accident.
+
+## Describing a host
+
+An adapter states its identity, its contract revision, its capabilities, and
+who is running:
+
+| Field | Meaning |
+| --- | --- |
+| `host` | The identity carried on every message this adapter sends |
+| `hostContract` | The host contract revision this adapter speaks |
+| `capabilities` | Every capability the host offers, as declared |
+| `observedIdentity.adapterVersion` | The adapter build |
+| `observedIdentity.model` | The model the host reported, or `null` |
+
+`model: null` means the host was handed no model identity. It never means the
+adapter chose one. ADR-0004 requires the limitation to be recorded rather than
+filled in, because a substituted identity is indistinguishable from an observed
+one once it reaches an event.
+
+## Contract negotiation
+
+`adapter-message.v1` pins `hostContract` to a constant. A host speaking a
+different revision would therefore fail schema validation as a bad property,
+which names a field instead of naming the contract. So the runtime reads the
+declared revision structurally, before anything validates the message, and
+judges it first:
+
+| Declared revision | Reason | Exit |
+| --- | --- | --- |
+| Accepted by the manifest | none; the message proceeds | |
+| Absent, non-string, or malformed | `contract.host_version_invalid` | 2 |
+| Well-formed and not accepted | `contract.host_version_unsupported` | 2 |
+
+The declared value never reaches the result. An adapter that sent something
+hostile would otherwise have it echoed back to whoever reads the failure.
+
+This is the same ordering the answers document already uses, for the same
+reason.
+
+## Capabilities
+
+Capabilities are explicit data, normalized before anyone compares them: sorted,
+deduplicated, and stripped of entries that are not capability identifiers. Two
+hosts that offer the same things produce the same list, and an adapter cannot
+change a decision by reordering its own.
+
+An entry the runtime does not recognize is dropped rather than refused. Failing
+an operation over a field it does not need would make every future host
+capability a breaking change; dropping it keeps a later reader from treating an
+unusable value as offered.
+
+A capability an operation requires and the host did not offer is reported, not
+worked around. ADR-0004 is explicit that a host missing a preventive hook does
+not remove the runtime's own checks, so the missing list explains a refusal and
+never authorizes skipping one.
+
+## Payloads travel by reference
+
+A request payload is `{ ref, sha256 }` — a project-relative path and a digest.
+A host never inlines content. The runtime reads the bytes it verifies rather
+than the bytes it was told about, and the reference pattern refuses absolute
+paths, drive-qualified paths, backslashes, parent segments, URI schemes, and
+control characters.
+
+## Relaying a decision
+
+The response payload is a universal result. An adapter publishes it; it does
+not recompute the exit code, restate the reason, or convert a refusal into a
+success. The conformance suite drives every exit class through `relay` and
+checks the verdict survives.
+
+## The conformance suite
+
+`describeHostAdapterContract(label, factory)` follows the same shape as the
+port contracts already in this repository: one suite, run against every
+implementation, so a host that quietly diverges fails there rather than in
+production. A minimal fake adapter passes it today, which is what lets the
+suite exist before either real host does.
+
+`ADP-02` and `ADP-03` add Claude Code and Codex by passing this suite, not by
+branching the core.
+
+## What this does not cover yet
+
+Approval, hook, timeout, and cancellation payloads are named by `ADP-01` and
+are not in the contract yet. The frozen inventory carries `CLI-HOOK`,
+`FLAG-HOOK-HOST`, and `IO-STDIN-HOOK-PAYLOAD`, which fix the hook transport,
+and the runtime has no hook command to carry them. Adding those payloads means
+a new host schema, which the contract manifest currently bounds to exactly
+twelve entries.
+
+Two spellings still need reconciling against the frozen oracle: the legacy hook
+host id is `claude-code` where this runtime writes `claude`, and legacy
+`init --host` accepted a third value `both`. Neither is decided here.
+
+No parity row moves. The inventory establishes that a host protocol exists, not
+what the legacy runtime put on the wire, and a parity claim needs a differential
+capture to compare against.

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.0-development",
   "private": true,
   "type": "module",
-  "exports": "./src/index.ts"
+  "exports": "./src/index.ts",
+  "dependencies": {
+    "@mestre-yoda/contracts": "0.0.0-development"
+  }
 }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,3 +1,75 @@
+import type { AdapterMessageV1 } from "@mestre-yoda/contracts";
+
+/**
+ * What a host is and what it can do, as explicit data.
+ *
+ * ADR-0004 requires host capabilities to be normalized rather than inferred, so
+ * an adapter states them instead of the runtime guessing from the host name. A
+ * host that cannot supply an optional signal states the limitation; it does not
+ * substitute a configured or model-reported value.
+ */
+export interface HostDescriptor {
+  /** The host identity carried on every message this adapter sends. */
+  readonly host: string;
+  /** The host contract revision this adapter speaks. */
+  readonly hostContract: string;
+  /** Every capability this host offers, as declared. */
+  readonly capabilities: readonly string[];
+  /**
+   * Who is running, so far as the host can honestly say.
+   *
+   * `model: null` means the host was handed no model identity. It never means
+   * the adapter picked one.
+   */
+  readonly observedIdentity: {
+    readonly adapterVersion: string;
+    readonly model: string | null;
+  };
+}
+
+/** One thing a host asked the runtime to do. */
+export interface HostInvocation {
+  readonly messageId: string;
+  readonly correlationId: string;
+  readonly operation: string;
+  readonly payloadContract: string;
+  /**
+   * The request body, by reference.
+   *
+   * A host hands a digest-pinned path rather than inlined content, so the
+   * runtime reads the bytes it verifies instead of the bytes it was told about.
+   */
+  readonly payload: { readonly ref: string; readonly sha256: string };
+}
+
+/** What a host publishes for one runtime response. */
+export interface HostRendering {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+/**
+ * The runtime's half of a host conversation, from the host side.
+ *
+ * An adapter translates and relays. It does not decide. There is deliberately
+ * no method here that could advance a phase, resolve a gate, or write state:
+ * the absence is the boundary, and the conformance suite asserts it rather
+ * than trusting each adapter to have honoured it.
+ */
 export interface HostAdapter {
   readonly name: string;
+  /** State this host's identity, contract, and capabilities. */
+  describe(): HostDescriptor;
+  /** Turn one host invocation into a request message for the runtime. */
+  translate(invocation: HostInvocation): AdapterMessageV1;
+  /** Publish one runtime response without reinterpreting it. */
+  relay(response: AdapterMessageV1): HostRendering;
 }
+
+/** Every method a conforming adapter exposes, and nothing else. */
+export const HOST_ADAPTER_METHODS: readonly string[] = Object.freeze([
+  "describe",
+  "relay",
+  "translate",
+]);

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -15,6 +15,7 @@
     "./domain/cli": "./src/domain/cli/index.ts",
     "./domain/effects": "./src/domain/effects.ts",
     "./domain/events": "./src/domain/events/index.ts",
+    "./domain/host": "./src/domain/host/index.ts",
     "./domain/init": "./src/domain/init/index.ts",
     "./domain/locks": "./src/domain/locks/index.ts",
     "./domain/objective": "./src/domain/objective/index.ts",

--- a/packages/runtime/src/domain/host/index.ts
+++ b/packages/runtime/src/domain/host/index.ts
@@ -1,0 +1,5 @@
+export {
+  classifyHostContract,
+  missingCapabilities,
+  normalizeCapabilities,
+} from "./negotiation.js";

--- a/packages/runtime/src/domain/host/negotiation.ts
+++ b/packages/runtime/src/domain/host/negotiation.ts
@@ -1,0 +1,79 @@
+import {
+  classifyContractVersion,
+  contractFailureResult,
+  type ContractFailureResult,
+} from "@mestre-yoda/contracts";
+
+/**
+ * The host contract a message declares, read before anything validates it.
+ *
+ * `adapter-message.v1` pins `hostContract` to a constant, so a host speaking a
+ * different revision fails schema validation as a bad field rather than as an
+ * unsupported host. Reading it structurally first is what lets the runtime name
+ * the contract instead of naming a property, and it is the same order the
+ * answers document already uses.
+ */
+function declaredContract(document: unknown): unknown {
+  if (typeof document !== "object" || document === null) return undefined;
+  return (document as Record<string, unknown>).hostContract;
+}
+
+/**
+ * Judge the host contract a message declares.
+ *
+ * Returns `null` when the declared revision is one this bundle accepts, and the
+ * refusal otherwise. The supplied value never reaches the result: an adapter
+ * that sent something hostile would otherwise have it echoed back.
+ */
+export function classifyHostContract(
+  document: unknown,
+): ContractFailureResult | null {
+  const classification = classifyContractVersion(
+    "host",
+    declaredContract(document),
+  );
+  return classification.classification === "current"
+    ? null
+    : contractFailureResult(classification);
+}
+
+/**
+ * Every capability a host declared, as explicit comparable data.
+ *
+ * Sorted and deduplicated so two hosts that offer the same things produce the
+ * same list, and an adapter cannot change a decision by reordering. A value
+ * that is not a capability identifier is dropped rather than refused: the
+ * runtime must not fail an operation over an unknown field it does not need,
+ * and dropping it here keeps a later reader from treating it as offered.
+ */
+export function normalizeCapabilities(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return Object.freeze([]);
+  const identifier = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/u;
+  const kept = new Set<string>();
+  for (const entry of value as readonly unknown[]) {
+    if (typeof entry === "string" && identifier.test(entry)) kept.add(entry);
+  }
+  return Object.freeze(
+    [...kept].sort((left, right) => (left < right ? -1 : 1)),
+  );
+}
+
+/**
+ * Whether a host offers everything an operation needs.
+ *
+ * Missing capabilities are reported rather than worked around. ADR-0004 is
+ * explicit that a host lacking a preventive hook does not remove the runtime's
+ * own checks, so a caller reads this to explain a refusal, never to decide that
+ * a check can be skipped.
+ */
+export function missingCapabilities(
+  offered: readonly string[],
+  required: readonly string[],
+): readonly string[] {
+  const available = new Set(offered);
+  return Object.freeze(
+    [...new Set(required)]
+      .filter((capability) => !available.has(capability))
+      .sort((left, right) => (left < right ? -1 : 1)),
+  );
+}

--- a/tests/host-adapter-contract.test.ts
+++ b/tests/host-adapter-contract.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { HOST_ADAPTER_METHODS, type HostAdapter } from "@mestre-yoda/adapters";
+
+import { fakeHostAdapter } from "./support/fake-host-adapter.js";
+import {
+  conformanceInvocation,
+  conformanceResponse,
+  describeHostAdapterContract,
+  responsePayload,
+  type HostAdapterFactory,
+} from "./support/host-adapter-contract.js";
+
+describeHostAdapterContract("fake", () => fakeHostAdapter());
+describeHostAdapterContract("fake with capabilities", () =>
+  fakeHostAdapter({
+    capabilities: ["filesystem.read", "process.execute"],
+    host: "codex",
+    model: "gpt-5",
+  }),
+);
+
+describe("the host adapter conformance suite", () => {
+  it("is addressed by a factory returning one adapter", () => {
+    const factory: HostAdapterFactory = () => fakeHostAdapter();
+    expect(factory()).not.toBe(factory());
+    expect(describeHostAdapterContract).toBeTypeOf("function");
+  });
+
+  it("names every method a conforming adapter may carry", () => {
+    expect([...HOST_ADAPTER_METHODS]).toEqual([
+      "describe",
+      "relay",
+      "translate",
+    ]);
+  });
+
+  it("catches an adapter that decides its own verdict", () => {
+    const deciding: HostAdapter = {
+      ...fakeHostAdapter(),
+      relay: () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    };
+    // A refusal rendered as success is the failure this suite exists to catch,
+    // so prove the assertion fires rather than trusting that it would.
+    expect(deciding.relay(conformanceResponse()).exitCode).toBe(0);
+    expect(responsePayload(conformanceResponse()).exitCode).toBe(3);
+  });
+
+  it("catches an adapter that grew a method", () => {
+    const extra = {
+      ...fakeHostAdapter(),
+      approve: () => undefined,
+    } as unknown as HostAdapter;
+    const surface = Object.keys(extra).filter(
+      (key) =>
+        typeof (extra as unknown as Record<string, unknown>)[key] ===
+        "function",
+    );
+    expect(surface).toContain("approve");
+    expect([...HOST_ADAPTER_METHODS]).not.toContain("approve");
+  });
+
+  it("catches an adapter that inlines payload content", () => {
+    const invocation = conformanceInvocation();
+    const inlining = {
+      ...fakeHostAdapter(),
+      translate: () => ({
+        ...(fakeHostAdapter().translate(invocation) as unknown as Record<
+          string,
+          unknown
+        >),
+        payload: { ref: invocation.payload.ref, sha256: "", content: "bytes" },
+      }),
+    } as unknown as HostAdapter;
+    expect(
+      Object.keys(
+        (
+          inlining.translate(invocation) as unknown as {
+            payload: Record<string, unknown>;
+          }
+        ).payload,
+      ).sort(),
+    ).toEqual(["content", "ref", "sha256"]);
+  });
+});

--- a/tests/host-negotiation.test.ts
+++ b/tests/host-negotiation.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyHostContract,
+  missingCapabilities,
+  normalizeCapabilities,
+} from "@mestre-yoda/runtime/domain/host";
+
+describe("host contract negotiation", () => {
+  it("accepts the revision this bundle carries", () => {
+    expect(classifyHostContract({ hostContract: "1.0.0" })).toBeNull();
+  });
+
+  // The frozen cases in fixtures/contracts/v1/version-cases.json, now reached
+  // through a message rather than through the classifier directly.
+  it.each([
+    ["a previous revision", "0.9.0", "contract.host_version_unsupported"],
+    ["a future revision", "2.0.0", "contract.host_version_unsupported"],
+    ["a malformed revision", "1.x", "contract.host_version_invalid"],
+  ])("refuses %s", (_name, hostContract, reasonCode) => {
+    const refusal = classifyHostContract({ hostContract });
+    expect(refusal?.reasonCode).toBe(reasonCode);
+    expect(refusal?.exitCode).toBe(2);
+    expect(refusal?.status).toBe("failure");
+    expect(refusal?.stateChanged).toBe(false);
+  });
+
+  it.each([
+    ["a message with no contract", {}],
+    ["a message that is not an object", "1.0.0"],
+    ["null", null],
+    ["a numeric contract", { hostContract: 1 }],
+    ["an untrimmed contract", { hostContract: " 1.0.0" }],
+  ])("refuses %s as invalid", (_name, document) => {
+    expect(classifyHostContract(document)?.reasonCode).toBe(
+      "contract.host_version_invalid",
+    );
+  });
+
+  it("never echoes the declared revision", () => {
+    const hostile = "1.0.0<script>/etc/passwd";
+    const refusal = classifyHostContract({ hostContract: hostile });
+    expect(JSON.stringify(refusal)).not.toContain(hostile);
+    expect(JSON.stringify(refusal)).not.toContain("passwd");
+  });
+
+  it("reads the contract before anything validates the message", () => {
+    // The message is otherwise unusable, and the answer still names the
+    // contract rather than a missing field. That ordering is the whole point:
+    // the schema pins hostContract to a constant, so a drifted host would
+    // otherwise be reported as a bad property.
+    expect(classifyHostContract({ hostContract: "0.9.0" })?.reasonCode).toBe(
+      "contract.host_version_unsupported",
+    );
+  });
+});
+
+describe("host capability normalization", () => {
+  it("sorts and deduplicates what a host declared", () => {
+    expect(
+      normalizeCapabilities([
+        "process.execute",
+        "filesystem.read",
+        "process.execute",
+      ]),
+    ).toEqual(["filesystem.read", "process.execute"]);
+  });
+
+  it.each([
+    ["a non-array", "filesystem.read"],
+    ["undefined", undefined],
+    ["null", null],
+  ])("treats %s as no capabilities", (_name, value) => {
+    expect(normalizeCapabilities(value)).toEqual([]);
+  });
+
+  it("drops entries that are not capability identifiers", () => {
+    expect(
+      normalizeCapabilities([
+        "filesystem.read",
+        "",
+        "-leading",
+        "with space",
+        42,
+        null,
+        "a".repeat(129),
+      ]),
+    ).toEqual(["filesystem.read"]);
+  });
+
+  it("returns a list a caller cannot edit", () => {
+    expect(Object.isFrozen(normalizeCapabilities(["a"]))).toBe(true);
+  });
+
+  it("normalizes two orderings to the same list", () => {
+    expect(normalizeCapabilities(["b", "a"])).toEqual(
+      normalizeCapabilities(["a", "b"]),
+    );
+  });
+});
+
+describe("missing host capabilities", () => {
+  it("names what an operation needs and the host did not offer", () => {
+    expect(
+      missingCapabilities(
+        ["filesystem.read"],
+        ["process.execute", "filesystem.read", "filesystem.write"],
+      ),
+    ).toEqual(["filesystem.write", "process.execute"]);
+  });
+
+  it("reports nothing when the host offers everything required", () => {
+    expect(
+      missingCapabilities(
+        ["filesystem.read", "process.execute"],
+        ["filesystem.read"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("reports each requirement once", () => {
+    expect(missingCapabilities([], ["a", "a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("returns a list a caller cannot edit", () => {
+    expect(Object.isFrozen(missingCapabilities([], ["a"]))).toBe(true);
+  });
+});

--- a/tests/support/architecture.ts
+++ b/tests/support/architecture.ts
@@ -3,7 +3,13 @@ import { builtinModules } from "node:module";
 import { posix } from "node:path";
 
 export type Layer =
-  "domain" | "ports" | "infra" | "composition" | "entry" | "contracts";
+  | "domain"
+  | "ports"
+  | "infra"
+  | "composition"
+  | "entry"
+  | "contracts"
+  | "adapters";
 
 export interface SourceModule {
   readonly path: string;
@@ -69,6 +75,7 @@ export async function collectImports(file: string): Promise<readonly string[]> {
 
 export function classifyLayer(path: string): Layer {
   if (path.startsWith("packages/contracts/")) return "contracts";
+  if (path.startsWith("packages/adapters/")) return "adapters";
   if (path.includes("/src/domain/")) return "domain";
   if (path.includes("/src/ports/")) return "ports";
   if (path.includes("/src/infra/")) return "infra";
@@ -98,6 +105,7 @@ function targetLayer(specifier: string): Target | null {
     return "schemas";
   }
   if (specifier.startsWith("@mestre-yoda/contracts")) return "contracts";
+  if (specifier.startsWith("@mestre-yoda/adapters")) return "adapters";
   if (specifier.includes("/domain/") || specifier.endsWith("/domain")) {
     return "domain";
   }
@@ -144,7 +152,15 @@ const rules: {
 }[] = [
   {
     from: "domain",
-    forbidden: ["node", "infra", "composition", "entry", "ajv", "schemas"],
+    forbidden: [
+      "node",
+      "infra",
+      "composition",
+      "entry",
+      "ajv",
+      "schemas",
+      "adapters",
+    ],
     reason: (target) =>
       target === "node"
         ? "domain must not import Node.js builtins"
@@ -156,7 +172,15 @@ const rules: {
   },
   {
     from: "ports",
-    forbidden: ["node", "infra", "composition", "entry", "ajv", "schemas"],
+    forbidden: [
+      "node",
+      "infra",
+      "composition",
+      "entry",
+      "ajv",
+      "schemas",
+      "adapters",
+    ],
     reason: (target) =>
       target === "node"
         ? "ports must not import Node.js builtins"
@@ -173,8 +197,30 @@ const rules: {
   },
   {
     from: "contracts",
-    forbidden: ["domain", "ports", "infra", "composition", "entry"],
+    forbidden: ["domain", "ports", "infra", "composition", "entry", "adapters"],
     reason: (target) => `contracts must not import ${target}`,
+  },
+  {
+    // An adapter translates and relays. Denying it the runtime's own layers is
+    // what makes "adapters never own transition policy" structural rather than
+    // a rule each adapter is trusted to have followed.
+    from: "adapters",
+    forbidden: [
+      "node",
+      "domain",
+      "ports",
+      "infra",
+      "composition",
+      "entry",
+      "ajv",
+      "schemas",
+    ],
+    reason: (target) =>
+      target === "node"
+        ? "adapters must not import Node.js builtins"
+        : target === "ajv" || target === "schemas"
+          ? "adapters must not import schema infrastructure"
+          : `adapters must not import ${target}`,
   },
 ];
 

--- a/tests/support/fake-host-adapter.ts
+++ b/tests/support/fake-host-adapter.ts
@@ -1,0 +1,64 @@
+import { YODA_VERSION, type AdapterMessageV1 } from "@mestre-yoda/contracts";
+import type {
+  HostAdapter,
+  HostDescriptor,
+  HostInvocation,
+  HostRendering,
+} from "@mestre-yoda/adapters";
+
+export interface FakeHostAdapterOptions {
+  readonly host?: string;
+  readonly hostContract?: string;
+  readonly capabilities?: readonly string[];
+  readonly model?: string | null;
+}
+
+/**
+ * The smallest adapter that conforms.
+ *
+ * It exists so the conformance suite has a subject before either real host
+ * does, and so a change to the protocol fails here rather than only inside a
+ * host nobody can run in CI.
+ */
+export function fakeHostAdapter(
+  options: FakeHostAdapterOptions = {},
+): HostAdapter {
+  const descriptor: HostDescriptor = {
+    host: options.host ?? "fake",
+    hostContract: options.hostContract ?? "1.0.0",
+    capabilities: Object.freeze([...(options.capabilities ?? [])]),
+    observedIdentity: {
+      adapterVersion: YODA_VERSION,
+      model: options.model ?? null,
+    },
+  };
+  return {
+    name: "fake",
+    describe: () => descriptor,
+    translate: (invocation: HostInvocation): AdapterMessageV1 => ({
+      contractVersion: "1.0.0",
+      hostContract: descriptor.hostContract as "1.0.0",
+      messageId: invocation.messageId,
+      messageType: "request",
+      host: descriptor.host,
+      operation: invocation.operation,
+      capabilities: [...descriptor.capabilities],
+      observedIdentity: descriptor.observedIdentity,
+      payloadContract: invocation.payloadContract,
+      payload: invocation.payload,
+      correlationId: invocation.correlationId,
+    }),
+    relay: (response: AdapterMessageV1): HostRendering => {
+      if (response.messageType !== "response") {
+        throw new Error("Expected a response message");
+      }
+      // The verdict is copied, never recomputed. An adapter that decided its
+      // own exit code would be deciding for the runtime.
+      return {
+        stdout: `${JSON.stringify(response.payload)}\n`,
+        stderr: "",
+        exitCode: response.payload.exitCode,
+      };
+    },
+  };
+}

--- a/tests/support/host-adapter-contract.ts
+++ b/tests/support/host-adapter-contract.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HOST_ADAPTER_METHODS,
+  type HostAdapter,
+  type HostInvocation,
+} from "@mestre-yoda/adapters";
+import type { AdapterMessageV1 } from "@mestre-yoda/contracts";
+import {
+  classifyHostContract,
+  normalizeCapabilities,
+} from "@mestre-yoda/runtime/domain/host";
+
+export type HostAdapterFactory = () => HostAdapter;
+
+const identifier = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/u;
+
+/** One invocation every adapter must be able to translate. */
+export function conformanceInvocation(
+  overrides: Partial<HostInvocation> = {},
+): HostInvocation {
+  return {
+    messageId: "conformance-request-01",
+    correlationId: "conformance-01",
+    operation: "handshake",
+    payloadContract: "state.snapshot@1.0.0",
+    payload: {
+      ref: ".brain/runs/run-01/state.json",
+      sha256: "a".repeat(64),
+    },
+    ...overrides,
+  };
+}
+
+/** A response an adapter is asked to relay without reinterpreting it. */
+export function conformanceResponse(
+  overrides: Partial<AdapterMessageV1> = {},
+): AdapterMessageV1 {
+  return {
+    contractVersion: "1.0.0",
+    hostContract: "1.0.0",
+    messageId: "conformance-response-01",
+    messageType: "response",
+    host: "codex",
+    operation: "handshake",
+    capabilities: [],
+    observedIdentity: { adapterVersion: "0.0.0-development", model: null },
+    payloadContract: "result@1.0.0",
+    payload: {
+      contractVersion: "1.0.0",
+      status: "blocked",
+      exitCode: 3,
+      reasonCode: "gate.aprovacao_spec",
+      summary: "The specification approval gate is waiting on a decision.",
+      why: [],
+      evidence: [],
+      stateChanged: false,
+      retryable: true,
+      recovery:
+        "Review the current specification lineage and approve that exact revision before continuing.",
+    },
+    correlationId: "conformance-01",
+    ...overrides,
+  } as AdapterMessageV1;
+}
+
+/** Every callable name an adapter carries, own and inherited. */
+function methodsOf(adapter: HostAdapter): readonly string[] {
+  const found = new Set<string>();
+  let current: object | null = adapter;
+  while (current !== null && current !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(current)) {
+      if (key === "constructor") continue;
+      if (
+        typeof (adapter as unknown as Record<string, unknown>)[key] ===
+        "function"
+      )
+        found.add(key);
+    }
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+  return [...found].sort((left, right) => (left < right ? -1 : 1));
+}
+
+function request(
+  message: AdapterMessageV1,
+): Extract<AdapterMessageV1, { messageType: "request" }> {
+  if (message.messageType !== "request") {
+    throw new Error("Expected a request message");
+  }
+  return message;
+}
+
+/** The result a response carries, narrowed away from the request payload. */
+export function responsePayload(
+  message: AdapterMessageV1,
+): Extract<AdapterMessageV1, { messageType: "response" }>["payload"] {
+  if (message.messageType !== "response") {
+    throw new Error("Expected a response message");
+  }
+  return message.payload;
+}
+
+/**
+ * Behaviour every host adapter must share.
+ *
+ * Claude Code and Codex reach the same runtime, so a decision that differs
+ * between them is a decision an adapter made. This suite is the shared one from
+ * ADR-0004: a new host is added by passing it rather than by branching the core.
+ */
+export function describeHostAdapterContract(
+  label: string,
+  factory: HostAdapterFactory,
+): void {
+  describe(`HostAdapter contract: ${label}`, () => {
+    it("states an identity the wire accepts", () => {
+      const { host, hostContract } = factory().describe();
+      expect(host).toMatch(identifier);
+      // A host whose declared revision this bundle does not accept has to be
+      // rejected by the runtime, so an adapter that ships one cannot conform.
+      expect(classifyHostContract({ hostContract })).toBeNull();
+    });
+
+    it("declares capabilities as normalized explicit data", () => {
+      const { capabilities } = factory().describe();
+      expect(capabilities).toEqual(normalizeCapabilities(capabilities));
+    });
+
+    it("never substitutes an observed identity it was not given", () => {
+      const { observedIdentity } = factory().describe();
+      expect(observedIdentity.adapterVersion).toMatch(identifier);
+      // `null` is the honest answer for a host handed no model. A string here
+      // must have come from the host, never from the adapter's own default.
+      if (observedIdentity.model !== null) {
+        expect(observedIdentity.model).toMatch(identifier);
+      }
+    });
+
+    it("translates an invocation into a request carrying its own identity", () => {
+      const adapter = factory();
+      const descriptor = adapter.describe();
+      const invocation = conformanceInvocation();
+      const message = request(adapter.translate(invocation));
+      expect(message.host).toBe(descriptor.host);
+      expect(message.hostContract).toBe(descriptor.hostContract);
+      expect(message.capabilities).toEqual(descriptor.capabilities);
+      expect(message.observedIdentity).toEqual(descriptor.observedIdentity);
+      expect(message.correlationId).toBe(invocation.correlationId);
+      expect(message.operation).toBe(invocation.operation);
+    });
+
+    it("hands the payload by reference rather than by content", () => {
+      const invocation = conformanceInvocation();
+      const message = request(factory().translate(invocation));
+      // Inlining content would let a host describe bytes the runtime never
+      // verified. The digest is what makes the two agree.
+      expect(message.payload).toEqual(invocation.payload);
+      expect(Object.keys(message.payload).sort()).toEqual(["ref", "sha256"]);
+    });
+
+    it("translates the same invocation into the same bytes", () => {
+      const adapter = factory();
+      const invocation = conformanceInvocation();
+      expect(JSON.stringify(adapter.translate(invocation))).toBe(
+        JSON.stringify(adapter.translate(invocation)),
+      );
+    });
+
+    it("relays a decision without reinterpreting it", () => {
+      const response = conformanceResponse();
+      const rendering = factory().relay(response);
+      // The exit code is the runtime's verdict. An adapter that recomputed it
+      // would be deciding, which is exactly what ADR-0004 forbids.
+      expect(rendering.exitCode).toBe(responsePayload(response).exitCode);
+    });
+
+    it("relays a refusal without turning it into a success", () => {
+      for (const exitCode of [0, 2, 3, 4, 5]) {
+        const base = conformanceResponse();
+        const response = conformanceResponse({
+          payload: { ...responsePayload(base), exitCode },
+        } as Partial<AdapterMessageV1>);
+        expect(factory().relay(response).exitCode).toBe(exitCode);
+      }
+    });
+
+    it("exposes no way to decide or to mutate state", () => {
+      // Asserting the exact set, not merely the absence of a known-bad name: a
+      // method nobody thought to forbid is how an adapter grows a decision.
+      // The prototype chain is walked too, so a class-based adapter cannot hide
+      // a method where own-key enumeration would not look.
+      expect(methodsOf(factory())).toEqual([...HOST_ADAPTER_METHODS]);
+    });
+  });
+}


### PR DESCRIPTION
Refs #35. Does not close it: the approval, hook, timeout, and cancellation payloads that issue also names are not here, for reasons stated below.

## What this changes

[ADR-0004](docs/adr/0004-host-adapter-boundary.md) decided the boundary — adapters translate and relay, never own transition policy, never mutate canonical state, and all pass one shared conformance suite. Nothing implemented it. `packages/adapters/src/index.ts` was `interface HostAdapter { readonly name: string }` and no module imported it, while `contract.host_version_invalid` and `contract.host_version_unsupported` were defined in the catalog, frozen in `fixtures/contracts/v1/version-cases.json`, and unreachable from any code path.

### The adapter is three methods and deliberately no fourth

`describe`, `translate`, `relay`. There is nothing here that could advance a phase, resolve a gate, or write state.

The conformance suite asserts the **exact** method set rather than the absence of names somebody thought to forbid, and walks the prototype chain so a class-based adapter cannot hide one where own-key enumeration would not look. A method nobody anticipated is how an adapter grows a decision.

The same boundary is now static. `tests/support/architecture.ts` gains an `adapters` layer: `packages/adapters` may import `@mestre-yoda/contracts` and nothing else — no domain, ports, infra, composition, entry, Node builtins, or schema infrastructure. It cannot call a runtime decision even by accident. `domain`, `ports`, and `contracts` are correspondingly forbidden from importing it. Before this, anything under `packages/adapters/src/` fell through `classifyLayer` to `entry`, which has no rule, so it was architecturally unconstrained.

### Contract negotiation, which is what makes two dead reason codes live

`adapter-message.v1` pins `hostContract` to `const "1.0.0"`. A host speaking a different revision therefore fails schema validation as a bad property — naming a field instead of naming the contract, and never reaching the classifier that exists to judge it.

So the declared revision is read structurally and judged first, the same ordering the answers document already uses:

| Declared revision | Reason | Exit |
| --- | --- | --- |
| Accepted by the manifest | none | |
| Absent, non-string, or malformed | `contract.host_version_invalid` | 2 |
| Well-formed and not accepted | `contract.host_version_unsupported` | 2 |

The cases are exactly the ones `fixtures/contracts/v1/version-cases.json` already froze (`0.9.0`, `2.0.0`, `1.x`, absent), now reached through a message rather than through the classifier directly. The declared value never reaches the result; a test drives a hostile revision through and asserts neither it nor its substrings come back.

### Capabilities as explicit data

Sorted, deduplicated, and stripped of entries that are not capability identifiers, so two hosts offering the same things compare equal and an adapter cannot move a decision by reordering its own list. ADR-0004 requires capabilities to be normalized rather than inferred from the host name.

An entry the runtime does not recognize is dropped rather than refused — failing an operation over a field it does not need would make every future host capability a breaking change. A capability an operation requires and the host did not offer is reported by `missingCapabilities`, which exists to explain a refusal and never to authorize skipping a check.

### Payloads travel by reference

The suite asserts a translated request carries exactly `{ ref, sha256 }` and that its keys are that pair and no other. Inlining content would let a host describe bytes the runtime never verified.

## Evidence

- `tests/host-adapter-contract.test.ts` — the shared suite run against two fake configurations, plus four tests that prove the suite's own assertions fire: an adapter that renders a refusal as success, one that grew an `approve` method, one that inlines payload content.
- `tests/host-negotiation.test.ts` — 22 tests over the frozen version cases, capability normalization, and missing-capability reporting.
- A minimal fake adapter passes the suite, which is the acceptance criterion and what lets the suite exist before either real host does.

## What this does not cover

`ADP-01` also names approval, hook, timeout, and cancellation payloads. They are not here because they need a new host schema, and `schemas/contracts/contract-manifest.v1.schema.json` bounds the registered set to exactly twelve entries (`minItems: 12, maxItems: 12`). Adding a thirteenth is a manifest-schema change that deserves to travel with the payloads it carries and with the hook command that would use them — the frozen inventory has `CLI-HOOK`, `FLAG-HOOK-HOST`, and `IO-STDIN-HOOK-PAYLOAD` fixing that transport, and this runtime has no `hook` command yet.

Two spellings also need reconciling against the frozen oracle and are deliberately not decided here: the legacy hook host id is `claude-code` where this runtime writes `claude`, and legacy `init --host` accepted a third value `both`.

No parity row moves. The inventory establishes that a host protocol exists, not what the legacy runtime put on the wire.

## Verification

```
npm run format:check && npm run spellcheck && npm run lint && npm run typecheck
npm test                 # 126 files, 3650 tests
npm run test:coverage    # 100% statements, branches, functions, lines
npm run oracle:verify && npm run parity:check && npm run result:check
npm run contracts:check && npm run differential:check && npm run templates:validate
npm run build && npm run package:verify
```

Made with [Orca](https://github.com/stablyai/orca) 🐋
