### PR TITLE
docs: write the threat model and close its untested claims

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,225 @@
+# Threat Model
+
+Issue [#52](https://github.com/thiagocorreanet/mestre-yoda/issues/52)
+(`QAL-04`) asks what this runtime is defended against. This document answers
+that per threat, names the test that proves each answer, and states plainly
+where a defense is partial or absent. A threat model that only lists strengths
+is a marketing document; the gaps below are the part worth reading.
+
+Reporting goes through [SECURITY.md](../../SECURITY.md). Nothing here is a
+promise about a released version: no public release is supported yet.
+
+## What this runtime touches
+
+It reads a repository, writes managed state under `.brain/`, spawns `git`, and
+hands text to a terminal. It also ships as a public plugin, so it receives fork
+pull requests and packaged dependencies. Those four surfaces bound everything
+below.
+
+## Path traversal
+
+Four independent gates refuse a path that leaves the managed surface: the shape
+rule in the transaction domain, a pre-syscall check in the Node adapter, a
+`realpath`-based confinement in the project filesystem port, and a reference
+pattern in every schema that persists a path. Absolute paths, drive-qualified
+paths, backslashes, `.` and `..` segments, empty segments, and control
+characters are all refused, with `guard.outside_allow` where a caller supplied
+the path.
+
+Proven by `tests/managed-surface.test.ts`, `tests/transaction-normalization.test.ts`,
+`tests/node-transaction-security.test.ts`, and `tests/contract-schemas.test.ts`.
+
+**Partial.** `--root <path>` is not validated. That is deliberate — it names
+your project, which may live anywhere — but it means the confinement begins at
+the root the caller chose, not at a root the runtime vetted.
+
+**Partial.** The active-feature pointer is a plain line of text whose contents
+are interpolated into every path the objective command touches. The managed-path
+rule catches a hostile pointer downstream, and
+`tests/objective-adversarial.test.ts` proves nothing is written and nothing is
+echoed. But most such pointers surface as `runtime.internal_failure`, which by
+contract carries no evidence, so the caller is told something broke and not
+which file to repair.
+
+## Symlinks
+
+The durable adapter captures the project root by device, inode, and `realpath`,
+revalidates that identity before every operation, refuses a symlinked ancestor,
+and opens every file with `O_NOFOLLOW`. A root swapped for a symlink mid-flight
+is refused at three separate cut points.
+
+Proven by the eighteen cases in `tests/node-transaction-security.test.ts`,
+including the strongest one, which swaps a destination directory for a symlink
+between the observation and the rename.
+
+**Absent.** The project `FileSystem` port — used for `init --answers <path>` —
+is not `O_NOFOLLOW` protected. It relies on `realpath` plus a containment
+check, which is a check-then-use window. The hardened, tested path is the
+durable filesystem.
+
+**Absent.** `listGitDirectory` reads whatever directory `git rev-parse
+--git-dir` reported, with no confinement to the project root. A `.git` file that
+redirects to another directory makes the runtime list that directory.
+It is read-only and names-only, and the result is matched against a five-entry
+marker table, so the impact is a directory-existence oracle. Nothing defends
+it.
+
+## Command injection
+
+Every process spawn in the shipped runtime passes an argument array, never a
+string, and no code path sets `shell: true`. `tests/architecture.test.ts`
+confines `child_process` to one module. The Git service is called only with two
+frozen constant argument arrays; no caller text is interpolated into argv.
+
+`tests/git-runner-hardening.test.ts` pins the fixed argument prefix
+(`--no-optional-locks`, `--no-pager`, `-c core.quotepath=false`,
+`-c status.renames=copies`) and the environment that neutralizes system and
+global Git configuration. Before it, deleting `GIT_CONFIG_NOSYSTEM` changed no
+test while changing what a gate would see.
+
+## Malicious Git names and configuration
+
+Path bytes are never decoded with loss: invalid UTF-8 becomes a digest rather
+than a replacement character, so two distinct files cannot normalize to one
+name. Ordering is by UTF-8 bytes rather than locale. The status parser fails
+closed on any record it does not fully recognize, because a partial parse would
+report a change set quietly missing entries.
+
+Proven by `tests/git-paths.test.ts`, `tests/git-status-parser.test.ts`, and
+`tests/git-scenarios.test.ts`, which observes real repositories holding names
+with spaces, newlines, leading dashes, and undecodable bytes.
+
+**Absent.** Branch, ref, and remote names are copied through unvalidated. This
+is currently unreachable because no command consumes the Git service yet. The
+first command that renders a branch name will meet the public-text validator,
+which would turn a hostile name into an internal failure rather than a clean
+refusal — that is the moment to add a bound, not later.
+
+**Partial.** A repository's own `.git/config` is not neutralized. Only path
+quoting and rename detection are pinned with `-c`, which outranks it.
+
+## Schema bombs
+
+The event store bounds a record at 64 KiB, a stream at 64 MiB, and a stream at
+100 000 lines, checking the file size before reading it. Reference arrays are
+capped at 256 on the sealing path. Canonicalization refuses a cycle. No
+caller-supplied schema is ever compiled: the registry holds twelve embedded,
+repo-owned schemas whose identities are pinned against the contract manifest.
+
+Proven by `tests/event-chain.test.ts`, `tests/schema-catalog.test.ts`, and
+`tests/schema-registry-integrity.test.ts`.
+
+**Absent.** There is no JSON nesting-depth limit anywhere. Canonicalization,
+data-shape inspection, and deep freezing all recurse without a bound. A deeply
+nested persisted file produces a stack overflow, which the composition boundary
+catches and reports as a sanitized failure — so it degrades safely, but it is
+not a bound and no test asserts the behaviour.
+
+**Absent.** Standard input is unbounded. The init answers document is read
+whole into memory and parsed, and its schema declares no maximum length, item
+count, or property count.
+
+## Event tampering
+
+Every event carries a digest over all of its own fields, chained to its
+predecessor, and the persisted record must be byte-identical to its canonical
+form — a re-ordered or re-spaced record is refused even when semantically
+identical. The snapshot must equal the replayed state byte for byte. Ten
+hand-edit cases are refused without writing anything and without echoing the
+rejected bytes.
+
+Proven by `tests/event-store-corruption.test.ts`, `tests/event-chain.test.ts`,
+and `tests/event-sealing.test.ts`.
+
+**By design, not a gap, but state it plainly.** This is integrity, not
+authenticity. There is no signature and no external witness. Anyone who can
+write to the run directory can recompute the whole chain and its snapshot. The
+chain detects accidental and naive edits; it does not detect an attacker who
+has the same write access the runtime has.
+
+## Terminal injection
+
+Every byte reaching a stream passes one validator, which refuses C0 controls,
+DEL, and C1 controls. C1 matters because a terminal reading UTF-8 treats U+009B
+as a control sequence introducer exactly as it treats `ESC [`, so refusing only
+the seven-bit spelling would leave the same door open under a different name.
+Any backslash is refused, so no JSON escape can smuggle one through a
+structured payload.
+
+Proven by `tests/result-validation.test.ts`, `tests/result-contract-rendering.test.ts`,
+and `tests/cli-contracts.test.ts`, which drives hostile argv through both modes
+and asserts neither stream carries it.
+
+`scripts/lib/dco.mjs` renders a commit subject from an unreviewed fork branch
+into a build log; control characters there are replaced and the subject is
+length-bounded, proven by `tests/dco-log-safety.test.ts`.
+
+**Absent.** Objective text is written to `objective.md` verbatim, and the
+feature-state schema bounds its length but constrains no characters. It never
+reaches a stream — the summary uses only the sanitized slug — but anyone who
+prints that file gets whatever was recorded.
+
+## Secrets and sensitive paths
+
+The result contract refuses fourteen shapes in public text: URLs, absolute and
+drive-qualified paths, any backslash, stack frames, Python tracebacks, GitHub
+tokens, JWTs, PEM blocks, auth headers, cloud credential variables, and
+credential assignments. Internal failures may carry only fixed catalog prose,
+enforced by the validator rather than by convention. Evidence carries digests
+and paths, never content.
+
+Proven by `tests/result-contract-rendering.test.ts`, which includes
+false-positive counter-tests so the rule cannot be tightened into uselessness,
+and `tests/cli-composition.test.ts`.
+
+**Say it accurately.** This is a denylist of shapes, not redaction. A bare
+high-entropy string, a vendor key format nobody listed, or a base64 blob passes.
+What the contract guarantees is that a leak of a *known* shape becomes a
+contract violation rather than output.
+
+**Partial.** The environment port can read any variable with no allowlist. No
+production code calls it today.
+
+## Untrusted contributions
+
+Both workflows are `pull_request`, never `pull_request_target`. Permissions are
+`contents: read` at the workflow level with no job override, no step references
+a secret, every checkout sets `persist-credentials: false`, every action is
+pinned to a commit, jobs are time-bounded, and failure artifacts are uploaded
+only for same-repository runs.
+
+`tests/ci-workflow-contract.test.ts` has always proven this for the CI
+workflow. `tests/supply-chain-contract.test.ts` now proves it for the
+documentation workflow, which runs two third-party actions on fork pull
+requests and previously carried no assertions at all.
+
+**Inherent.** A fork pull request runs `npm ci` and the full suite on a
+GitHub-hosted runner with contributor-controlled code. The mitigations are the
+read-only token, the absent secrets, and the timeout; the blast radius is the
+ephemeral runner.
+
+## Package substitution
+
+Installs use `npm ci` against a lockfile in which every third-party package
+carries an integrity digest and resolves from one registry, with exact saving
+and script confinement configured. Exactly one dependency is allowed to run an
+install script. The packaging verifier refuses symlinks in the staged tree,
+requires the recorded core digest to match the built bytes, and refuses any
+external import that is not a Node builtin.
+
+`tests/supply-chain-contract.test.ts` pins the installer configuration, the
+allowed-script decisions, and both lockfile properties — none of which had a
+test, so deleting `.npmrc` changed nothing that CI would notice.
+`tests/package-verifier.test.ts` and `tests/go-v3-oracle-verifier.test.ts` cover
+the rest.
+
+**Absent.** No CodeQL, no dependency review, no Dependabot configuration, no
+audit in CI (`audit=false` is set deliberately, so the check has to come from
+somewhere else), no provenance or signature verification, and no documented
+license policy. Those are the remaining `QAL-04` deliverables.
+
+## What this document is not
+
+It is not a penetration test, and no finding here came from one. It is a map of
+what the code does, written from the code, so that the next person changing a
+defense knows what it was for and which test will tell them they broke it.

--- a/packages/runtime/src/domain/result/validate.ts
+++ b/packages/runtime/src/domain/result/validate.ts
@@ -54,10 +54,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * Whether text carries a code point a terminal may act on rather than print.
+ *
+ * C0 and DEL are the obvious ones. C1 is here because a terminal reading UTF-8
+ * treats U+009B as a control sequence introducer exactly as it treats
+ * `ESC [`, so refusing the seven-bit spelling while publishing the eight-bit
+ * one would leave the same door open under a different name.
+ */
 function hasControlCharacter(value: string): boolean {
   for (const character of value) {
-    const code = character.codePointAt(0);
-    if (code !== undefined && (code <= 31 || code === 127)) return true;
+    // A character yielded by a string iterator is never empty, so index zero
+    // always exists and the optional result would be an unreachable branch.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const code = character.codePointAt(0)!;
+    if (code <= 31 || code === 127 || (code >= 128 && code <= 159)) return true;
   }
   return false;
 }

--- a/scripts/lib/dco.mjs
+++ b/scripts/lib/dco.mjs
@@ -72,6 +72,27 @@ export function parseCommits(stdout) {
   return commits;
 }
 
+/**
+ * A commit subject as it is safe to put in a build log.
+ *
+ * The subject comes from a fork branch nobody reviewed, and this text lands in
+ * an Actions log. Control characters are replaced rather than printed so a
+ * contributor cannot move the cursor, clear the screen, or hide the rest of
+ * the report behind an escape sequence. The length bound keeps one commit from
+ * burying the remedy that follows it.
+ */
+export function safeSubject(subject) {
+  const printable = [...String(subject)]
+    .map((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      const control =
+        code <= 31 || code === 127 || (code >= 128 && code <= 159);
+      return control ? "�" : character;
+    })
+    .join("");
+  return printable.length <= 120 ? printable : `${printable.slice(0, 119)}…`;
+}
+
 /** The exact remedy, so a failing build does not send anyone hunting. */
 export function remedyFor(violations) {
   const lines = [
@@ -79,7 +100,9 @@ export function remedyFor(violations) {
     "",
   ];
   for (const violation of violations) {
-    lines.push(`  ${violation.hash.slice(0, 12)} ${violation.subject}`);
+    lines.push(
+      `  ${violation.hash.slice(0, 12)} ${safeSubject(violation.subject)}`,
+    );
   }
   lines.push(
     "",

--- a/tests/dco-log-safety.test.ts
+++ b/tests/dco-log-safety.test.ts
@@ -1,0 +1,130 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const checker = join(repositoryRoot, "scripts/check-dco.mjs");
+const author = [
+  "-c",
+  "user.name=Test Author",
+  "-c",
+  "user.email=author@example.com",
+];
+
+const ESCAPE = "\u001b";
+const BELL = "\u0007";
+const EIGHT_BIT_CSI = "\u009b";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+function git(root: string, args: readonly string[]): string {
+  const result = spawnSync("git", [...args], { cwd: root, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")}: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+async function commitWith(
+  root: string,
+  message: string,
+  file: string,
+  signOff: boolean,
+): Promise<string> {
+  await writeFile(join(root, file), `${file}\n`, "utf8");
+  git(root, ["add", file]);
+  git(root, [
+    ...author,
+    "commit",
+    "-q",
+    ...(signOff ? ["-s"] : []),
+    "-m",
+    message,
+  ]);
+  return git(root, ["rev-parse", "HEAD"]);
+}
+
+function check(
+  root: string,
+  base: string,
+  head: string,
+): { status: number | null; stderr: string } {
+  const result = spawnSync(
+    process.execPath,
+    [checker, "--base", base, "--head", head],
+    { cwd: root, encoding: "utf8" },
+  );
+  return { status: result.status, stderr: result.stderr };
+}
+
+/**
+ * The subject of an unsigned commit reaches an Actions log, and it comes from a
+ * fork branch nobody reviewed. Nothing sanitized it: an escape sequence there
+ * could clear the screen or move the cursor over the remedy that follows.
+ */
+describe("the remedy printed for an unsigned commit", () => {
+  it("never lets an unreviewed subject drive the build log", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-dco-log-"));
+    roots.push(root);
+    git(root, ["init", "-q", "--initial-branch=main"]);
+    const base = await commitWith(root, "base", "base.txt", true);
+    const hostile = `feat: add${ESCAPE}[2Jthing${BELL} and ${EIGHT_BIT_CSI}more`;
+    const head = await commitWith(root, hostile, "hostile.txt", false);
+
+    const result = check(root, base, head);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).not.toContain(ESCAPE);
+    expect(result.stderr).not.toContain(BELL);
+    expect(result.stderr).not.toContain(EIGHT_BIT_CSI);
+    // The commit is still named, so a contributor can find what to sign.
+    expect(result.stderr).toContain(head.slice(0, 12));
+    expect(result.stderr).toContain("feat: add");
+  });
+
+  it("keeps an ordinary subject intact", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-dco-log-"));
+    roots.push(root);
+    git(root, ["init", "-q", "--initial-branch=main"]);
+    const base = await commitWith(root, "base", "base.txt", true);
+    const head = await commitWith(
+      root,
+      "feat: add the objective command",
+      "one.txt",
+      false,
+    );
+
+    expect(check(root, base, head).stderr).toContain(
+      "feat: add the objective command",
+    );
+    expect(head).toHaveLength(40);
+  });
+
+  it("bounds one subject so it cannot bury the remedy", async () => {
+    const root = await mkdtemp(join(tmpdir(), "yoda-dco-log-"));
+    roots.push(root);
+    git(root, ["init", "-q", "--initial-branch=main"]);
+    const base = await commitWith(root, "base", "base.txt", true);
+    await commitWith(root, `feat: ${"a".repeat(500)}`, "long.txt", false);
+    const head = git(root, ["rev-parse", "HEAD"]);
+
+    const { stderr } = check(root, base, head);
+
+    expect(stderr).toContain("…");
+    expect(stderr).toContain("git rebase --signoff");
+    for (const line of stderr.split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(140);
+    }
+    expect(head).toHaveLength(40);
+  });
+});

--- a/tests/git-runner-hardening.test.ts
+++ b/tests/git-runner-hardening.test.ts
@@ -1,0 +1,145 @@
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { nodeGitRunner } from "@mestre-yoda/runtime/infra/node";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+/**
+ * Run the real runner against a `git` that only records how it was called.
+ *
+ * The hardening this file pins is a set of constants nothing asserted: the
+ * fixed argument prefix and the environment that neutralizes system and global
+ * configuration. Deleting `GIT_CONFIG_NOSYSTEM` or `-c core.quotepath=false`
+ * used to change no test, while changing what a gate sees. `pathOverride` is
+ * the seam that already exists for this, so nothing in the adapter moves.
+ */
+async function record(
+  args: readonly string[],
+): Promise<{ argv: readonly string[]; env: Record<string, string> }> {
+  const root = await mkdtemp(join(tmpdir(), "yoda-git-hardening-"));
+  roots.push(root);
+  const binaries = join(root, "bin");
+  await mkdir(binaries, { recursive: true });
+  const argvPath = join(root, "argv");
+  const envPath = join(root, "env");
+  const shim = join(binaries, "git");
+  await writeFile(
+    shim,
+    [
+      "#!/bin/sh",
+      `: > '${argvPath}'`,
+      `for argument in "$@"; do printf '%s\\n' "$argument" >> '${argvPath}'; done`,
+      // `env` is not reachable: PATH is replaced by the shim directory alone,
+      // which is itself part of what this test proves. `export -p` is a shell
+      // builtin, so it needs no PATH entry.
+      `export -p > '${envPath}'`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(shim, 0o755);
+  await nodeGitRunner(root, { pathOverride: binaries }).run(args);
+  const argv = (await readFile(argvPath, "utf8")).split("\n").slice(0, -1);
+  const env: Record<string, string> = {};
+  for (const raw of (await readFile(envPath, "utf8")).split("\n")) {
+    const line = raw.startsWith("export ") ? raw.slice(7) : raw;
+    const separator = line.indexOf("=");
+    if (separator <= 0) continue;
+    const value = line.slice(separator + 1);
+    env[line.slice(0, separator)] = /^'.*'$/su.test(value)
+      ? value.slice(1, -1).replaceAll("'\\''", "'")
+      : value;
+  }
+  return { argv, env };
+}
+
+describe("the Git runner's fixed argument prefix", () => {
+  it("prefixes every command with the exact hardening flags", async () => {
+    const { argv } = await record(["status", "--porcelain=v2"]);
+    expect(argv).toEqual([
+      "--no-optional-locks",
+      "--no-pager",
+      "-c",
+      "core.quotepath=false",
+      "-c",
+      "status.renames=copies",
+      "status",
+      "--porcelain=v2",
+    ]);
+  });
+
+  it("pins path quoting and rename detection past a repository's own config", async () => {
+    // `-c` on the command line outranks `.git/config`, which this adapter does
+    // not neutralize. A repository that turned rename detection off would
+    // otherwise turn every rename into an add plus a delete.
+    const { argv } = await record(["rev-parse"]);
+    expect(argv.slice(0, 6)).toContain("core.quotepath=false");
+    expect(argv.slice(0, 6)).toContain("status.renames=copies");
+  });
+
+  it("passes the caller's arguments after the prefix and never before it", async () => {
+    const { argv } = await record(["--version"]);
+    expect(argv.at(-1)).toBe("--version");
+    expect(argv[0]).toBe("--no-optional-locks");
+  });
+});
+
+describe("the Git runner's environment", () => {
+  it("neutralizes system and global configuration", async () => {
+    const { env } = await record(["rev-parse"]);
+    expect(env.GIT_CONFIG_NOSYSTEM).toBe("1");
+    // A path that cannot exist is what makes a personal ~/.gitconfig inert.
+    expect(env.GIT_CONFIG_GLOBAL).toContain("yoda-absent-global-config");
+    expect(env.GIT_OPTIONAL_LOCKS).toBe("0");
+    expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(env.LC_ALL).toBe("C");
+  });
+
+  it("hands Git nothing else from the ambient environment", async () => {
+    const { env } = await record(["rev-parse"]);
+    const declared = [
+      "GIT_CONFIG_GLOBAL",
+      "GIT_CONFIG_NOSYSTEM",
+      "GIT_OPTIONAL_LOCKS",
+      "GIT_TERMINAL_PROMPT",
+      "LC_ALL",
+      "PATH",
+    ];
+    // Node adds its own variables to a spawned child, so the assertion is that
+    // nothing the adapter declares is missing and no other GIT_* leaks in.
+    for (const name of declared) expect(env[name]).toBeDefined();
+    expect(
+      Object.keys(env)
+        .filter((name) => name.startsWith("GIT_"))
+        .sort(),
+    ).toEqual([
+      "GIT_CONFIG_GLOBAL",
+      "GIT_CONFIG_NOSYSTEM",
+      "GIT_OPTIONAL_LOCKS",
+      "GIT_TERMINAL_PROMPT",
+    ]);
+  });
+
+  it("uses the supplied PATH rather than the ambient one", async () => {
+    const { env } = await record(["rev-parse"]);
+    expect(env.PATH).not.toBe(process.env.PATH);
+    expect(env.PATH).toContain("yoda-git-hardening-");
+  });
+});

--- a/tests/objective-adversarial.test.ts
+++ b/tests/objective-adversarial.test.ts
@@ -1,0 +1,136 @@
+import { runCommandLine } from "@mestre-yoda/runtime/composition/cli";
+import {
+  fixedClock,
+  fixedEnvironment,
+  memoryFileSystem,
+  memoryTransactionStorage,
+  memoryWorkspace,
+  pipedInput,
+  recordingOutput,
+  sequentialIds,
+} from "@mestre-yoda/runtime/infra/fake";
+import type { RuntimePorts } from "@mestre-yoda/runtime/ports";
+import { describe, expect, it } from "vitest";
+
+const ROOT = "/project";
+const NOW = "2026-08-14T12:00:00.000Z";
+
+interface Subject {
+  readonly ports: RuntimePorts;
+  readonly storage: ReturnType<typeof memoryTransactionStorage>;
+  readonly output: ReturnType<typeof recordingOutput>;
+}
+
+function subject(files: Readonly<Record<string, string>>): Subject {
+  const storage = memoryTransactionStorage({
+    files,
+    directories: [".brain", ".brain/transactions", ".brain/02-features"],
+  });
+  const output = recordingOutput();
+  return {
+    storage,
+    output,
+    ports: {
+      clock: fixedClock(NOW),
+      ids: sequentialIds("transaction"),
+      digests: storage.digests,
+      durableFileSystem: storage.durableFileSystem,
+      fileSystem: memoryFileSystem({}),
+      environment: fixedEnvironment({}, ROOT),
+      output,
+      standardInput: pipedInput(null),
+      workspace: memoryWorkspace({ directories: [ROOT] }),
+    } as unknown as RuntimePorts,
+  };
+}
+
+/**
+ * The active-feature pointer is a plain line of text on disk, and the feature
+ * name it carries is interpolated into every path the command touches. Nothing
+ * between the file and that interpolation validates it, so these cases prove
+ * the downstream managed-path rule is what actually holds, and that a rejected
+ * pointer publishes nothing and says nothing about the bytes it rejected.
+ */
+describe("a hand-edited active-feature pointer", () => {
+  const hostile: readonly (readonly [string, string])[] = [
+    ["a traversing name", "../../../etc\n"],
+    ["a parent segment", "..\n"],
+    ["an absolute name", "/etc/passwd\n"],
+    ["a drive-qualified name", "C:/Windows\n"],
+    ["a backslash name", "..\\..\\etc\n"],
+    ["a name reaching the lock namespace", "../../locks/project\n"],
+    ["a name reaching the transaction namespace", "../../transactions\n"],
+  ];
+
+  it.each(hostile)(
+    "refuses %s without writing anything",
+    async (_label, active) => {
+      const run = subject({ ".brain/02-features/active": active });
+      const before = run.storage.snapshot();
+
+      const exitCode = await runCommandLine(
+        ["objective", "Ship the export pipeline"],
+        run.ports,
+      );
+
+      expect(exitCode).not.toBe(0);
+      expect(run.storage.snapshot()).toEqual(before);
+      expect(
+        run.storage.calls().filter((operation) => operation === "write_file"),
+      ).toEqual([]);
+    },
+  );
+
+  it.each(hostile)(
+    "never echoes %s on either stream",
+    async (_label, active) => {
+      const run = subject({ ".brain/02-features/active": active });
+
+      await runCommandLine(
+        ["objective", "Ship the export pipeline"],
+        run.ports,
+      );
+
+      const published = [...run.output.structured_, ...run.output.human_].join(
+        "\n",
+      );
+      expect(published).not.toContain(active.trim());
+      expect(published).not.toContain("passwd");
+      expect(published).not.toContain("Windows");
+      expect(published).not.toContain("etc");
+      // Most of these reach the managed-path rule as a raw refusal, so the
+      // answer is a sanitized internal failure that names nothing at all. That
+      // is safe but unhelpful: the caller is not told which file to fix. The
+      // threat model records it rather than this test pretending otherwise.
+      expect(published).toMatch(
+        /(The operation stopped after an unexpected internal failure\.|\.brain\/02-features\/active)/u,
+      );
+    },
+  );
+
+  it("refuses a pointer naming an entry no feature name can produce", async () => {
+    // The identity rule folds to `[a-z0-9-]`, so a pointer carrying anything
+    // else was not written by this runtime.
+    const run = subject({
+      ".brain/02-features/active": "Feature With Spaces\n",
+    });
+    const before = run.storage.snapshot();
+
+    expect(await runCommandLine(["objective", "Ship it"], run.ports)).not.toBe(
+      0,
+    );
+    expect(run.storage.snapshot()).toEqual(before);
+  });
+
+  it("treats an empty pointer as nothing started", async () => {
+    // An empty file is the initialized state, not a hostile one, so this is
+    // the counter-case that keeps the rule above from being read as "any
+    // unusual pointer fails".
+    const run = subject({ ".brain/02-features/active": "" });
+
+    expect(await runCommandLine(["objective", "Ship it"], run.ports)).toBe(0);
+    expect(run.storage.snapshot().files[".brain/02-features/active"]).toBe(
+      "ship-it\n",
+    );
+  });
+});

--- a/tests/result-validation.test.ts
+++ b/tests/result-validation.test.ts
@@ -104,6 +104,12 @@ describe("result validation", () => {
     ["an absolute path", "Failed reading /home/someone/project/file.json"],
     ["a URL", "See https://example.test/report for details"],
     ["a control character", "Broken\u0007summary"],
+    ["an escape character", "Broken\u001bsummary"],
+    // A terminal reading UTF-8 treats U+009B as a control sequence introducer
+    // exactly as it treats `ESC [`, so refusing only the seven-bit spelling
+    // would leave the same door open under a different name.
+    ["an eight-bit control sequence introducer", "Broken\u009b31msummary"],
+    ["a C1 control", "Broken\u0085summary"],
     ["a stack frame", "at handler (/app/index.js:10:5)"],
     ["a bearer token", "Authorization Bearer abcdefghijklmnopqrstuvwxyz"],
     ["a backslash", "C:\\Users\\someone"],

--- a/tests/supply-chain-contract.test.ts
+++ b/tests/supply-chain-contract.test.ts
@@ -1,0 +1,155 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+
+async function read(relative: string): Promise<string> {
+  return await readFile(join(repositoryRoot, relative), "utf8");
+}
+
+describe("the installer configuration", () => {
+  it("keeps every setting that decides what an install may do", async () => {
+    // These six lines are the whole supply-chain posture of an install, and
+    // nothing asserted them: deleting the file changed no test while turning
+    // exact pinning and script confinement off.
+    expect(
+      (await read(".npmrc"))
+        .split("\n")
+        .filter((line) => line.trim() !== "")
+        .sort(),
+    ).toEqual([
+      "audit=false",
+      "engine-strict=true",
+      "fund=false",
+      "package-lock=true",
+      "save-exact=true",
+      "strict-allow-scripts=true",
+    ]);
+  });
+
+  it("names every package allowed to run an install script", async () => {
+    const manifest = JSON.parse(await read("package.json")) as {
+      readonly allowScripts?: Readonly<Record<string, boolean>>;
+    };
+    // An install script runs attacker-reachable code on every `npm ci`,
+    // including one triggered by a fork pull request. The decisions are the
+    // control, so they belong in a test rather than in a diff nobody reads.
+    // Exactly one package is allowed to run one; the other is recorded as
+    // refused so a later install cannot quietly promote it.
+    expect(manifest.allowScripts).toEqual({
+      "esbuild@0.28.1": true,
+      "fsevents@2.3.3": false,
+    });
+  });
+});
+
+describe("the lockfile", () => {
+  it("pins every third-party package to a digest", async () => {
+    const lockfile = JSON.parse(await read("package-lock.json")) as {
+      readonly lockfileVersion: number;
+      readonly packages: Readonly<
+        Record<
+          string,
+          {
+            readonly resolved?: string;
+            readonly integrity?: string;
+            readonly link?: boolean;
+          }
+        >
+      >;
+    };
+    expect(lockfile.lockfileVersion).toBe(3);
+    const unpinned = Object.entries(lockfile.packages)
+      .filter(([name, entry]) => {
+        // The workspaces are this repository; only what npm fetches counts.
+        if (name === "" || name.startsWith("packages/")) return false;
+        if (entry.link === true) return false;
+        return entry.resolved !== undefined && entry.integrity === undefined;
+      })
+      .map(([name]) => name);
+    // A resolved entry with no integrity is a package npm will accept from
+    // whatever the registry serves at install time.
+    expect(unpinned).toEqual([]);
+  });
+
+  it("resolves every third-party package from one registry", async () => {
+    const lockfile = JSON.parse(await read("package-lock.json")) as {
+      readonly packages: Readonly<
+        Record<string, { readonly resolved?: string; readonly link?: boolean }>
+      >;
+    };
+    const foreign = Object.entries(lockfile.packages)
+      .filter(([name, entry]) => {
+        if (name === "" || name.startsWith("packages/")) return false;
+        if (entry.link === true) return false;
+        return (
+          entry.resolved !== undefined &&
+          !entry.resolved.startsWith("https://registry.npmjs.org/")
+        );
+      })
+      .map(([name]) => name);
+    // A git or tarball URL in the lockfile is a dependency nobody reviewed
+    // arriving from somewhere the registry does not control.
+    expect(foreign).toEqual([]);
+  });
+});
+
+describe("the documentation workflow", () => {
+  it("stays fork-safe and read-only", async () => {
+    const raw = await read(".github/workflows/docs.yml");
+    const workflow = parse(raw) as {
+      readonly permissions?: unknown;
+      readonly jobs: Readonly<
+        Record<string, { readonly permissions?: unknown }>
+      >;
+    };
+    // `ci.yml` has carried these assertions since it shipped; this workflow
+    // runs third-party actions on fork pull requests and carried none, so an
+    // edit adding write authority would have passed unnoticed.
+    expect(raw).not.toContain("pull_request_target");
+    expect(raw).not.toMatch(/\bsecrets\b/iu);
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    for (const job of Object.values(workflow.jobs)) {
+      expect(job.permissions).toBeUndefined();
+    }
+  });
+
+  it("pins every action to a commit rather than a moving tag", async () => {
+    const workflow = parse(await read(".github/workflows/docs.yml")) as {
+      readonly jobs: Readonly<
+        Record<
+          string,
+          { readonly steps: readonly { readonly uses?: string }[] }
+        >
+      >;
+    };
+    const uses = Object.values(workflow.jobs)
+      .flatMap((job) => job.steps)
+      .map((step) => step.uses)
+      .filter((value): value is string => value !== undefined);
+    expect(uses).toEqual([
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      "DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff",
+      "lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8",
+    ]);
+    for (const value of uses) {
+      expect(value.split("@")[1]).toMatch(/^[0-9a-f]{40}$/u);
+    }
+  });
+
+  it("checks out without leaving a credential behind", async () => {
+    const workflow = parse(await read(".github/workflows/docs.yml")) as {
+      readonly jobs: Readonly<
+        Record<
+          string,
+          { readonly steps: readonly { readonly with?: unknown }[] }
+        >
+      >;
+    };
+    const checkout = Object.values(workflow.jobs)[0]?.steps[0];
+    expect(checkout?.with).toEqual({ "persist-credentials": false });
+  });
+});


### PR DESCRIPTION
Refs #52. Does not close it: CodeQL, dependency review, and the license policy are not here.

## What this changes

`QAL-04`'s first deliverable is a threat model. Writing one honestly meant reading the code rather than the docs, and the reading found several controls that **no test held** — deleting them would have changed nothing CI notices while changing what the runtime actually refuses. Those are closed here, and the document states plainly where a defense is still partial or absent.

### Controls that had no test

**The Git runner's hardening.** `--no-optional-locks`, `--no-pager`, `-c core.quotepath=false`, `-c status.renames=copies`, and the environment that neutralizes system and global Git configuration were documented and unasserted. Rename detection is load-bearing: a file moved out of a declared scope is a case a gate has to see, and a repository that turned it off would turn every rename into an add plus a delete. `nodeGitRunner` already accepts a `pathOverride`, so `tests/git-runner-hardening.test.ts` drives the real adapter against a recording shim — nothing in production moves.

**The installer posture.** `.npmrc` carries six lines that decide what an install may do, `package.json` names which packages may run an install script, and the lockfile pins every third-party package to a digest from one registry. None of it was asserted; deleting `.npmrc` turned exact pinning and script confinement off silently. `tests/supply-chain-contract.test.ts` pins all of it.

**The documentation workflow.** `ci.yml` has always been held by `tests/ci-workflow-contract.test.ts`. `docs.yml` runs two third-party actions on fork pull requests and carried no assertions at all — an edit adding `pull_request_target` or a write permission would have passed. Now held to the same rules: no `pull_request_target`, no secrets, `contents: read` with no job override, commit-pinned actions, `persist-credentials: false`.

### Two behaviour fixes

**C1 controls are refused in public text.** A terminal reading UTF-8 treats U+009B as a control sequence introducer exactly as it treats `ESC [`. The validator refused C0 and DEL, so the seven-bit spelling was blocked and the eight-bit one was not — the same door under another name.

**The DCO check no longer prints a raw commit subject.** That subject comes from a fork branch nobody reviewed and lands in an Actions log, where an escape sequence could clear the screen or move the cursor over the remedy that follows. Control characters are replaced and the subject is length-bounded; the commit is still named so a contributor knows what to sign.

### Adversarial cases

`tests/objective-adversarial.test.ts` hand-edits the active-feature pointer, whose contents are interpolated into every path the objective command touches — traversal, absolute, drive-qualified, backslash, and pointers reaching the lock and transaction namespaces. Nothing is written, no rejected byte reaches either stream, and an empty pointer is still the ordinary "nothing started" case.

Those tests also record something the threat model states rather than dresses up: most hostile pointers answer with `runtime.internal_failure`, which by contract carries no evidence, so the caller learns something broke but not which file to repair.

## What the document says is missing

The gaps are the part worth reading, so they are in the document rather than in a follow-up nobody opens:

- no JSON nesting-depth bound anywhere — canonicalization, data-shape inspection, and deep freezing all recurse unbounded, degrading to a sanitized failure rather than a refusal;
- standard input is unbounded, and the answers schema declares no maximum length, item count, or property count;
- branch, ref, and remote names are copied through unvalidated (currently unreachable, because no command consumes the Git service yet);
- `listGitDirectory` reads whatever directory `git rev-parse --git-dir` reported, with no confinement to the project root;
- the event chain is integrity, not authenticity — anyone with the runtime's write access can recompute it;
- the secret rules are a denylist of shapes, not redaction;
- the project `FileSystem` port is not `O_NOFOLLOW` protected.

## What is not in this PR

CodeQL, dependency review, and a documented license policy are the remaining `QAL-04` deliverables. They add workflows and a policy rather than tests, and belong with the SBOM work in `BET-02` (#59) that has to comply with the same policy.

## Verification

```
npm run format:check && npm run spellcheck && npm run lint && npm run typecheck
npm test                 # 132 files, 3761 tests
npm run test:coverage    # 100% statements, branches, functions, lines
npm run oracle:verify && npm run parity:check && npm run result:check
npm run contracts:check && npm run differential:check && npm run templates:validate
npm run build && npm run package:verify
```

Made with [Orca](https://github.com/stablyai/orca) 🐋
