### PR TITLE
fix: put a run where the frozen contract says it lives

### DIFF
--- a/docs/architecture/event-store.md
+++ b/docs/architecture/event-store.md
@@ -7,18 +7,33 @@ runtime. It does not add a public command: the staged bundle still exposes only
 
 ## Run ownership and layout
 
-Each validated run owns exactly two event-store destinations:
+A run belongs to the feature that opened it, and owns exactly two event-store
+destinations beneath it:
 
 ```text
-.brain/runs/<run-id>/events.jsonl
-.brain/runs/<run-id>/state.json
+.brain/02-features/<feature>/runs/<run-id>/events.jsonl
+.brain/02-features/<feature>/runs/<run-id>/state.json
 ```
 
-The event-store composition derives both paths from the validated run ID.
+The event-store composition derives both paths from a validated run location —
+the feature and the run identifier together. It cannot derive them from the run
+identifier alone, which is why a caller names both.
+
+Issue [#108](https://github.com/thiagocorreanet/mestre-yoda/issues/108)
+(`RUN-06a`) moved them here. `RUN-06` shipped `.brain/runs/<run-id>/`, a path
+that appears nowhere in the frozen discovery snapshot and that no parity row
+covers, while eleven frozen rows place every run artifact under its feature.
+Two layouts for one run would have meant the trail's history living somewhere
+the frozen contract never names.
+
 Callers never supply event-store destinations, and no caller effect may write
 or delete either selected path. `events.jsonl` is the accepted history;
 `state.json` is its replayed, validated snapshot. Transaction staging and
 progress remain owned by the separate `.brain/transactions/` boundary.
+
+A run identifier keeps its own grammar. The feature is constrained to the
+grammar `state.feature` declares, so a location the store accepts is one the
+feature contract could have produced.
 
 ## Canonical history
 

--- a/docs/compatibility/result-contract.md
+++ b/docs/compatibility/result-contract.md
@@ -162,7 +162,7 @@ Successful state change:
   "evidence": [
     {
       "kind": "event",
-      "ref": ".brain/runs/0001-login/events.jsonl",
+      "ref": ".brain/02-features/login/runs/0001/events.jsonl",
       "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
     }
   ],
@@ -187,7 +187,7 @@ Blocked policy transition:
   "evidence": [
     {
       "kind": "approval",
-      "ref": ".brain/runs/0001-login/approvals.jsonl",
+      "ref": ".brain/02-features/login/runs/0001/approvals.jsonl",
       "sha256": "3333333333333333333333333333333333333333333333333333333333333333"
     }
   ],

--- a/docs/verification/issue-26-objective-evidence.md
+++ b/docs/verification/issue-26-objective-evidence.md
@@ -52,7 +52,7 @@ This is why the five objective rows move to `in_progress` rather than `parity`,
 and why parity stays `0 / 400 (0.00%)`.
 
 **Events in the canonical event store.** The issue asks for canonical events.
-The event store from `RUN-06` writes `.brain/runs/<run-id>/events.jsonl`, and
+The event store writes `.brain/02-features/<feature>/runs/<run>/events.jsonl`, and
 runs are `SDD-03` work -- an objective has no run yet. The append-only
 `objective-history.jsonl` is the frozen inventory's record for this lifecycle
 and carries every transition with its lineage; wiring the same transitions into

--- a/packages/runtime/src/composition/events.ts
+++ b/packages/runtime/src/composition/events.ts
@@ -30,6 +30,9 @@ import type {
 import { TransactionFailure } from "./transactions.js";
 
 const runIdPattern = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$/u;
+// The same grammar `state.feature` declares, so a location the event store
+// accepts is one the feature contract could have produced.
+const featurePattern = /^[a-z0-9][a-z0-9-]{0,63}$/u;
 const encoder = new TextEncoder();
 
 /** Private boundary sentinels prevent injected errors from gaining authority. */
@@ -113,9 +116,26 @@ export interface PreparedEventAppend {
   readonly expected: ReadonlyMap<string, PathFingerprint>;
 }
 
-export function eventStorePaths(runId: string): EventStorePaths {
-  if (!runIdPattern.test(runId)) throw new EventIntegrityError("invalid_event");
-  const root = `.brain/runs/${runId}`;
+/**
+ * Which run a stream belongs to.
+ *
+ * A run belongs to the feature that opened it, and the frozen layout says so:
+ * every run artifact lives under its feature. Naming both here is what keeps
+ * the store from inventing a second place for a run to live.
+ */
+export interface RunLocation {
+  readonly feature: string;
+  readonly runId: string;
+}
+
+export function eventStorePaths(location: RunLocation): EventStorePaths {
+  if (
+    !featurePattern.test(location.feature) ||
+    !runIdPattern.test(location.runId)
+  ) {
+    throw new EventIntegrityError("invalid_event");
+  }
+  const root = `.brain/02-features/${location.feature}/runs/${location.runId}`;
   return { events: `${root}/events.jsonl`, snapshot: `${root}/state.json` };
 }
 
@@ -124,7 +144,11 @@ export function eventStorePaths(runId: string): EventStorePaths {
  * required to append one sealed event. This function deliberately never writes.
  */
 export async function prepareEventAppend<State = JsonState>(
-  input: { readonly runId: string; readonly event: EventDraftV1 },
+  input: {
+    readonly feature: string;
+    readonly runId: string;
+    readonly event: EventDraftV1;
+  },
   services: EventAppendServices<State>,
 ): Promise<PreparedEventAppend> {
   let paths: EventStorePaths;
@@ -138,7 +162,7 @@ export async function prepareEventAppend<State = JsonState>(
     tracker = new DependencyTracker();
     const trusted = trustedServices(services, tracker);
     const request = snapshotRequest(input, trusted.events.isProxy, tracker);
-    paths = derivePaths(request.runId);
+    paths = derivePaths(request);
     runId = request.runId;
     draft = request.event;
     eventServices = trusted.events;
@@ -249,14 +273,22 @@ function snapshotRequest(
   input: unknown,
   isProxy: EventServices["isProxy"],
   tracker: DependencyTracker,
-): { readonly runId: string; readonly event: EventDraftV1 } {
+): {
+  readonly feature: string;
+  readonly runId: string;
+  readonly event: EventDraftV1;
+} {
   if (typeof input !== "object" || input === null || isProxy(input)) {
     throw new IntegrityFailure();
   }
+  const feature = ownData(input, "feature");
   const runId = ownData(input, "runId");
   const event = ownData(input, "event");
-  if (typeof runId !== "string") throw new IntegrityFailure();
+  if (typeof feature !== "string" || typeof runId !== "string") {
+    throw new IntegrityFailure();
+  }
   return {
+    feature,
     runId,
     event: eventDomain(tracker, () => snapshotEventDraft(event, isProxy)),
   };
@@ -303,9 +335,14 @@ function assertReplayRunId(
   if (snapshot.runId !== runId) throw new IntegrityFailure();
 }
 
-function derivePaths(runId: string): EventStorePaths {
-  if (!runIdPattern.test(runId)) throw new IntegrityFailure();
-  const root = `.brain/runs/${runId}`;
+function derivePaths(location: RunLocation): EventStorePaths {
+  if (
+    !featurePattern.test(location.feature) ||
+    !runIdPattern.test(location.runId)
+  ) {
+    throw new IntegrityFailure();
+  }
+  const root = `.brain/02-features/${location.feature}/runs/${location.runId}`;
   return { events: `${root}/events.jsonl`, snapshot: `${root}/state.json` };
 }
 

--- a/packages/runtime/src/composition/index.ts
+++ b/packages/runtime/src/composition/index.ts
@@ -293,7 +293,7 @@ async function decideMutation<State = JsonState>(
     );
     await preflightManagedTransactions(frozenOptions, services, reconcile);
     prepared = await prepareEventAppend(
-      { runId: append.runId, event: append.event },
+      { feature: append.feature, runId: append.runId, event: append.event },
       {
         durableFileSystem: ports.durableFileSystem,
         digests: ports.digests,
@@ -620,26 +620,37 @@ function snapshotAppendEffect(
 ): AppendEventEffect {
   const keys = Reflect.ownKeys(value);
   if (
-    keys.length !== 3 ||
+    keys.length !== 4 ||
     keys.some(
       (key) =>
-        typeof key !== "string" || !["kind", "runId", "event"].includes(key),
+        typeof key !== "string" ||
+        !["kind", "feature", "runId", "event"].includes(key),
     )
   )
     throw invalidApplyInput();
   const kind = ownData(value, "kind");
+  const feature = ownData(value, "feature");
   const runId = ownData(value, "runId");
   const event = ownData(value, "event");
-  if (kind !== "append_event" || typeof runId !== "string")
+  if (
+    kind !== "append_event" ||
+    typeof feature !== "string" ||
+    typeof runId !== "string"
+  )
     throw invalidApplyInput();
   let paths: ReturnType<typeof eventStorePaths> | undefined;
   try {
-    paths = eventStorePaths(runId);
+    paths = eventStorePaths({ feature, runId });
   } catch {
     throw invalidApplyInput();
   }
   try {
-    return { kind, runId, event: snapshotEventDraft(event, types.isProxy) };
+    return {
+      kind,
+      feature,
+      runId,
+      event: snapshotEventDraft(event, types.isProxy),
+    };
   } catch {
     throw new TransactionFailure("runtime.state_corrupt", eventEvidence(paths));
   }
@@ -708,7 +719,7 @@ function assertAppendDestinationsExclusive(
 ): void {
   let paths: ReturnType<typeof eventStorePaths> | undefined;
   try {
-    paths = eventStorePaths(append.runId);
+    paths = eventStorePaths(append);
     const owned = [
       managedPathCollisionKey(paths.events),
       managedPathCollisionKey(paths.snapshot),
@@ -731,7 +742,7 @@ function snapshotAppendReducers<State>(
   append: AppendEventEffect,
   schemaRegistry: TransactionServices["schemaRegistry"],
 ): EventReducerRegistry<State> {
-  const paths = eventStorePaths(append.runId);
+  const paths = eventStorePaths(append);
   const dependencyState = { proxyDetectorFailed: false };
   try {
     let registry: unknown;

--- a/packages/runtime/src/composition/transactions.ts
+++ b/packages/runtime/src/composition/transactions.ts
@@ -166,16 +166,19 @@ function freezeExecuteOptions(value: unknown): ExecuteManagedMutationOptions {
       EventStorePrecondition,
       EventStorePrecondition,
     ] = [freezePrecondition(first), freezePrecondition(second)];
+    // A run lives under the feature that opened it, so the pair this
+    // transaction may fence is identified by both names, not by the run alone.
     const match =
-      /^\.brain\/runs\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/(events\.jsonl|state\.json)$/u;
+      /^\.brain\/02-features\/([a-z0-9][a-z0-9-]{0,63})\/runs\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/(events\.jsonl|state\.json)$/u;
     const firstPrecondition = preconditions[0];
     const secondPrecondition = preconditions[1];
     const left = match.exec(firstPrecondition.path);
     const right = match.exec(secondPrecondition.path);
     if (
-      left?.[2] !== "events.jsonl" ||
-      right?.[2] !== "state.json" ||
-      left[1] !== right[1]
+      left?.[3] !== "events.jsonl" ||
+      right?.[3] !== "state.json" ||
+      left[1] !== right[1] ||
+      left[2] !== right[2]
     )
       throw new Error();
     return leaseGuard === undefined
@@ -253,6 +256,13 @@ function freezeLeaseGuard(
     expected: Object.freeze(pair),
   }) as unknown as LeaseGuardBinding;
 }
+
+/**
+ * The one path under a run whose drift is trail evidence rather than an
+ * ordinary artifact. A run lives under the feature that opened it.
+ */
+const EVENT_STREAM_PATH =
+  /^\.brain\/02-features\/[a-z0-9][a-z0-9-]{0,63}\/runs\/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\/events\.jsonl$/u;
 
 function reservedGuardPath(path: string, name: string): boolean {
   return lockScope.test(path) && path.endsWith(`/${name}`);
@@ -510,12 +520,7 @@ async function assertDeclaredEventStorePreconditions(
       throw new TransactionFailure("runtime.internal_failure", []);
     }
     if (!sameFingerprint(observed, entry.expected)) {
-      const kind =
-        /^\.brain\/runs\/[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\/events\.jsonl$/u.test(
-          entry.path,
-        )
-          ? "event"
-          : "artifact";
+      const kind = EVENT_STREAM_PATH.test(entry.path) ? "event" : "artifact";
       evidence.push({ kind, ref: entry.path });
     }
   }

--- a/packages/runtime/src/domain/effects.ts
+++ b/packages/runtime/src/domain/effects.ts
@@ -9,6 +9,13 @@ import type { EventDraftV1 } from "./events/index.js";
  */
 export interface AppendEventEffect {
   readonly kind: "append_event";
+  /**
+   * The feature that owns this run.
+   *
+   * A run lives under its feature, so the store cannot derive where to write
+   * from the run identifier alone.
+   */
+  readonly feature: string;
   readonly runId: string;
   readonly event: EventDraftV1;
 }

--- a/tests/cli-composition.test.ts
+++ b/tests/cli-composition.test.ts
@@ -345,6 +345,7 @@ describe("composed command line", () => {
           }),
           plan: planOf({
             kind: "append_event" as const,
+            feature: "sample-feature",
             runId: "run-01",
             event: {
               contractVersion: "1.0.0",
@@ -382,8 +383,14 @@ describe("composed command line", () => {
       exitCode: 4,
       reasonCode: "runtime.state_corrupt",
       evidence: [
-        { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-        { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
       ],
       stateChanged: false,
       retryable: true,

--- a/tests/event-store-corruption.test.ts
+++ b/tests/event-store-corruption.test.ts
@@ -19,8 +19,8 @@ import {
 } from "@mestre-yoda/runtime/infra/fake";
 import { describe, expect, it } from "vitest";
 
-const eventsPath = ".brain/runs/run-01/events.jsonl";
-const snapshotPath = ".brain/runs/run-01/state.json";
+const eventsPath = ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+const snapshotPath = ".brain/02-features/sample-feature/runs/run-01/state.json";
 const rejectedPersistedText = "PRIVATE_PERSISTED_CORRUPTION_93847";
 const mutationOperations: readonly DurableOperation[] = [
   "create_directory",
@@ -99,7 +99,12 @@ async function persistedThreeEvents(): Promise<
   const ports = runtime(storage);
   for (const index of [1, 2, 3]) {
     await applyPlan(
-      planOf({ kind: "append_event", runId: "run-01", event: draft(index) }),
+      planOf({
+        kind: "append_event",
+        feature: "sample-feature",
+        runId: "run-01",
+        event: draft(index),
+      }),
       ports,
       {
         rootMode: "existing",
@@ -248,6 +253,7 @@ describe("persisted event-store corruption", () => {
         await applyPlan(
           planOf({
             kind: "append_event",
+            feature: "sample-feature",
             runId: "run-01",
             event: draft(4),
           }),

--- a/tests/event-store-fault-campaign.test.ts
+++ b/tests/event-store-fault-campaign.test.ts
@@ -34,8 +34,8 @@ import { describe, expect, it } from "vitest";
  */
 const campaignTimeoutMilliseconds = 180_000;
 
-const eventsPath = ".brain/runs/run-01/events.jsonl";
-const snapshotPath = ".brain/runs/run-01/state.json";
+const eventsPath = ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+const snapshotPath = ".brain/02-features/sample-feature/runs/run-01/state.json";
 const progressPath = ".brain/transactions/campaign-1/progress.json";
 const selectedOperations = [
   "inspect",
@@ -103,8 +103,12 @@ const crashCases: readonly CrashCase[] = [
   },
 ];
 
+// `RUN-06a` moved a run under the feature that opened it, so its root sits two
+// directories deeper than `.brain/runs/<run>` did. The transaction inspects
+// each parent on the way down, which is exactly the two additional inspections
+// counted here; no other operation moved.
 const executionCounts: Readonly<Record<SelectedOperation, number>> = {
-  inspect: 119,
+  inspect: 121,
   read_text: 14,
   create_directory_exclusive: 1,
   write_file: 9,
@@ -114,8 +118,11 @@ const executionCounts: Readonly<Record<SelectedOperation, number>> = {
   remove_file: 0,
 };
 
+// The four additional boundaries all fall before the transaction has begun:
+// creating and synchronizing the two extra parent directories happens outside
+// any phase, so only the `none` tally moves.
 const executionPhaseCounts: Readonly<Record<ExecutionPhase, number>> = {
-  none: 229,
+  none: 233,
   begun: 38,
   prepared: 10,
   publishing: 58,
@@ -123,8 +130,10 @@ const executionPhaseCounts: Readonly<Record<ExecutionPhase, number>> = {
 };
 
 const expectedDirectExecutionReceipts = [
-  "inspect:before:119:committed",
-  "inspect:after:119:committed",
+  // The last inspection moved with the run's depth: two additional parents on
+  // the way to `.brain/02-features/<feature>/runs/<run>`.
+  "inspect:before:121:committed",
+  "inspect:after:121:committed",
   "sync_directory:before:14:committed",
   "sync_directory:after:14:committed",
 ] as const;
@@ -225,7 +234,12 @@ async function oldSeed(): Promise<StorageSnapshot> {
   const ports = runtime(initial, "seed");
   for (const index of [1, 2, 3]) {
     await applyPlan(
-      planOf({ kind: "append_event", runId: "run-01", event: draft(index) }),
+      planOf({
+        kind: "append_event",
+        feature: "sample-feature",
+        runId: "run-01",
+        event: draft(index),
+      }),
       ports,
       { rootMode: "existing", eventReducers: reducers },
     );
@@ -311,7 +325,12 @@ function executionPhase(
 async function executeFourth(storage: Storage): Promise<unknown> {
   try {
     await applyPlan(
-      planOf({ kind: "append_event", runId: "run-01", event: draft(4) }),
+      planOf({
+        kind: "append_event",
+        feature: "sample-feature",
+        runId: "run-01",
+        event: draft(4),
+      }),
       runtime(storage, "campaign"),
       { rootMode: "existing", eventReducers: reducers },
     );
@@ -403,7 +422,10 @@ describe("event-store recovery fault campaign", () => {
     const newPair = pair(baseline);
     expect(selectedCounts(executionTrace)).toEqual(executionCounts);
     const executionBoundaries = boundaries(executionTrace);
-    expect(executionBoundaries).toHaveLength(348);
+    // Two directories deeper than `.brain/runs/<run>`, so the campaign reaches
+    // four more mutating boundaries: the two additional parents are created and
+    // synchronized. Nothing else about the publication changed.
+    expect(executionBoundaries).toHaveLength(352);
     const phases = new Map<ExecutionPhase, number>();
     const directReceipts: string[] = [];
 

--- a/tests/event-store-preparation.test.ts
+++ b/tests/event-store-preparation.test.ts
@@ -107,10 +107,13 @@ async function firstFiles(): Promise<{
   readonly snapshot: string;
 }> {
   const storage = memoryTransactionStorage({
-    directories: [".brain/transactions", ".brain/runs/run-01"],
+    directories: [
+      ".brain/transactions",
+      ".brain/02-features/sample-feature/runs/run-01",
+    ],
   });
   const prepared = await prepareEventAppend(
-    { runId: "run-01", event: draft(1) },
+    { feature: "sample-feature", runId: "run-01", event: draft(1) },
     services(storage),
   );
   const [events, snapshot] = prepared.effects;
@@ -122,10 +125,15 @@ function persistedStorage(files: {
   readonly snapshot: string;
 }) {
   return memoryTransactionStorage({
-    directories: [".brain/transactions", ".brain/runs/run-01"],
+    directories: [
+      ".brain/transactions",
+      ".brain/02-features/sample-feature/runs/run-01",
+    ],
     files: {
-      ".brain/runs/run-01/events.jsonl": files.events,
-      ".brain/runs/run-01/state.json": files.snapshot,
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl":
+        files.events,
+      ".brain/02-features/sample-feature/runs/run-01/state.json":
+        files.snapshot,
     },
   });
 }
@@ -142,9 +150,11 @@ async function failureCode(run: () => Promise<unknown>): Promise<string> {
 
 describe("event-store append preparation", () => {
   it("derives only the two canonical paths for a valid run ID", () => {
-    expect(eventStorePaths("run-01")).toEqual({
-      events: ".brain/runs/run-01/events.jsonl",
-      snapshot: ".brain/runs/run-01/state.json",
+    expect(
+      eventStorePaths({ feature: "sample-feature", runId: "run-01" }),
+    ).toEqual({
+      events: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+      snapshot: ".brain/02-features/sample-feature/runs/run-01/state.json",
     });
   });
 
@@ -154,8 +164,14 @@ describe("event-store append preparation", () => {
   ] as const)("publishes %s without forbidden evidence", (reasonCode) => {
     const result = transactionFailureResult(
       new TransactionFailure(reasonCode, [
-        { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-        { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
       ]),
     );
 
@@ -165,16 +181,19 @@ describe("event-store append preparation", () => {
 
   it("prepares a first append and exact-prefix successor without writes", async () => {
     const initial = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const first = await prepareEventAppend(
-      { runId: "run-01", event: draft(1) },
+      { feature: "sample-feature", runId: "run-01", event: draft(1) },
       services(initial),
     );
 
     expect(first.paths).toEqual({
-      events: ".brain/runs/run-01/events.jsonl",
-      snapshot: ".brain/runs/run-01/state.json",
+      events: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+      snapshot: ".brain/02-features/sample-feature/runs/run-01/state.json",
     });
     expect(first.effects.map(({ path }) => path)).toEqual([
       first.paths.events,
@@ -185,14 +204,17 @@ describe("event-store append preparation", () => {
 
     const [eventEffect, snapshotEffect] = first.effects;
     const successor = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
       files: {
         [first.paths.events]: eventEffect.content,
         [first.paths.snapshot]: snapshotEffect.content,
       },
     });
     const second = await prepareEventAppend(
-      { runId: "run-01", event: draft(2) },
+      { feature: "sample-feature", runId: "run-01", event: draft(2) },
       services(successor),
     );
     const secondEvents = second.effects[0].content;
@@ -210,7 +232,10 @@ describe("event-store append preparation", () => {
 
   it("refuses a first append whose replayed snapshot belongs to another run", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const mismatched: EventReducerRegistry<State> = {
       ...reducers,
@@ -219,7 +244,7 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(1) },
+        { feature: "sample-feature", runId: "run-01", event: draft(1) },
         { ...services(storage), reducers: mismatched },
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
@@ -241,7 +266,7 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         { ...services(storage), reducers: mismatched },
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
@@ -250,10 +275,13 @@ describe("event-store append preparation", () => {
 
   it("returns an immutable map view for prepared fingerprints", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const prepared = await prepareEventAppend(
-      { runId: "run-01", event: draft(1) },
+      { feature: "sample-feature", runId: "run-01", event: draft(1) },
       services(storage),
     );
 
@@ -281,12 +309,20 @@ describe("event-store append preparation", () => {
     "refuses unsafe run identifier %j before storage access",
     async (runId) => {
       const storage = memoryTransactionStorage({
-        directories: [".brain/transactions", ".brain/runs/run-01"],
+        directories: [
+          ".brain/transactions",
+          ".brain/02-features/sample-feature/runs/run-01",
+        ],
       });
 
-      expect(() => eventStorePaths(runId)).toThrow(EventIntegrityError);
+      expect(() =>
+        eventStorePaths({ feature: "sample-feature", runId }),
+      ).toThrow(EventIntegrityError);
       await expect(
-        prepareEventAppend({ runId, event: draft(1) }, services(storage)),
+        prepareEventAppend(
+          { feature: "sample-feature", runId, event: draft(1) },
+          services(storage),
+        ),
       ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
       expect(storage.calls()).toEqual([]);
     },
@@ -331,7 +367,10 @@ describe("event-store append preparation", () => {
     "sanitizes a rejected cross-realm Promise from %s without an unhandled rejection",
     async (_label, override) => {
       const storage = memoryTransactionStorage({
-        directories: [".brain/transactions", ".brain/runs/run-01"],
+        directories: [
+          ".brain/transactions",
+          ".brain/02-features/sample-feature/runs/run-01",
+        ],
       });
       const unhandled: unknown[] = [];
       const observe = (reason: unknown) => unhandled.push(reason);
@@ -339,7 +378,7 @@ describe("event-store append preparation", () => {
       try {
         await expect(
           prepareEventAppend(
-            { runId: "run-01", event: draft(1) },
+            { feature: "sample-feature", runId: "run-01", event: draft(1) },
             override(
               services(storage),
             ) as unknown as EventAppendServices<State>,
@@ -359,12 +398,15 @@ describe("event-store append preparation", () => {
 
   it("refuses a non-string run ID before storage access", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
 
     await expect(
       prepareEventAppend(
-        { runId: 1 as never, event: draft(1) },
+        { feature: "sample-feature", runId: 1 as never, event: draft(1) },
         services(storage),
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
@@ -373,7 +415,10 @@ describe("event-store append preparation", () => {
 
   it("uses the production proxy detector when none is supplied", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const prepared = services(storage);
     const withoutDetector: EventAppendServices<State> = {
@@ -384,19 +429,27 @@ describe("event-store append preparation", () => {
     };
 
     await expect(
-      prepareEventAppend({ runId: "run-01", event: draft(1) }, withoutDetector),
-    ).resolves.toMatchObject({ paths: eventStorePaths("run-01") });
+      prepareEventAppend(
+        { feature: "sample-feature", runId: "run-01", event: draft(1) },
+        withoutDetector,
+      ),
+    ).resolves.toMatchObject({
+      paths: eventStorePaths({ feature: "sample-feature", runId: "run-01" }),
+    });
   });
 
   it("sanitizes a detector that fails after the request precheck", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     let calls = 0;
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(1) },
+        { feature: "sample-feature", runId: "run-01", event: draft(1) },
         {
           ...services(storage),
           isProxy: () => {
@@ -414,14 +467,17 @@ describe("event-store append preparation", () => {
 
   it("sanitizes an unexpected event-domain value without exposing it", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const circular: Record<string, unknown> = {};
     circular.self = circular;
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(1) },
+        { feature: "sample-feature", runId: "run-01", event: draft(1) },
         {
           ...services(storage),
           schemaRegistry: {
@@ -443,16 +499,20 @@ describe("event-store append preparation", () => {
     async (_name, snapshot, reasonCode) => {
       const files = await firstFiles();
       const storage = memoryTransactionStorage({
-        directories: [".brain/transactions", ".brain/runs/run-01"],
+        directories: [
+          ".brain/transactions",
+          ".brain/02-features/sample-feature/runs/run-01",
+        ],
         files: {
-          ".brain/runs/run-01/events.jsonl": files.events,
-          ".brain/runs/run-01/state.json": snapshot,
+          ".brain/02-features/sample-feature/runs/run-01/events.jsonl":
+            files.events,
+          ".brain/02-features/sample-feature/runs/run-01/state.json": snapshot,
         },
       });
 
       await expect(
         prepareEventAppend(
-          { runId: "run-01", event: draft(2) },
+          { feature: "sample-feature", runId: "run-01", event: draft(2) },
           services(storage),
         ),
       ).rejects.toMatchObject({ reasonCode });
@@ -467,7 +527,10 @@ describe("event-store append preparation", () => {
 
   it("refuses an inspected file with an invalid fingerprint shape", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
@@ -479,7 +542,7 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(1) },
+        { feature: "sample-feature", runId: "run-01", event: draft(1) },
         { ...services(storage), durableFileSystem },
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
@@ -489,23 +552,33 @@ describe("event-store append preparation", () => {
     const files = await firstFiles();
     const snapshot = JSON.parse(files.snapshot) as SnapshotV1;
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
       files: {
-        ".brain/runs/run-01/events.jsonl": files.events,
-        ".brain/runs/run-01/state.json": `${canonicalizeJson({ ...snapshot, status: "private" })}\n`,
+        ".brain/02-features/sample-feature/runs/run-01/events.jsonl":
+          files.events,
+        ".brain/02-features/sample-feature/runs/run-01/state.json": `${canonicalizeJson({ ...snapshot, status: "private" })}\n`,
       },
     });
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         services(storage),
       ),
     ).rejects.toMatchObject({
       reasonCode: "runtime.state_corrupt",
       evidence: [
-        { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-        { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
       ],
     });
   });
@@ -523,12 +596,17 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         { ...services(storage), durableFileSystem },
       ),
     ).rejects.toMatchObject({
       reasonCode: "runtime.revision_conflict",
-      evidence: [{ kind: "artifact", ref: ".brain/runs/run-01/state.json" }],
+      evidence: [
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
+      ],
     });
   });
 
@@ -560,7 +638,10 @@ describe("event-store append preparation", () => {
     "sanitizes a rejected native Promise from %s without an unhandled rejection",
     async (_label, override) => {
       const storage = memoryTransactionStorage({
-        directories: [".brain/transactions", ".brain/runs/run-01"],
+        directories: [
+          ".brain/transactions",
+          ".brain/02-features/sample-feature/runs/run-01",
+        ],
       });
       const unhandled: unknown[] = [];
       const observe = (reason: unknown) => unhandled.push(reason);
@@ -568,7 +649,7 @@ describe("event-store append preparation", () => {
       try {
         await expect(
           prepareEventAppend(
-            { runId: "run-01", event: draft(1) },
+            { feature: "sample-feature", runId: "run-01", event: draft(1) },
             override(
               services(storage),
             ) as unknown as EventAppendServices<State>,
@@ -589,13 +670,19 @@ describe("event-store append preparation", () => {
   it("rejects a missing stream/snapshot pair without reading or writing", async () => {
     const files = await firstFiles();
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
-      files: { ".brain/runs/run-01/events.jsonl": files.events },
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
+      files: {
+        ".brain/02-features/sample-feature/runs/run-01/events.jsonl":
+          files.events,
+      },
     });
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         services(storage),
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
@@ -605,20 +692,32 @@ describe("event-store append preparation", () => {
   it("rejects a missing snapshot when the event stream is absent", async () => {
     const files = await firstFiles();
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
-      files: { ".brain/runs/run-01/state.json": files.snapshot },
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
+      files: {
+        ".brain/02-features/sample-feature/runs/run-01/state.json":
+          files.snapshot,
+      },
     });
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         services(storage),
       ),
     ).rejects.toMatchObject({
       reasonCode: "runtime.state_corrupt",
       evidence: [
-        { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-        { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
       ],
     });
     expect(storage.calls()).toEqual(["inspect", "inspect"]);
@@ -629,15 +728,18 @@ describe("event-store append preparation", () => {
     const storage = memoryTransactionStorage({
       directories: [
         ".brain/transactions",
-        ".brain/runs/run-01",
-        ".brain/runs/run-01/events.jsonl",
+        ".brain/02-features/sample-feature/runs/run-01",
+        ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
       ],
-      files: { ".brain/runs/run-01/state.json": files.snapshot },
+      files: {
+        ".brain/02-features/sample-feature/runs/run-01/state.json":
+          files.snapshot,
+      },
     });
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         services(storage),
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
@@ -659,14 +761,20 @@ describe("event-store append preparation", () => {
 
       await expect(
         prepareEventAppend(
-          { runId: "run-01", event: draft(2) },
+          { feature: "sample-feature", runId: "run-01", event: draft(2) },
           { ...services(storage), durableFileSystem },
         ),
       ).rejects.toMatchObject({
         reasonCode: "runtime.state_corrupt",
         evidence: [
-          { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-          { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+          {
+            kind: "event",
+            ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+          },
+          {
+            kind: "artifact",
+            ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+          },
         ],
       });
     },
@@ -685,14 +793,20 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         { ...services(storage), durableFileSystem },
       ),
     ).rejects.toMatchObject({
       reasonCode: "runtime.state_corrupt",
       evidence: [
-        { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-        { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
       ],
     });
   });
@@ -711,7 +825,7 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         { ...services(storage), durableFileSystem },
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.state_corrupt" });
@@ -739,14 +853,14 @@ describe("event-store append preparation", () => {
     expect(
       await failureCode(() =>
         prepareEventAppend(
-          { runId: "run-01", event: draft(2) },
+          { feature: "sample-feature", runId: "run-01", event: draft(2) },
           services(storage),
         ),
       ),
     ).toBe("runtime.state_corrupt");
     expect(storage.snapshot().files).toEqual({
-      ".brain/runs/run-01/events.jsonl": events,
-      ".brain/runs/run-01/state.json": snapshot,
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl": events,
+      ".brain/02-features/sample-feature/runs/run-01/state.json": snapshot,
     });
   });
 
@@ -766,7 +880,7 @@ describe("event-store append preparation", () => {
       expect(
         await failureCode(() =>
           prepareEventAppend(
-            { runId: "run-01", event: draft(2) },
+            { feature: "sample-feature", runId: "run-01", event: draft(2) },
             services(storage),
           ),
         ),
@@ -784,7 +898,7 @@ describe("event-store append preparation", () => {
     let failure: TransactionFailure | undefined;
     try {
       await prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         services(storage),
       );
     } catch (error: unknown) {
@@ -815,7 +929,7 @@ describe("event-store append preparation", () => {
       },
     };
     const pending = prepareEventAppend(
-      { runId: "run-01", event: mutable },
+      { feature: "sample-feature", runId: "run-01", event: mutable },
       { ...services(storage), durableFileSystem },
     );
     mutable.operation = "attacker-change";
@@ -827,7 +941,10 @@ describe("event-store append preparation", () => {
 
   it("snapshots reducers before the first durable await", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const mutable: EventReducerRegistry<State> & {
       seed: State & { runId: string };
@@ -854,7 +971,7 @@ describe("event-store append preparation", () => {
     };
 
     const prepared = await prepareEventAppend(
-      { runId: "run-01", event: draft(1) },
+      { feature: "sample-feature", runId: "run-01", event: draft(1) },
       { ...services(storage), durableFileSystem, reducers: mutable },
     );
 
@@ -867,7 +984,10 @@ describe("event-store append preparation", () => {
 
   it("refuses throwing input accessors without storage access", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const input = Object.defineProperty({ runId: "run-01" }, "event", {
       enumerable: true,
@@ -895,7 +1015,7 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         { ...services(storage), durableFileSystem },
       ),
     ).rejects.toMatchObject({ reasonCode: "runtime.revision_conflict" });
@@ -915,18 +1035,26 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(2) },
+        { feature: "sample-feature", runId: "run-01", event: draft(2) },
         { ...services(storage), durableFileSystem },
       ),
     ).rejects.toMatchObject({
       reasonCode: "runtime.revision_conflict",
-      evidence: [{ kind: "event", ref: ".brain/runs/run-01/events.jsonl" }],
+      evidence: [
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+      ],
     });
   });
 
   it("classifies forged storage failures as sanitized internal failures", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
@@ -940,7 +1068,7 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(1) },
+        { feature: "sample-feature", runId: "run-01", event: draft(1) },
         { ...services(storage), durableFileSystem },
       ),
     ).rejects.toMatchObject({
@@ -991,12 +1119,15 @@ describe("event-store append preparation", () => {
     "sanitizes a forged %s capability error",
     async (_label, override) => {
       const storage = memoryTransactionStorage({
-        directories: [".brain/transactions", ".brain/runs/run-01"],
+        directories: [
+          ".brain/transactions",
+          ".brain/02-features/sample-feature/runs/run-01",
+        ],
       });
 
       await expect(
         prepareEventAppend(
-          { runId: "run-01", event: draft(1) },
+          { feature: "sample-feature", runId: "run-01", event: draft(1) },
           override(services(storage)),
         ),
       ).rejects.toMatchObject({
@@ -1009,7 +1140,10 @@ describe("event-store append preparation", () => {
 
   it("rejects root and draft proxies after proxy detection without traps", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     let traps = 0;
     const handler = {
@@ -1018,7 +1152,10 @@ describe("event-store append preparation", () => {
         throw new Error("proxy trap must not run");
       },
     };
-    const root = new Proxy({ runId: "run-01", event: draft(1) }, handler);
+    const root = new Proxy(
+      { feature: "sample-feature", runId: "run-01", event: draft(1) },
+      handler,
+    );
     const event = new Proxy(draft(1), handler);
 
     for (const input of [root, { runId: "run-01", event }]) {
@@ -1032,7 +1169,10 @@ describe("event-store append preparation", () => {
 
   it("rejects a hostile registry before storage without running its traps", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     let traps = 0;
     const registryProxy = new Proxy(reducers, {
@@ -1044,7 +1184,7 @@ describe("event-store append preparation", () => {
 
     await expect(
       prepareEventAppend(
-        { runId: "run-01", event: draft(1) },
+        { feature: "sample-feature", runId: "run-01", event: draft(1) },
         { ...services(storage), reducers: registryProxy },
       ),
     ).rejects.toMatchObject({
@@ -1059,7 +1199,10 @@ describe("event-store append preparation", () => {
     "sanitizes a rejected native Promise from a %s as state corruption",
     async (kind) => {
       const storage = memoryTransactionStorage({
-        directories: [".brain/transactions", ".brain/runs/run-01"],
+        directories: [
+          ".brain/transactions",
+          ".brain/02-features/sample-feature/runs/run-01",
+        ],
       });
       const asyncRegistry =
         kind === "reducer"
@@ -1074,7 +1217,7 @@ describe("event-store append preparation", () => {
 
       await expect(
         prepareEventAppend(
-          { runId: "run-01", event: draft(1) },
+          { feature: "sample-feature", runId: "run-01", event: draft(1) },
           {
             ...services(storage),
             reducers: asyncRegistry as unknown as EventReducerRegistry<State>,
@@ -1083,8 +1226,14 @@ describe("event-store append preparation", () => {
       ).rejects.toMatchObject({
         reasonCode: "runtime.state_corrupt",
         evidence: [
-          { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-          { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+          {
+            kind: "event",
+            ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+          },
+          {
+            kind: "artifact",
+            ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+          },
         ],
       });
       await Promise.resolve();
@@ -1093,10 +1242,13 @@ describe("event-store append preparation", () => {
 
   it("does not permit runtime mutation of prepared effects or fingerprints", async () => {
     const storage = memoryTransactionStorage({
-      directories: [".brain/transactions", ".brain/runs/run-01"],
+      directories: [
+        ".brain/transactions",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ],
     });
     const prepared = await prepareEventAppend(
-      { runId: "run-01", event: draft(1) },
+      { feature: "sample-feature", runId: "run-01", event: draft(1) },
       services(storage),
     );
     const events = prepared.effects[0].content;

--- a/tests/event-store-transaction.test.ts
+++ b/tests/event-store-transaction.test.ts
@@ -97,7 +97,12 @@ function fakeRuntime(
 }
 
 function eventPlan(index: number) {
-  return planOf({ kind: "append_event", runId: "run-01", event: draft(index) });
+  return planOf({
+    kind: "append_event",
+    feature: "sample-feature",
+    runId: "run-01",
+    event: draft(index),
+  });
 }
 
 function manifestPaths(storage: ReturnType<typeof memoryTransactionStorage>) {
@@ -119,13 +124,20 @@ describe("event-store transaction integration", () => {
     });
 
     expect(manifestPaths(storage)).toEqual([
-      ".brain/runs",
-      ".brain/runs/run-01",
-      ".brain/runs/run-01/events.jsonl",
-      ".brain/runs/run-01/state.json",
+      ".brain/02-features",
+      ".brain/02-features/sample-feature",
+      ".brain/02-features/sample-feature/runs",
+      ".brain/02-features/sample-feature/runs/run-01",
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+      ".brain/02-features/sample-feature/runs/run-01/state.json",
     ]);
     expect(storage.snapshot().directories).toEqual(
-      expect.arrayContaining([".brain/runs", ".brain/runs/run-01"]),
+      expect.arrayContaining([
+        ".brain/02-features",
+        ".brain/02-features/sample-feature",
+        ".brain/02-features/sample-feature/runs",
+        ".brain/02-features/sample-feature/runs/run-01",
+      ]),
     );
   });
 
@@ -144,12 +156,18 @@ describe("event-store transaction integration", () => {
 
     const second = storage.snapshot();
     expect(
-      second.files[".brain/runs/run-01/events.jsonl"]?.startsWith(
-        first.files[".brain/runs/run-01/events.jsonl"] ?? "",
+      second.files[
+        ".brain/02-features/sample-feature/runs/run-01/events.jsonl"
+      ]?.startsWith(
+        first.files[
+          ".brain/02-features/sample-feature/runs/run-01/events.jsonl"
+        ] ?? "",
       ),
     ).toBe(true);
     const state = JSON.parse(
-      second.files[".brain/runs/run-01/state.json"] ?? "",
+      second.files[
+        ".brain/02-features/sample-feature/runs/run-01/state.json"
+      ] ?? "",
     ) as SnapshotV1;
     expect(state.eventCursor).toBe(2);
   });
@@ -160,8 +178,18 @@ describe("event-store transaction integration", () => {
     await expect(
       applyPlan(
         planOf(
-          { kind: "append_event", runId: "run-01", event: draft(1) },
-          { kind: "append_event", runId: "run-01", event: draft(2) },
+          {
+            kind: "append_event",
+            feature: "sample-feature",
+            runId: "run-01",
+            event: draft(1),
+          },
+          {
+            kind: "append_event",
+            feature: "sample-feature",
+            runId: "run-01",
+            event: draft(2),
+          },
         ),
         ports,
         { rootMode: "existing", eventReducers: reducers },
@@ -234,8 +262,14 @@ describe("event-store transaction integration", () => {
         }),
       ).rejects.toEqual(
         new TransactionFailure("runtime.state_corrupt", [
-          { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-          { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+          {
+            kind: "event",
+            ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+          },
+          {
+            kind: "artifact",
+            ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+          },
         ]),
       );
       expect(storage.calls()).toEqual([]);
@@ -369,9 +403,13 @@ describe("event-store transaction integration", () => {
     );
 
     const events =
-      storage.snapshot().files[".brain/runs/run-01/events.jsonl"] ?? "";
+      storage.snapshot().files[
+        ".brain/02-features/sample-feature/runs/run-01/events.jsonl"
+      ] ?? "";
     const snapshot = JSON.parse(
-      storage.snapshot().files[".brain/runs/run-01/state.json"] ?? "",
+      storage.snapshot().files[
+        ".brain/02-features/sample-feature/runs/run-01/state.json"
+      ] ?? "",
     ) as SnapshotV1;
     expect(mutated).toBe(true);
     expect(events).toContain('"operation":"sdd.step-1"');
@@ -384,14 +422,25 @@ describe("event-store transaction integration", () => {
 
     await expect(
       applyPlan(
-        planOf({ kind: "append_event", runId: "run-01", event }),
+        planOf({
+          kind: "append_event",
+          feature: "sample-feature",
+          runId: "run-01",
+          event,
+        }),
         ports,
         { rootMode: "existing", eventReducers: reducers },
       ),
     ).rejects.toEqual(
       new TransactionFailure("runtime.state_corrupt", [
-        { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-        { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
       ]),
     );
     expect(storage.calls()).toEqual([]);
@@ -400,10 +449,13 @@ describe("event-store transaction integration", () => {
   it.each([
     {
       kind: "write_file" as const,
-      path: ".brain/runs/run-01/events.jsonl",
+      path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
       content: "forged",
     },
-    { kind: "delete_file" as const, path: ".brain/runs/run-01/state.json" },
+    {
+      kind: "delete_file" as const,
+      path: ".brain/02-features/sample-feature/runs/run-01/state.json",
+    },
   ])(
     "rejects direct $kind targeting the selected event-store paths before I/O",
     async (effect) => {
@@ -412,7 +464,12 @@ describe("event-store transaction integration", () => {
       await expect(
         applyPlan(
           planOf(
-            { kind: "append_event", runId: "run-01", event: draft(1) },
+            {
+              kind: "append_event",
+              feature: "sample-feature",
+              runId: "run-01",
+              event: draft(1),
+            },
             effect,
           ),
           ports,
@@ -423,7 +480,10 @@ describe("event-store transaction integration", () => {
     },
   );
 
-  it.each([".brain/runs/run-01/EVENTS.JSONL", ".brain/runs/RUN-01/state.json"])(
+  it.each([
+    ".brain/02-features/sample-feature/runs/run-01/EVENTS.JSONL",
+    ".brain/02-features/sample-feature/runs/RUN-01/state.json",
+  ])(
     "rejects a case-colliding direct destination %s before I/O",
     async (path) => {
       const { storage, ports } = fakeRuntime();
@@ -431,7 +491,12 @@ describe("event-store transaction integration", () => {
       await expect(
         applyPlan(
           planOf(
-            { kind: "append_event", runId: "run-01", event: draft(1) },
+            {
+              kind: "append_event",
+              feature: "sample-feature",
+              runId: "run-01",
+              event: draft(1),
+            },
             { kind: "write_file", path, content: "forged" },
           ),
           ports,
@@ -451,7 +516,12 @@ describe("event-store transaction integration", () => {
           path: ".brain/ordinary.json",
           content: "ordinary",
         },
-        { kind: "append_event", runId: "run-01", event: draft(1) },
+        {
+          kind: "append_event",
+          feature: "sample-feature",
+          runId: "run-01",
+          event: draft(1),
+        },
       ),
       ports,
       { rootMode: "existing", eventReducers: reducers },
@@ -459,14 +529,19 @@ describe("event-store transaction integration", () => {
 
     expect(manifestPaths(storage)).toEqual([
       ".brain/ordinary.json",
-      ".brain/runs",
-      ".brain/runs/run-01",
-      ".brain/runs/run-01/events.jsonl",
-      ".brain/runs/run-01/state.json",
+      ".brain/02-features",
+      ".brain/02-features/sample-feature",
+      ".brain/02-features/sample-feature/runs",
+      ".brain/02-features/sample-feature/runs/run-01",
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+      ".brain/02-features/sample-feature/runs/run-01/state.json",
     ]);
   });
 
-  it.each([".brain/runs/run-01/events.jsonl", ".brain/runs/run-01/state.json"])(
+  it.each([
+    ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+    ".brain/02-features/sample-feature/runs/run-01/state.json",
+  ])(
     "fails a stale %s observation before transaction creation",
     async (changedPath) => {
       const { storage, ports } = fakeRuntime();
@@ -503,7 +578,11 @@ describe("event-store transaction integration", () => {
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
       inspect(path): Promise<DurableEntry> {
-        if (path === ".brain/runs/run-01/events.jsonl" && ++reads === 2) {
+        if (
+          path ===
+            ".brain/02-features/sample-feature/runs/run-01/events.jsonl" &&
+          ++reads === 2
+        ) {
           return Promise.reject(new Error("/private/fresh-inspection"));
         }
         return storage.durableFileSystem.inspect(path);
@@ -522,8 +601,8 @@ describe("event-store transaction integration", () => {
 
   it("blocks a stream mutation at the declarative pre-marker gate", async () => {
     const { storage, ports } = fakeRuntime();
-    const events = ".brain/runs/run-01/events.jsonl";
-    const snapshot = ".brain/runs/run-01/state.json";
+    const events = ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+    const snapshot = ".brain/02-features/sample-feature/runs/run-01/state.json";
     let reads = 0;
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
@@ -572,7 +651,12 @@ describe("event-store transaction integration", () => {
 
     await applyPlan(
       planOf(
-        { kind: "append_event", runId: "run-01", event: draft(1) },
+        {
+          kind: "append_event",
+          feature: "sample-feature",
+          runId: "run-01",
+          event: draft(1),
+        },
         { kind: "emit", channel: "structured", text: "committed\n" },
       ),
       { ...ports, output },

--- a/tests/node-event-store.test.ts
+++ b/tests/node-event-store.test.ts
@@ -33,8 +33,8 @@ import type { DurableFileSystem } from "@mestre-yoda/runtime/ports";
 import { describe, expect, it, type TestContext } from "vitest";
 
 const runId = "run-01";
-const eventsPath = `.brain/runs/${runId}/events.jsonl`;
-const snapshotPath = `.brain/runs/${runId}/state.json`;
+const eventsPath = `.brain/02-features/sample-feature/runs/${runId}/events.jsonl`;
+const snapshotPath = `.brain/02-features/sample-feature/runs/${runId}/state.json`;
 const execFileAsync = promisify(execFile);
 const readOnlyUnsupported =
   process.platform === "win32" || process.geteuid?.() === 0;
@@ -180,7 +180,12 @@ async function append(
   selectedRunId = runId,
 ) {
   return applyPlan(
-    planOf({ kind: "append_event", runId: selectedRunId, event: draft(index) }),
+    planOf({
+      kind: "append_event",
+      feature: "sample-feature",
+      runId: selectedRunId,
+      event: draft(index),
+    }),
     runtime(root, prefix),
     {
       rootMode: "existing",
@@ -214,7 +219,7 @@ async function assertEscapingSymlinkRefusal(
 ): Promise<void> {
   const symlinkResult = await temporaryProject(async (root, outside) => {
     await projectScaffold(root);
-    const run = join(root, ".brain/runs/run-01");
+    const run = join(root, ".brain/02-features/sample-feature/runs/run-01");
     const target = join(outside, name);
     await mkdir(run, { recursive: true });
     await writeFile(target, "outside sentinel", "utf8");
@@ -243,7 +248,12 @@ describe("node event store", () => {
       const firstRuntime = runtime(root, "first");
       for (const index of [1, 2]) {
         await applyPlan(
-          planOf({ kind: "append_event", runId, event: draft(index) }),
+          planOf({
+            kind: "append_event",
+            feature: "sample-feature",
+            runId,
+            event: draft(index),
+          }),
           firstRuntime,
           { rootMode: "existing", eventReducers: reducers },
         );
@@ -274,7 +284,9 @@ describe("node event store", () => {
   it("refuses a case-colliding run directory without creating the requested spelling", async () => {
     await temporaryProject(async (root) => {
       await projectScaffold(root);
-      await mkdir(join(root, ".brain/runs/RUN-01"), { recursive: true });
+      await mkdir(join(root, ".brain/02-features/sample-feature/runs/RUN-01"), {
+        recursive: true,
+      });
 
       await expectRefusal(append(root, "case", 1));
       await expect(readFile(join(root, eventsPath), "utf8")).rejects.toThrow();
@@ -288,7 +300,12 @@ describe("node event store", () => {
 
       await expectRefusal(
         applyPlan(
-          planOf({ kind: "append_event", runId: "run-é", event: draft(1) }),
+          planOf({
+            kind: "append_event",
+            feature: "sample-feature",
+            runId: "run-é",
+            event: draft(1),
+          }),
           runtime(root, "unicode", counted.durableFileSystem),
           { rootMode: "existing", eventReducers: reducers },
         ),
@@ -302,7 +319,7 @@ describe("node event store", () => {
     async () => {
       await temporaryProject(async (root) => {
         await projectScaffold(root);
-        const run = join(root, ".brain/runs/run-01");
+        const run = join(root, ".brain/02-features/sample-feature/runs/run-01");
         await mkdir(run, { recursive: true });
         await execFileAsync("mkfifo", [join(run, "events.jsonl")]);
 
@@ -316,7 +333,7 @@ describe("node event store", () => {
     async () => {
       await temporaryProject(async (root) => {
         await projectScaffold(root);
-        const run = join(root, ".brain/runs/run-01");
+        const run = join(root, ".brain/02-features/sample-feature/runs/run-01");
         await mkdir(run, { recursive: true });
         await chmod(run, 0o500);
         try {

--- a/tests/runtime-composition.test.ts
+++ b/tests/runtime-composition.test.ts
@@ -547,11 +547,13 @@ describe("effect plan application", () => {
     const { storage, ports } = fakeRuntime();
     const invalidRunId = {
       kind: "append_event",
+      feature: "sample-feature",
       runId: "../run-01",
       event: eventDraft(1),
     };
     const nonStringRunId = {
       kind: "append_event",
+      feature: "sample-feature",
       runId: 7,
       event: eventDraft(1),
     };
@@ -607,13 +609,18 @@ describe("effect plan application", () => {
         ".brain",
         ".brain/transactions",
         ".brain/runs",
-        ".brain/runs/run-01",
+        ".brain/02-features/sample-feature/runs/run-01",
       ],
     });
 
     await expect(
       applyPlan(
-        planOf({ kind: "append_event", runId: "run-01", event: eventDraft(1) }),
+        planOf({
+          kind: "append_event",
+          feature: "sample-feature",
+          runId: "run-01",
+          event: eventDraft(1),
+        }),
         ports,
         { rootMode: "existing", eventReducers },
       ),
@@ -623,12 +630,17 @@ describe("effect plan application", () => {
       snapshot.files[".brain/transactions/transaction-1/manifest.json"] ?? "",
     ) as { readonly operations: readonly { readonly path: string }[] };
     expect(manifest.operations.map(({ path }) => path)).toEqual([
-      ".brain/runs/run-01/events.jsonl",
-      ".brain/runs/run-01/state.json",
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+      ".brain/02-features/sample-feature/runs/run-01/state.json",
     ]);
-    const events = snapshot.files[".brain/runs/run-01/events.jsonl"] ?? "";
+    const events =
+      snapshot.files[
+        ".brain/02-features/sample-feature/runs/run-01/events.jsonl"
+      ] ?? "";
     const state = JSON.parse(
-      snapshot.files[".brain/runs/run-01/state.json"] ?? "",
+      snapshot.files[
+        ".brain/02-features/sample-feature/runs/run-01/state.json"
+      ] ?? "",
     ) as SnapshotV1;
     const sealed = JSON.parse(events) as { readonly eventHash: string };
     const schemaRegistry = createSchemaRegistry();
@@ -647,12 +659,16 @@ describe("effect plan application", () => {
     expect(state.eventHash).toBe(sealed.eventHash);
     expect(replayed.snapshot).toEqual(state);
     expect(events).toMatch(/\n$/u);
-    expect(snapshot.files[".brain/runs/run-01/state.json"]).toMatch(/\n$/u);
+    expect(
+      snapshot.files[
+        ".brain/02-features/sample-feature/runs/run-01/state.json"
+      ],
+    ).toMatch(/\n$/u);
   });
 
   it("rejects a special event-store entry observed after preparation", async () => {
     const { storage, ports } = fakeRuntime();
-    const events = ".brain/runs/run-01/events.jsonl";
+    const events = ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
     let reads = 0;
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
@@ -666,7 +682,12 @@ describe("effect plan application", () => {
 
     await expect(
       applyPlan(
-        planOf({ kind: "append_event", runId: "run-01", event: eventDraft(1) }),
+        planOf({
+          kind: "append_event",
+          feature: "sample-feature",
+          runId: "run-01",
+          event: eventDraft(1),
+        }),
         { ...ports, durableFileSystem },
         { rootMode: "existing", eventReducers },
       ),
@@ -683,7 +704,12 @@ describe("effect plan application", () => {
 
     await expect(
       applyPlan(
-        planOf({ kind: "append_event", runId: "run-01", event: eventDraft(1) }),
+        planOf({
+          kind: "append_event",
+          feature: "sample-feature",
+          runId: "run-01",
+          event: eventDraft(1),
+        }),
         ports,
         {
           rootMode: "existing",
@@ -692,8 +718,14 @@ describe("effect plan application", () => {
       ),
     ).rejects.toEqual(
       new TransactionFailure("runtime.state_corrupt", [
-        { kind: "event", ref: ".brain/runs/run-01/events.jsonl" },
-        { kind: "artifact", ref: ".brain/runs/run-01/state.json" },
+        {
+          kind: "event",
+          ref: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+        },
+        {
+          kind: "artifact",
+          ref: ".brain/02-features/sample-feature/runs/run-01/state.json",
+        },
       ]),
     );
     expect(storage.calls()).toEqual([]);

--- a/tests/support/lease-guard.ts
+++ b/tests/support/lease-guard.ts
@@ -39,10 +39,10 @@ export type GuardedFixture = ReturnType<typeof guardedFixture>;
  * durable filesystem, because fencing only means anything when the guard and
  * the mutation land on the same storage.
  */
-export function guardedFixture() {
-  const storage = memoryTransactionStorage({
-    directories: [".brain/runs/run-01"],
-  });
+export function guardedFixture(
+  directories: readonly string[] = [".brain/runs/run-01"],
+) {
+  const storage = memoryTransactionStorage({ directories: [...directories] });
   let now = new Date("2026-08-11T00:00:00.000Z").getTime();
   const services: TransactionServices = {
     clock: { now: () => new Date(now) },

--- a/tests/transaction-execution.test.ts
+++ b/tests/transaction-execution.test.ts
@@ -72,7 +72,7 @@ describe("managed transaction execution", () => {
         rootMode: "existing",
         eventStorePreconditions: [
           {
-            path: ".brain/runs/run-01/events.jsonl",
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
             expected: { kind: "missing" },
           },
           { path: ".brain/outside.json", expected: { kind: "missing" } },
@@ -84,11 +84,11 @@ describe("managed transaction execution", () => {
       {
         eventStorePreconditions: [
           {
-            path: ".brain/runs/run-01/events.jsonl",
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
             expected: { kind: "missing" },
           },
           {
-            path: ".brain/runs/run-01/state.json",
+            path: ".brain/02-features/sample-feature/runs/run-01/state.json",
             expected: { kind: "missing" },
           },
         ],
@@ -188,7 +188,7 @@ describe("managed transaction execution", () => {
         rootMode: "existing",
         eventStorePreconditions: [
           {
-            path: ".brain/runs/run-01/events.jsonl",
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
             expected: { kind: "missing" },
             extra: true,
           },
@@ -203,7 +203,7 @@ describe("managed transaction execution", () => {
         eventStorePreconditions: [
           { path: 7, expected: { kind: "missing" } },
           {
-            path: ".brain/runs/run-01/state.json",
+            path: ".brain/02-features/sample-feature/runs/run-01/state.json",
             expected: { kind: "missing" },
           },
         ],
@@ -215,7 +215,7 @@ describe("managed transaction execution", () => {
         rootMode: "existing",
         eventStorePreconditions: [
           {
-            path: ".brain/runs/run-01/events.jsonl",
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
             expected: new Proxy({ kind: "missing" }, {}),
           },
           {},
@@ -230,7 +230,10 @@ describe("managed transaction execution", () => {
         return {
           rootMode: "existing",
           eventStorePreconditions: [
-            { path: ".brain/runs/run-01/events.jsonl", expected },
+            {
+              path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+              expected,
+            },
             {},
           ],
         };
@@ -242,11 +245,11 @@ describe("managed transaction execution", () => {
         rootMode: "existing",
         eventStorePreconditions: [
           {
-            path: ".brain/runs/run-01/events.jsonl",
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
             expected: { kind: "directory" },
           },
           {
-            path: ".brain/runs/run-01/state.json",
+            path: ".brain/02-features/sample-feature/runs/run-01/state.json",
             expected: { kind: "missing" },
           },
         ],
@@ -258,11 +261,11 @@ describe("managed transaction execution", () => {
         rootMode: "existing",
         eventStorePreconditions: [
           {
-            path: ".brain/runs/run-01/state.json",
+            path: ".brain/02-features/sample-feature/runs/run-01/state.json",
             expected: { kind: "missing" },
           },
           {
-            path: ".brain/runs/run-01/events.jsonl",
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
             expected: { kind: "missing" },
           },
         ],
@@ -274,11 +277,11 @@ describe("managed transaction execution", () => {
         rootMode: "existing",
         eventStorePreconditions: [
           {
-            path: ".brain/runs/run-01/events.jsonl",
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
             expected: { kind: "missing" },
           },
           {
-            path: ".brain/runs/run-02/state.json",
+            path: ".brain/02-features/sample-feature/runs/run-02/state.json",
             expected: { kind: "missing" },
           },
         ],
@@ -294,7 +297,7 @@ describe("managed transaction execution", () => {
             expected: { kind: "missing" },
           },
           {
-            path: ".brain/runs/run-01/state.json",
+            path: ".brain/02-features/sample-feature/runs/run-01/state.json",
             expected: { kind: "missing" },
           },
         ],
@@ -320,8 +323,10 @@ describe("managed transaction execution", () => {
       const storage = memoryTransactionStorage({
         directories: [".brain", ".brain/transactions"],
       });
-      const eventPath = ".brain/runs/run-01/events.jsonl";
-      const snapshotPath = ".brain/runs/run-01/state.json";
+      const eventPath =
+        ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+      const snapshotPath =
+        ".brain/02-features/sample-feature/runs/run-01/state.json";
       const durableFileSystem: DurableFileSystem = {
         ...storage.durableFileSystem,
         inspect(path) {
@@ -359,8 +364,10 @@ describe("managed transaction execution", () => {
     const storage = memoryTransactionStorage({
       directories: [".brain", ".brain/transactions"],
     });
-    const eventPath = ".brain/runs/run-01/events.jsonl";
-    const snapshotPath = ".brain/runs/run-01/state.json";
+    const eventPath =
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+    const snapshotPath =
+      ".brain/02-features/sample-feature/runs/run-01/state.json";
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
       inspect(path) {
@@ -394,8 +401,10 @@ describe("managed transaction execution", () => {
     const storage = memoryTransactionStorage({
       directories: [".brain", ".brain/transactions"],
     });
-    const eventPath = ".brain/runs/run-01/events.jsonl";
-    const snapshotPath = ".brain/runs/run-01/state.json";
+    const eventPath =
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+    const snapshotPath =
+      ".brain/02-features/sample-feature/runs/run-01/state.json";
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
       inspect(path) {
@@ -431,8 +440,10 @@ describe("managed transaction execution", () => {
   });
 
   it("accepts matching file event-store preconditions before execution", async () => {
-    const eventPath = ".brain/runs/run-01/events.jsonl";
-    const snapshotPath = ".brain/runs/run-01/state.json";
+    const eventPath =
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+    const snapshotPath =
+      ".brain/02-features/sample-feature/runs/run-01/state.json";
     const storage = memoryTransactionStorage({
       directories: [
         ".brain",
@@ -504,8 +515,10 @@ describe("managed transaction execution", () => {
     const storage = memoryTransactionStorage({
       directories: [".brain", ".brain/transactions"],
     });
-    const eventPath = ".brain/runs/run-01/events.jsonl";
-    const snapshotPath = ".brain/runs/run-01/state.json";
+    const eventPath =
+      ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
+    const snapshotPath =
+      ".brain/02-features/sample-feature/runs/run-01/state.json";
     const durableFileSystem: DurableFileSystem = {
       ...storage.durableFileSystem,
       inspect(path) {

--- a/tests/transaction-lease-guard.test.ts
+++ b/tests/transaction-lease-guard.test.ts
@@ -165,7 +165,9 @@ describe("protected transaction lease guard", () => {
   });
 
   it("carries declared event-store preconditions alongside the guard", async () => {
-    const subject = fixture();
+    // The event store writes under the feature that opened the run, so this
+    // test seeds that chain rather than the fixture's arbitrary caller path.
+    const subject = fixture([".brain/02-features/sample-feature/runs/run-01"]);
     const held = await subject.locks.acquire(acquireRequest());
     if (held.kind !== "acquired") throw new Error("Expected an acquired lease");
 
@@ -175,7 +177,7 @@ describe("protected transaction lease guard", () => {
     );
     // The run's own event store is the ordinary caller of a guarded mutation,
     // so both authorities have to hold for the same transaction to publish.
-    const events = ".brain/runs/run-01/events.jsonl";
+    const events = ".brain/02-features/sample-feature/runs/run-01/events.jsonl";
     await executeManagedMutation(
       callerPlan(subject.storage, events, "{}\n"),
       {
@@ -183,7 +185,7 @@ describe("protected transaction lease guard", () => {
         eventStorePreconditions: [
           { path: events, expected: { kind: "missing" } },
           {
-            path: ".brain/runs/run-01/state.json",
+            path: ".brain/02-features/sample-feature/runs/run-01/state.json",
             expected: { kind: "missing" },
           },
         ],
@@ -240,7 +242,10 @@ describe("protected transaction lease guard", () => {
       "expected paths outside the lock namespace",
       {
         expected: [
-          { path: ".brain/runs/run-01/events.jsonl", expected: FINGERPRINT },
+          {
+            path: ".brain/02-features/sample-feature/runs/run-01/events.jsonl",
+            expected: FINGERPRINT,
+          },
           { path: ".brain/runs/run-01/lease.json", expected: FINGERPRINT },
         ],
       },

--- a/tests/transaction-normalization.test.ts
+++ b/tests/transaction-normalization.test.ts
@@ -366,6 +366,7 @@ describe("managed mutation plan normalization", () => {
       normalizeManagedMutationPlan(
         planOf({
           kind: "append_event",
+          feature: "sample-feature",
           runId: "run-01",
           event: {} as never,
         }),


### PR DESCRIPTION
Closes #108. Unblocks #112.

## The problem

Two run layouts existed in this repository and they named different directories.

The frozen inventory places every run artifact under the feature that opened it — eleven matrix rows, all `not_started`:

```
.brain/02-features/<feature>/runs/<run>/{state.json,plan.json,events.jsonl}
.brain/02-features/<feature>/runs/<run>/artifacts/*
```

`RUN-06` shipped the event store deriving its own two destinations from the run identifier alone:

```
.brain/runs/<run-id>/{events.jsonl,state.json}
```

`.brain/runs/` appears **nowhere** in `compatibility/inventory/go-v3-v0.6.5/discovery.json` and is covered by **no** matrix row. Nothing in the frozen contract asked for it and no parity row protected it.

`SDD-03` is the first issue that has to write a run, and it cannot write the frozen layout while the store owns `events.jsonl` and `state.json` at a different root. That is why this blocked #112.

## What this changes

`eventStorePaths` now takes a **run location** — the feature and the run identifier together — and derives the frozen path. It cannot place a run from the identifier alone, so `AppendEventEffect` carries the feature for the same reason.

The feature is constrained to the grammar `state.feature` declares (`^[a-z0-9][a-z0-9-]{0,63}$`), so a location the store accepts is one the feature contract could have produced. The run identifier keeps its own grammar unchanged.

Two derived rules move with the layout:

- the guarded-transaction fencing pattern, which identifies the pair a transaction may fence — now keyed by both names, and it checks both match rather than only the run;
- the drift classifier that decides whether a precondition failure is trail evidence or an ordinary artifact.

## Why this is safe to do now

**No production code consumed the store.** No command emits an `append_event` effect, so this moves no shipped behaviour — the only callers were tests. Doing it after `start` exists would have meant migrating written state instead of changing a constant.

The closed key-set guard on the append effect caught the omission when I first forgot to widen it, which is what that guard is for.

## The campaign counts, derived rather than re-pinned

A run now sits two directories deeper. Every moved number follows from that and nothing else:

| Pin | Before | After | Why |
| --- | ---: | ---: | --- |
| `inspect` | 119 | 121 | two more parents inspected on the way down |
| mutating boundaries | 348 | 352 | those two parents created and synchronized |
| `none` phase tally | 229 | 233 | all four fall before the transaction begins |
| last direct receipt | `inspect:*:119` | `inspect:*:121` | follows the inspect count |

No boundary changed phase, and no other operation count moved. The comments in the test record the derivation, not just the new value.

`tests/support/lease-guard.ts` keeps its shallow caller path deliberately: it is an arbitrary managed destination, not an event-store one, and the lock campaigns pin counts derived from its depth. Only the one test that exercises real event-store preconditions seeds the feature-scoped chain, through a new optional parameter.

## Parity

No row moves. The store now writes at the frozen paths, but nothing writes a run yet, so `FILE-BRAIN-02-FEATURES-FEATURE-RUNS-RUN-EVENTS-JSONL` and its siblings stay `not_started` until `SDD-03a` produces one. Parity remains `0 / 400 (0.00%)`.

## Verification

```
npm run format:check && npm run spellcheck && npm run lint && npm run typecheck
npm test                 # 128 files, 3726 tests
npm run test:coverage    # 100% statements, branches, functions, lines
npm run oracle:verify && npm run parity:check && npm run result:check
npm run contracts:check && npm run differential:check && npm run templates:validate
npm run build && npm run package:verify
```

Made with [Orca](https://github.com/stablyai/orca) 🐋
