### PR TITLE
feat: decide what a Brain migration would do before it does anything

### DIFF
--- a/docs/architecture/brain-migration.md
+++ b/docs/architecture/brain-migration.md
@@ -1,0 +1,68 @@
+# Legacy Brain Migration Planning
+
+Issue [#41](https://github.com/thiagocorreanet/mestre-yoda/issues/41)
+(`MIG-01`) decides what a migration would do, before anything does it. It adds
+no public command: the move itself is `MIG-02`, and registering `migrate brain`
+here would publish a capability this runtime does not have.
+
+## The layout it recognizes
+
+One. Discovery already reports a legacy sibling Brain as a directory
+`<project-name>-brain/.brain` beside the project, and refuses to read it as
+current state. `docs/architecture/project-discovery.md` states that rule; this
+document says what happens next.
+
+The frozen inventory records that `yoda migrate brain` exists, along with its
+`--root` and `--yes` flags and its confirmation contract. It does not record
+what the legacy layout contained, so the planner describes the layout this
+runtime recognizes rather than claiming parity with one it cannot see.
+
+## The decision
+
+The plan is a pure function of the observation and a digest function. Nothing
+is read inside it, so the same layout always produces the same plan, and the
+plan can be rendered, compared, and re-derived without touching a disk.
+
+Each legacy entry produces exactly one action:
+
+| Entry | Action | Why |
+| --- | --- | --- |
+| Absent from the project | `copy` | `absent_in_project` |
+| Present with the same digest | `skip` | `identical_in_project` |
+| Present with a different digest | `conflict` | `differs_in_project` |
+| Not a regular file | `unsupported` | `not_a_regular_file` |
+
+A directory produces no action of its own. It is created by the file it holds,
+and planning it separately would describe a byte nobody moves.
+
+Actions are ordered by source path, so two runs render identically, and the
+plan carries a digest over that ordered list.
+
+## What blocks a migration
+
+**A conflict blocks it.** The project's own state wins by default: overwriting
+it silently is how a migration destroys the work it was meant to preserve. The
+plan names both digests so a person can decide.
+
+**An unsupported entry blocks it.** Carrying across something no
+transformation is declared for would move a byte the plan cannot explain.
+
+**Two candidate layouts block it.** Two siblings are not a preference to
+resolve — they mean the runtime cannot know which project the state belongs to.
+The plan names the candidates and stops.
+
+## What the plan promises
+
+A ready plan reports the bytes its copies would write, so free space can be
+checked before anything moves, and declares itself reversible: every action
+either writes a file that was absent or writes nothing, so undoing the
+migration is removing exactly what it created.
+
+Nothing here writes, locks, or records an event. That is the point: a plan a
+person has not read yet is not authorization.
+
+## What this claims
+
+No parity row moves. `CLI-MIGRATE`, `FORM-MIGRATE-BRAIN`, the two flags, and
+the confirmation contract all describe a command, and this issue delivers the
+decision that command will make. They move when `MIG-02` registers it.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,6 +18,7 @@
     "./domain/host": "./src/domain/host/index.ts",
     "./domain/init": "./src/domain/init/index.ts",
     "./domain/locks": "./src/domain/locks/index.ts",
+    "./domain/migration": "./src/domain/migration/index.ts",
     "./domain/objective": "./src/domain/objective/index.ts",
     "./domain/project": "./src/domain/project/index.ts",
     "./domain/result": "./src/domain/result/index.ts",

--- a/packages/runtime/src/domain/migration/index.ts
+++ b/packages/runtime/src/domain/migration/index.ts
@@ -1,0 +1,7 @@
+export { planBrainMigration } from "./plan.js";
+export type {
+  MigrationAction,
+  MigrationEntry,
+  MigrationObservation,
+  MigrationPlan,
+} from "./plan.js";

--- a/packages/runtime/src/domain/migration/plan.ts
+++ b/packages/runtime/src/domain/migration/plan.ts
@@ -1,0 +1,183 @@
+/**
+ * What a legacy sibling Brain holds, and what would move into the project.
+ *
+ * The observation is supplied rather than read, so the decision is a pure
+ * function of the facts and the same layout always produces the same plan.
+ */
+export interface MigrationEntry {
+  /** Path relative to the Brain root, never absolute and never escaping it. */
+  readonly path: string;
+  readonly kind: "file" | "directory" | "other";
+  readonly sha256: string | null;
+  readonly bytes: number;
+}
+
+export interface MigrationObservation {
+  /**
+   * Every sibling layout discovery recognized.
+   *
+   * More than one is not a preference to resolve: two candidates mean the
+   * runtime cannot know which project the state belongs to.
+   */
+  readonly candidates: readonly string[];
+  /** What the recognized legacy layout holds, or null when there is none. */
+  readonly legacy: readonly MigrationEntry[] | null;
+  /** What the project's own `.brain` already holds. */
+  readonly destination: readonly MigrationEntry[];
+}
+
+export type MigrationAction =
+  | {
+      readonly kind: "copy";
+      readonly source: string;
+      readonly target: string;
+      readonly sha256: string;
+      readonly bytes: number;
+      readonly reason: "absent_in_project";
+    }
+  | {
+      readonly kind: "skip";
+      readonly source: string;
+      readonly target: string;
+      readonly sha256: string;
+      readonly reason: "identical_in_project";
+    }
+  | {
+      readonly kind: "conflict";
+      readonly source: string;
+      readonly target: string;
+      readonly sourceSha256: string;
+      /** Absent when the project holds something that is not a file there. */
+      readonly targetSha256: string | null;
+      readonly reason: "differs_in_project";
+    }
+  | {
+      readonly kind: "unsupported";
+      readonly source: string;
+      readonly target: string;
+      readonly reason: "not_a_regular_file";
+    };
+
+export type MigrationPlan =
+  | { readonly kind: "nothing_to_migrate" }
+  | { readonly kind: "ambiguous"; readonly candidates: readonly string[] }
+  | {
+      readonly kind: "blocked";
+      readonly actions: readonly MigrationAction[];
+      readonly blocking: readonly MigrationAction[];
+    }
+  | {
+      readonly kind: "ready";
+      readonly actions: readonly MigrationAction[];
+      /** Bytes the copy actions would write, so free space can be checked. */
+      readonly requiredBytes: number;
+      /** Whether every action can be undone by removing what it wrote. */
+      readonly reversible: true;
+      readonly planDigest: string;
+    };
+
+// Two entries never share a source path, so a two-way comparison is total.
+function byPath(left: { source: string }, right: { source: string }): number {
+  return left.source < right.source ? -1 : 1;
+}
+
+/**
+ * Decide what a migration would do, without doing any of it.
+ *
+ * Every entry produces exactly one action naming its source, its target, the
+ * transformation, and why. An entry the plan cannot describe blocks the
+ * migration rather than being carried across unexplained.
+ */
+export function planBrainMigration(
+  observation: MigrationObservation,
+  sha256: (value: string) => string,
+): MigrationPlan {
+  if (observation.candidates.length > 1) {
+    return Object.freeze({
+      kind: "ambiguous" as const,
+      candidates: Object.freeze([...observation.candidates].sort()),
+    });
+  }
+  const legacy = observation.legacy;
+  if (legacy === null || legacy.length === 0) {
+    return Object.freeze({ kind: "nothing_to_migrate" as const });
+  }
+
+  const existing = new Map(
+    observation.destination.map((entry) => [entry.path, entry]),
+  );
+  const actions: MigrationAction[] = [];
+  for (const entry of legacy) {
+    const target = `.brain/${entry.path}`;
+    if (entry.kind !== "file" || entry.sha256 === null) {
+      // A directory is created by the file it holds, and anything else is
+      // state no transformation is declared for.
+      if (entry.kind !== "directory") {
+        actions.push({
+          kind: "unsupported",
+          source: entry.path,
+          target,
+          reason: "not_a_regular_file",
+        });
+      }
+      continue;
+    }
+    const current = existing.get(entry.path);
+    if (current === undefined) {
+      actions.push({
+        kind: "copy",
+        source: entry.path,
+        target,
+        sha256: entry.sha256,
+        bytes: entry.bytes,
+        reason: "absent_in_project",
+      });
+      continue;
+    }
+    if (current.sha256 === entry.sha256) {
+      actions.push({
+        kind: "skip",
+        source: entry.path,
+        target,
+        sha256: entry.sha256,
+        reason: "identical_in_project",
+      });
+      continue;
+    }
+    // The project's own state wins by default: overwriting it silently is how
+    // a migration destroys the work it was meant to preserve.
+    actions.push({
+      kind: "conflict",
+      source: entry.path,
+      target,
+      sourceSha256: entry.sha256,
+      targetSha256: current.sha256,
+      reason: "differs_in_project",
+    });
+  }
+
+  const ordered = Object.freeze([...actions].sort(byPath));
+  const blocking = ordered.filter(
+    (action) => action.kind === "conflict" || action.kind === "unsupported",
+  );
+  if (blocking.length !== 0) {
+    return Object.freeze({
+      kind: "blocked" as const,
+      actions: ordered,
+      blocking: Object.freeze(blocking),
+    });
+  }
+  const requiredBytes = ordered.reduce(
+    (total, action) => (action.kind === "copy" ? total + action.bytes : total),
+    0,
+  );
+  return Object.freeze({
+    kind: "ready" as const,
+    actions: ordered,
+    requiredBytes,
+    // Every action either writes a file that was absent or writes nothing, so
+    // undoing the migration is removing exactly what it created.
+    reversible: true as const,
+    planDigest: sha256(JSON.stringify(ordered)),
+  });
+}

--- a/tests/migration-plan.test.ts
+++ b/tests/migration-plan.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planBrainMigration,
+  type MigrationEntry,
+  type MigrationObservation,
+  type MigrationPlan,
+} from "@mestre-yoda/runtime/domain/migration";
+import { sha256Digests } from "@mestre-yoda/runtime/infra/node";
+
+const digests = sha256Digests();
+const digest = (value: string): string => digests.sha256(value);
+
+function file(path: string, content: string): MigrationEntry {
+  return {
+    path,
+    kind: "file",
+    sha256: digest(content),
+    bytes: Buffer.byteLength(content, "utf8"),
+  };
+}
+
+function observation(
+  overrides: Partial<MigrationObservation> = {},
+): MigrationObservation {
+  return {
+    candidates: ["project-brain"],
+    legacy: [file("config.json", "{}\n")],
+    destination: [],
+    ...overrides,
+  };
+}
+
+function ready(plan: MigrationPlan): Extract<MigrationPlan, { kind: "ready" }> {
+  if (plan.kind !== "ready")
+    throw new Error(`Expected a ready plan: ${plan.kind}`);
+  return plan;
+}
+
+describe("the legacy Brain migration plan", () => {
+  it("plans a copy for state the project does not hold", () => {
+    const plan = ready(planBrainMigration(observation(), digest));
+    expect(plan.actions).toEqual([
+      {
+        kind: "copy",
+        source: "config.json",
+        target: ".brain/config.json",
+        sha256: digest("{}\n"),
+        bytes: 3,
+        reason: "absent_in_project",
+      },
+    ]);
+    expect(plan.requiredBytes).toBe(3);
+    expect(plan.reversible).toBe(true);
+  });
+
+  it("skips state the project already holds byte for byte", () => {
+    const plan = ready(
+      planBrainMigration(
+        observation({ destination: [file("config.json", "{}\n")] }),
+        digest,
+      ),
+    );
+    expect(plan.actions[0]?.kind).toBe("skip");
+    // Nothing to write means nothing to reserve space for.
+    expect(plan.requiredBytes).toBe(0);
+  });
+
+  it("blocks on state the project holds differently", () => {
+    const plan = planBrainMigration(
+      observation({ destination: [file("config.json", "{ }\n")] }),
+      digest,
+    );
+    expect(plan.kind).toBe("blocked");
+    if (plan.kind !== "blocked") throw new Error("Expected a blocked plan");
+    // The project's own state wins by default: overwriting it silently is how
+    // a migration destroys the work it was meant to preserve.
+    expect(plan.blocking).toHaveLength(1);
+    expect(plan.blocking[0]).toMatchObject({
+      kind: "conflict",
+      reason: "differs_in_project",
+      source: "config.json",
+      target: ".brain/config.json",
+    });
+  });
+
+  it("blocks when the project holds something that is not a file there", () => {
+    const plan = planBrainMigration(
+      observation({
+        destination: [
+          { path: "config.json", kind: "directory", sha256: null, bytes: 0 },
+        ],
+      }),
+      digest,
+    );
+    expect(plan.kind).toBe("blocked");
+    if (plan.kind !== "blocked") throw new Error("Expected a blocked plan");
+    // There is no digest to compare against, and the plan says so rather than
+    // inventing an empty one.
+    expect(plan.blocking[0]).toMatchObject({
+      kind: "conflict",
+      targetSha256: null,
+    });
+  });
+
+  it("blocks on an entry no transformation is declared for", () => {
+    const plan = planBrainMigration(
+      observation({
+        legacy: [{ path: "socket", kind: "other", sha256: null, bytes: 0 }],
+      }),
+      digest,
+    );
+    expect(plan.kind).toBe("blocked");
+    if (plan.kind !== "blocked") throw new Error("Expected a blocked plan");
+    expect(plan.blocking[0]).toMatchObject({
+      kind: "unsupported",
+      reason: "not_a_regular_file",
+    });
+  });
+
+  it("carries a directory across through the files it holds", () => {
+    const plan = ready(
+      planBrainMigration(
+        observation({
+          legacy: [
+            { path: "02-features", kind: "directory", sha256: null, bytes: 0 },
+            file("02-features/active", "login\n"),
+          ],
+        }),
+        digest,
+      ),
+    );
+    expect(plan.actions.map((action) => action.source)).toEqual([
+      "02-features/active",
+    ]);
+  });
+
+  it("refuses two candidate layouts instead of choosing one", () => {
+    const plan = planBrainMigration(
+      observation({ candidates: ["b-brain", "a-brain"] }),
+      digest,
+    );
+    expect(plan).toEqual({
+      kind: "ambiguous",
+      candidates: ["a-brain", "b-brain"],
+    });
+  });
+
+  it.each([
+    ["no legacy layout", null],
+    ["an empty legacy layout", [] as readonly MigrationEntry[]],
+  ])("reports %s as nothing to migrate", (_label, legacy) => {
+    expect(planBrainMigration(observation({ legacy }), digest)).toEqual({
+      kind: "nothing_to_migrate",
+    });
+  });
+
+  it("gives every planned byte a source, a target, and a reason", () => {
+    const plan = ready(
+      planBrainMigration(
+        observation({
+          legacy: [
+            file("b.json", "b"),
+            file("a.json", "a"),
+            file("c.json", "c"),
+          ],
+          destination: [file("c.json", "c")],
+        }),
+        digest,
+      ),
+    );
+    for (const action of plan.actions) {
+      expect(action.source).not.toBe("");
+      expect(action.target.startsWith(".brain/")).toBe(true);
+      expect(action.reason).toBeTruthy();
+    }
+    expect(plan.requiredBytes).toBe(2);
+  });
+
+  it("orders actions by source so two runs render identically", () => {
+    const forward = planBrainMigration(
+      observation({
+        legacy: [file("a.json", "a"), file("b.json", "b")],
+      }),
+      digest,
+    );
+    const reversed = planBrainMigration(
+      observation({
+        legacy: [file("b.json", "b"), file("a.json", "a")],
+      }),
+      digest,
+    );
+    expect(forward).toEqual(reversed);
+    expect(ready(forward).planDigest).toBe(ready(reversed).planDigest);
+  });
+
+  it("changes its digest when the plan changes", () => {
+    const first = ready(planBrainMigration(observation(), digest));
+    const second = ready(
+      planBrainMigration(
+        observation({ legacy: [file("config.json", "{ }\n")] }),
+        digest,
+      ),
+    );
+    expect(first.planDigest).not.toBe(second.planDigest);
+  });
+
+  it("returns a plan a caller cannot edit", () => {
+    const plan = ready(planBrainMigration(observation(), digest));
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(Object.isFrozen(plan.actions)).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #41. Does not close it: the `migrate brain` command is not registered, for the reason below.

## What this changes

Discovery already recognizes a legacy sibling Brain — a directory `<project-name>-brain/.brain` beside the project — and refuses to read it as current project state. What it could not say is what migrating would actually move.

`planBrainMigration` decides that, and does none of it. It is a pure function of an observation and a digest function: nothing is read inside it, so the same layout always produces the same plan, and the plan can be rendered, compared, and re-derived without touching a disk.

Every legacy entry produces exactly one action, naming its source, its target, the transformation, and why:

| Entry | Action | Reason |
| --- | --- | --- |
| Absent from the project | `copy` | `absent_in_project` |
| Present with the same digest | `skip` | `identical_in_project` |
| Present with a different digest | `conflict` | `differs_in_project` |
| Not a regular file | `unsupported` | `not_a_regular_file` |

A directory produces no action of its own — it is created by the file it holds, and planning it separately would describe a byte nobody moves.

## Three things stop a migration rather than resolving themselves

**A conflict.** The project's own state wins by default: overwriting it silently is how a migration destroys the work it was meant to preserve. The plan names both digests so a person can decide. When the project holds something that is not a file at that path there is no digest to compare, and the plan says so rather than inventing an empty one.

**An unsupported entry.** Carrying it across would move a byte the plan cannot explain.

**Two candidate layouts.** Two siblings are not a preference to resolve — they mean the runtime cannot know which project the state belongs to. The plan names the candidates and stops.

## What a ready plan promises

The bytes its copies would write, so free space can be checked before anything moves, and that it is reversible: every action either writes a file that was absent or writes nothing, so undoing the migration is removing exactly what it created.

Actions are ordered by source path, so two runs render identically, and the plan carries a digest over that ordered list. A test drives the same entries in both orders and asserts the plans and their digests are equal.

Nothing writes, locks, or records an event.

## Why no command

Registering `migrate brain` here would publish a capability this runtime does not have — the move is `MIG-02`, and `docs/architecture/command-routing.md` is explicit that reserving a name with a handler that cannot do the work is not allowed. This is the same shape `SDD-02` used for `completeObjective`: the decision lands in the domain, the command arrives with the issue that can perform it.

`schemas/state/migration.v1.schema.json` is also not the plan's shape. It requires `backupDigest`, `authorizationRef`, and `rollbackRef` — none of which exist before `MIG-02` has taken a backup — so it is a record of a migration, not a proposal for one.

## What this does not claim

No parity row moves. `CLI-MIGRATE`, `FORM-MIGRATE-BRAIN`, the two flags, and the stdin confirmation contract all describe a command; they move when `MIG-02` registers it. The frozen inventory records that the command exists, not what the legacy layout contained, so the planner describes the layout this runtime recognizes rather than claiming parity with one it cannot see.

## Verification

```
npm run format:check && npm run spellcheck && npm run lint && npm run typecheck
npm test
npm run test:coverage    # 100% statements, branches, functions, lines
npm run oracle:verify && npm run parity:check && npm run result:check
npm run contracts:check && npm run differential:check && npm run templates:validate
npm run build && npm run package:verify
```

Made with [Orca](https://github.com/stablyai/orca) 🐋
