### PR TITLE
ci: scan the dependencies and ship the notices they require

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -30,6 +30,7 @@
     "esbuild",
     "ESM",
     "evented",
+    "ghsas",
     "GOARCH",
     "gpgsign",
     "invalido",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+
+# Every dependency this repository has is pinned to an exact version or a
+# commit, which is what makes an update a reviewable change instead of
+# something that happens on its own at install time. The cost of that choice is
+# that nothing moves unless someone moves it, so this configuration is what
+# proposes the moves.
+#
+# A Dependabot pull request is a contribution like any other: the DCO gate in
+# `ci.yml` applies to it, so the range is signed with
+# `git rebase --signoff <base>` before it merges.
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    labels:
+      - type:maintenance
+      - area:quality
+    commit-message:
+      prefix: chore
+      include: scope
+    # One pull request per group rather than per package. A toolchain that
+    # moves together — the linter and its plugin, the test runner and its
+    # coverage provider — is reviewed once, against one CI run, instead of
+    # arriving as four pull requests that each invalidate the others.
+    groups:
+      lint:
+        patterns:
+          - "@eslint/*"
+          - eslint
+          - eslint-*
+          - typescript-eslint
+      test:
+        patterns:
+          - "@vitest/*"
+          - vitest
+      types:
+        patterns:
+          - "@types/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels:
+      - type:ci
+      - area:quality
+    commit-message:
+      prefix: ci
+      include: scope
+    # Every action is pinned to a commit, so an update here is a pin change
+    # with the version comment rewritten beside it — the only supported way to
+    # move a pin without a person resolving a tag by hand.
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,43 @@
+# The machine-readable half of `docs/security/dependency-policy.md`.
+#
+# `.npmrc` sets `audit=false`, so this is the only gate that sees a new
+# advisory before it is merged. It refuses at the lowest severity the API
+# reports: a threshold above `low` would mean the repository decided, in
+# advance and without a reader, that some known vulnerable dependency is
+# acceptable.
+fail-on-severity: low
+
+# Every scope. A build-time dependency runs attacker-reachable code on the
+# machine that produces the release, which is not a smaller problem than one
+# the release carries.
+fail-on-scopes:
+  - development
+  - runtime
+  - unknown
+
+# The development allowlist from the policy document. The redistributed subset
+# is narrower and is enforced separately, against the packages the bundle
+# actually carries, by `tests/dependency-policy.test.ts`.
+allow-licenses:
+  - 0BSD
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - BlueOak-1.0.0
+  - CC-BY-SA-4.0
+  - ISC
+  - MIT
+  - MPL-2.0
+  - Python-2.0
+  - Unlicense
+
+license-check: true
+vulnerability-check: true
+
+# A summary comment would need `pull-requests: write`. The job logs and the job
+# summary carry the same report without granting a workflow authority to write
+# to the pull request it is reviewing.
+comment-summary-in-pr: never
+
+# A finding is remediated or recorded, never downgraded to a passing run.
+warn-only: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+name: Code scanning
+
+# CodeQL runs on the protected branches and on a schedule rather than on pull
+# requests. A fork pull request carries a read-only token, so it cannot upload
+# an analysis, and every change reaches `developer` or `main` through a push
+# this workflow scans. The schedule is what catches a query-pack update finding
+# something in code that has not changed.
+on:
+  push:
+    branches:
+      - developer
+      - main
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  # A scan that is cancelled leaves the branch with the previous analysis, so
+  # cancelling one to start another would silently age the results.
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # The one authority this repository grants above read, and only here:
+      # uploading an analysis is the whole point of the job.
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended
+          config: |
+            paths-ignore:
+              - coverage
+              - dist
+              - node_modules
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:javascript-typescript
+          # Defaults to true. The findings are the point; publishing a queryable
+          # database of the sources alongside them is a separate decision, and
+          # this repository has not made it.
+          upload-database: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,36 @@
+name: Dependency review
+
+# The fast half of the security checks: it answers before a merge, on the only
+# event that has two revisions to diff. The full CodeQL scan runs afterwards on
+# the branch the merge produced.
+on:
+  pull_request:
+    branches:
+      - developer
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The thresholds live in the configuration file rather than here, so the
+      # policy this enforces is one file a reader can compare against
+      # `docs/security/dependency-policy.md` instead of a `with:` block.
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          config-file: ./.github/dependency-review-config.yml

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ npm run build
 npm run package:verify
 ```
 
-The build creates the three-file `dist/plugin/runtime/` staging directory;
+The build creates the four-file `dist/plugin/runtime/` staging directory;
 package verification and distribution tests copy it outside the checkout and
 collectively exercise help, version, and handshake. Passing these commands
 proves the repository foundation, not SDD product readiness.

--- a/docs/architecture/project-discovery.md
+++ b/docs/architecture/project-discovery.md
@@ -86,8 +86,8 @@ ambient state.
 
 The source workspace exposes the discovery contract at
 `@mestre-yoda/runtime/composition/discovery`. The standalone bundle still
-supports only `help`, `version`, and `handshake`, and its three-file inventory
-is unchanged. No discovery command is published by this issue.
+supports only `help`, `version`, and `handshake`, and no discovery command
+changed its published inventory. No discovery command is published by this issue.
 
 Parity remains `0 / 400 (0.00%)`. This work provides internal unit, property,
 and filesystem evidence, but no completed differential or end-to-end parity row.

--- a/docs/compatibility/runtime-distribution.md
+++ b/docs/compatibility/runtime-distribution.md
@@ -20,6 +20,7 @@ A plugin install contains exactly these files:
 | `runtime/yoda.mjs` | Canonical entry point: the interpreter gate |
 | `runtime/yoda.core.mjs` | The self-contained bundle |
 | `runtime/manifest.json` | Versions and digests of what actually shipped |
+| `runtime/THIRD-PARTY-NOTICES.txt` | License text of the packages the bundle carries |
 
 Schemas, skills, agents, providers, and templates are owned by later issues.
 This contract freezes the layout that will hold them.
@@ -121,6 +122,7 @@ two lists rather than one variation of the same list.
 fails the build:
 
 ```text
+runtime/THIRD-PARTY-NOTICES.txt
 runtime/manifest.json
 runtime/yoda.core.mjs
 runtime/yoda.mjs
@@ -144,6 +146,14 @@ Source maps are excluded deliberately. A source map reconstructs the TypeScript
 sources, and the denylist exists precisely to keep sources out of what ships.
 Debugging metadata becomes a considered release artifact rather than a file that
 rides along unnoticed.
+
+`runtime/THIRD-PARTY-NOTICES.txt` is in the allowlist for the opposite reason.
+The bundle inlines third-party code and is minified with
+`legalComments: "none"`, so the notice that MIT and BSD-3-Clause require is
+rebuilt from the installed packages and staged beside the runtime. Package
+verification re-derives the bundled set from the build metadata and refuses a
+staged plugin that attributes the wrong packages. Which licenses may appear
+there at all is [the dependency policy](../security/dependency-policy.md).
 
 ## Distribution manifest
 

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -1,0 +1,174 @@
+# Dependency Policy
+
+Issue [#114](https://github.com/thiagocorreanet/mestre-yoda/issues/114)
+(`QAL-04a`) asks which dependencies this project may take and what happens when
+one of them turns out to be vulnerable. This document answers both, names the
+file or test that enforces each answer, and states plainly where enforcement is
+still absent.
+
+[The threat model](threat-model.md) covers what the runtime is defended
+against. This covers what it is built and shipped from. Reporting a
+vulnerability, in a dependency or in this code, goes through
+[SECURITY.md](../../SECURITY.md).
+
+## Two dependency sets
+
+A dependency is governed by where it ends up, not by which section of
+`package.json` declares it.
+
+**Redistributed.** `runtime/yoda.core.mjs` is a bundle. Whatever the entry
+point reaches is inlined into it and shipped to every user of the plugin. That
+set is read from the build's own metadata rather than from a manifest, because
+a declared dependency and a bundled one are different things. Today it is four
+packages:
+
+| Package | Version | License |
+| --- | --- | --- |
+| `ajv` | 8.20.0 | `MIT` |
+| `fast-deep-equal` | 3.1.3 | `MIT` |
+| `fast-uri` | 3.1.5 | `BSD-3-Clause` |
+| `json-schema-traverse` | 1.0.0 | `MIT` |
+
+**Development.** Everything else: the compiler, the linter, the test runner,
+the bundler, and their trees. None of it is shipped, but all of it runs on the
+machine that produces the release, so a compromised build-time package is not
+a smaller problem than a compromised shipped one — it is a larger one with a
+shorter blast radius.
+
+## License policy
+
+A redistributed package may carry only a license that permits redistribution
+in a modified, minified, combined form and asks for nothing back but the
+notice:
+
+`0BSD`, `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `ISC`, `MIT`,
+`Unlicense`.
+
+A development-only package may additionally carry `BlueOak-1.0.0`,
+`CC-BY-SA-4.0`, `MPL-2.0`, or `Python-2.0`. Those are file-scoped or
+weak-copyleft terms that reach nothing this project distributes.
+
+Refused in both sets: `GPL`, `LGPL`, and `AGPL` in every version; the
+source-available families (`SSPL`, `BUSL`, `Elastic-2.0`); anything marked
+`UNLICENSED`; and any package that declares no license at all. A package whose
+license cannot be resolved is treated as refused until a person resolves it,
+never as permitted by default.
+
+One spelling exception is recorded rather than normalized away:
+`@cspell/dict-en-common-misspellings` declares its license as `CC BY-SA 4.0`,
+with spaces, which is not the SPDX identifier. `tests/dependency-policy.test.ts`
+accepts that exact string and nothing else like it.
+
+### Compliance means the notice ships
+
+Every license on the redistributed list is permissive about modification and
+combination, and strict about exactly one thing: the copyright notice and
+license text travel with the copy. The bundler is configured with
+`legalComments: "none"`, which strips those notices out of the minified
+output — so they are rebuilt.
+
+`scripts/build.mjs` reads the packages the bundle carries, copies each one's
+license text out of the installed package unmodified, and writes
+`runtime/THIRD-PARTY-NOTICES.txt` beside the runtime. It fails the build if a
+bundled package declares no license or ships no license text.
+
+`scripts/verify-package.mjs` re-derives the bundled set from the build metadata
+and checks the staged file against it. A notices file the builder validated
+against its own idea of what it bundled would prove only that the build agrees
+with itself.
+
+### Where the license policy is enforced
+
+- `.github/dependency-review-config.yml` — the allowlist, applied to every
+  dependency a pull request adds, before it merges.
+- `tests/dependency-policy.test.ts` — the installed tree carries no license
+  outside the allowlist; the bundled set carries none outside the narrower
+  redistributed list; the configuration file and this document agree.
+- `scripts/verify-package.mjs` — the staged plugin attributes exactly the
+  packages it carries, each with license text under it.
+
+## Vulnerability policy
+
+`.npmrc` sets `audit=false`. That is deliberate — an advisory database check
+that runs during install makes every `npm ci` depend on a network service and
+reports against the whole tree rather than against the change — but it means
+the check has to come from somewhere else. It comes from three places:
+
+| Check | Runs on | Enforces |
+| --- | --- | --- |
+| `dependency-review.yml` | every pull request | no new dependency with a known advisory or a refused license |
+| `codeql.yml` | push to `developer`/`main`, weekly | code-level defects in this repository's own sources |
+| `dependabot.yml` | weekly | proposes the updates that pinning otherwise prevents |
+
+Dependency review refuses at severity `low`, the lowest the API reports, in
+every scope. A threshold above `low` would be this repository deciding in
+advance, and without a reader, that some known vulnerable dependency is
+acceptable. `warn-only` is never enabled: a finding is remediated or recorded,
+not downgraded to a passing run.
+
+### Ownership and remediation
+
+Maintainers listed in [CODEOWNERS](../../.github/CODEOWNERS) own every finding
+these checks produce; there is no separate security team to escalate to. The
+targets below are good-faith commitments measured in business days, consistent
+with the response expectations in [SECURITY.md](../../SECURITY.md):
+
+| Severity | Redistributed set | Development set |
+| --- | --- | --- |
+| Critical | fix or remove within 7 days | fix or remove within 14 days |
+| High | within 14 days | within 30 days |
+| Moderate | within 30 days | next scheduled update |
+| Low | next scheduled update | next scheduled update |
+
+Remediation is, in order of preference: take the fixed version; drop the
+dependency; or vendor a patch and record why. Until one of those lands, the
+pull request that would introduce the finding does not merge.
+
+An advisory that cannot be remediated on that schedule is recorded as an
+explicit `allow-ghsas` entry in `.github/dependency-review-config.yml`, with
+the advisory identifier, the reason, and the condition that would remove it.
+An exception with no recorded reason is a failure of this policy, not a use of
+it.
+
+A vulnerability found in this project rather than in a dependency goes through
+the private path in [SECURITY.md](../../SECURITY.md) and never through a public
+issue, pull request, or advisory comment.
+
+### Updates
+
+Dependabot proposes weekly npm and GitHub Actions updates, grouped so a
+toolchain that moves together is reviewed once. Every action in this
+repository is pinned to a commit with its version in a trailing comment, and an
+Actions update rewrites both — which is the only supported way to move a pin
+without a person resolving a tag by hand.
+
+A Dependabot pull request is a contribution like any other. The DCO gate in
+`ci.yml` applies to it, so the range is signed with
+`git rebase --signoff <base>` before it merges.
+
+## Absent
+
+Stated here rather than left for someone to discover:
+
+**No SBOM.** This policy describes the dependency set; nothing yet publishes
+it as a released artifact with checksums and provenance. That is
+[#59](https://github.com/thiagocorreanet/mestre-yoda/issues/59) (`BET-02`), and
+this policy is what that artifact will be checked against.
+
+**No provenance or signature verification.** The lockfile pins every package to
+an integrity digest from one registry, which proves the bytes did not change
+after they were published. It does not prove who published them. npm provenance
+attestations are not verified.
+
+**CodeQL runs after a merge, not before one.** A fork pull request carries a
+read-only token and cannot upload an analysis, so the scan runs on the push
+that the merge produces and on a weekly schedule. A defect introduced by a pull
+request is found on the branch, not on the pull request.
+
+**Dependency review needs a repository setting.** The action reads the
+dependency graph, which is enabled in repository settings rather than in a file
+in this repository. Nothing here can assert it is on.
+
+**No scanning of the released bundle.** The checks above look at the dependency
+set and at this repository's sources. Nothing scans `runtime/yoda.core.mjs`
+itself, which is the artifact a user actually runs.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -213,10 +213,30 @@ test, so deleting `.npmrc` changed nothing that CI would notice.
 `tests/package-verifier.test.ts` and `tests/go-v3-oracle-verifier.test.ts` cover
 the rest.
 
-**Absent.** No CodeQL, no dependency review, no Dependabot configuration, no
-audit in CI (`audit=false` is set deliberately, so the check has to come from
-somewhere else), no provenance or signature verification, and no documented
-license policy. Those are the remaining `QAL-04` deliverables.
+[The dependency policy](dependency-policy.md) states which licenses either
+dependency set may carry and what happens when one of them turns out to be
+vulnerable. `dependency-review.yml` enforces it on every pull request at
+severity `low`, `codeql.yml` scans the sources on each protected-branch push
+and weekly, and `dependabot.yml` proposes the updates exact pinning otherwise
+prevents. `tests/dependency-policy.test.ts` holds the allowlists against the
+installed tree and against the four packages the bundle actually carries;
+`tests/supply-chain-contract.test.ts` holds every workflow to commit-pinned
+actions, fork-safe triggers, and read-only authority everywhere except the one
+job that uploads an analysis.
+
+The bundler is configured with `legalComments: "none"`, so the notices that
+MIT and BSD-3-Clause require were being stripped out of the artifact users
+run. `scripts/build.mjs` now rebuilds them into
+`runtime/THIRD-PARTY-NOTICES.txt`, and `scripts/verify-package.mjs` re-derives
+the bundled set independently and refuses a staged plugin that attributes the
+wrong packages.
+
+**Absent.** No provenance or signature verification: the lockfile proves the
+bytes did not change after publication, not who published them. CodeQL runs on
+the push a merge produces rather than on the pull request, because a fork
+cannot upload an analysis. Nothing scans the released bundle itself, and no
+SBOM is published yet — that is `BET-02` (#59). Each of these is stated at
+greater length in the dependency policy.
 
 ## What this document is not
 

--- a/docs/verification/issue-114-dependency-policy-evidence.md
+++ b/docs/verification/issue-114-dependency-policy-evidence.md
@@ -1,0 +1,121 @@
+# Issue 114 Code Scanning and Dependency Policy Evidence
+
+## Result
+
+Issue [#114](https://github.com/thiagocorreanet/mestre-yoda/issues/114)
+(`QAL-04a`) adds the scanning half of `QAL-04` and the license and
+vulnerability policy the released dependency set is measured against. What
+follows is what was reproduced locally. The GitHub-hosted runs are on the pull
+request itself; a scheduled CodeQL scan has by definition not run when the
+workflow that schedules it is still under review.
+
+Local verification used Node.js `24.18.0` and npm `11.16.0`:
+
+```text
+npm run verify
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml
+```
+
+`npm run verify` passed every gate: 3803 tests across 134 files, 100%
+statements, branches, functions, and lines on the measured runtime surface,
+and a verified standalone package. `actionlint` reported no diagnostic on any
+of the four workflows.
+
+## The license census this policy was written from
+
+The allowlists in [the dependency policy](../security/dependency-policy.md)
+were not chosen in the abstract. They were written against what the tree
+actually contains, so the policy describes a set that exists rather than one it
+would be pleasant to have. The 266 third-party packages installed by
+`npm ci` declare:
+
+| Declaration | Packages |
+| --- | --- |
+| `MIT` | 222 |
+| `Apache-2.0` | 16 |
+| `ISC` | 9 |
+| `BSD-2-Clause` | 7 |
+| `BSD-3-Clause` | 7 |
+| `MPL-2.0` | 2 |
+| `CC BY-SA 4.0` | 1 |
+| `Python-2.0` | 1 |
+| `BlueOak-1.0.0` | 1 |
+
+No `GPL`, `LGPL`, `AGPL`, source-available, or undeclared license is present.
+The single non-SPDX spelling, `CC BY-SA 4.0` from
+`@cspell/dict-en-common-misspellings`, is recorded in the policy and accepted
+by name rather than normalized.
+
+`tests/dependency-policy.test.ts` re-runs that census on every test run and
+refuses anything outside the allowlist. It asserts the walk found more than 200
+packages first, so a walk that returned nothing cannot pass by having nothing
+to refuse.
+
+## The attribution gap this closed
+
+`scripts/build.mjs` bundles with `legalComments: "none"`. The four packages the
+bundle carries are licensed `MIT` and `BSD-3-Clause`, both of which permit
+everything the build does to them except dropping the notice:
+
+| Package | Version | License |
+| --- | --- | --- |
+| `ajv` | 8.20.0 | `MIT` |
+| `fast-deep-equal` | 3.1.3 | `MIT` |
+| `fast-uri` | 3.1.5 | `BSD-3-Clause` |
+| `json-schema-traverse` | 1.0.0 | `MIT` |
+
+Before this change the released plugin was three files and none of them
+carried a notice. It is now four, and `runtime/THIRD-PARTY-NOTICES.txt` is
+built from the installed packages on every build.
+
+## Failure campaign against the notices verifier
+
+`scripts/verify-package.mjs` re-derives the bundled set from the build metadata
+rather than trusting the file the builder wrote. Each scenario below started
+from a clean `npm run build`, changed one thing in the staged notices, and ran
+`npm run package:verify`:
+
+| Scenario | Reported failure |
+| --- | --- |
+| Heading removed, license text left in place | `does not attribute ajv 8.20.0 (MIT)` |
+| Section appended for a package the bundle does not carry | `attributes unbundled left-pad 1.3.0 (WTFPL)` |
+| First section's license text emptied, heading kept | `carries no license text for ajv 8.20.0 (MIT)` |
+| Build-machine path appended to the file | `contains forbidden reference: node_modules` |
+
+Each message is prefixed `Package verification failed: runtime/THIRD-PARTY-NOTICES.txt`.
+The heading carries the version because the check matches on the exact package
+directory the bundle read from: a nested copy is a different version than a
+hoisted one, and a notice naming the wrong version attributes nothing.
+
+Each is held by a test in `tests/package-verifier.test.ts`, so the guard is
+proven to reject rather than assumed to.
+
+## No token or sensitive path in what the new automation produces
+
+The two new workflows produce no artifact and upload no log. Neither
+references a secret, and `tests/supply-chain-contract.test.ts` asserts that
+over the whole workflow directory rather than per file — which is what makes
+the assertion apply to the next workflow as well as these two.
+
+The artifact the pipeline does produce is unchanged: `ci.yml` uploads
+`.ci-diagnostics/`, `coverage/`, and `dist/` on failure only, from same-repository
+events only, and `tests/ci-workflow-contract.test.ts` continues to refuse
+`.npm`, `npm-debug`, and environment paths in that list.
+
+The one new staged file is held to the same reference rule as the bundle it
+ships beside: `node_modules`, `/packages/`, and the absolute repository root
+are refused in `runtime/THIRD-PARTY-NOTICES.txt` exactly as they are in
+`runtime/yoda.core.mjs`. The last row of the campaign table above is that rule
+failing on purpose.
+
+## What is still absent
+
+Stated here as well as in the policy, because an evidence document that lists
+only what passed is the marketing version:
+
+- no SBOM, provenance, or signature verification — `BET-02` (#59);
+- CodeQL runs on the push a merge produces, not on the pull request, because a
+  fork cannot upload an analysis;
+- nothing scans the released bundle itself;
+- dependency review depends on the dependency graph being enabled in
+  repository settings, which no file in this repository can assert.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,5 +1,12 @@
 import { createHash } from "node:crypto";
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,7 +18,9 @@ const repositoryRoot = dirname(
 const pluginDirectory = join(repositoryRoot, "dist/plugin");
 const entryPath = join(pluginDirectory, "runtime/yoda.mjs");
 const corePath = join(pluginDirectory, "runtime/yoda.core.mjs");
+const coreOutput = "dist/plugin/runtime/yoda.core.mjs";
 const manifestPath = join(pluginDirectory, "runtime/manifest.json");
+const noticesPath = join(pluginDirectory, "runtime/THIRD-PARTY-NOTICES.txt");
 const metadataFile = join(repositoryRoot, "dist/build-meta.json");
 const preflightTemplate = join(
   repositoryRoot,
@@ -37,6 +46,84 @@ function embed(value) {
   return JSON.stringify(value).slice(1, -1);
 }
 
+/**
+ * Every third-party package directory whose code the bundle carries.
+ *
+ * Read from the build's own metadata rather than from a manifest, because a
+ * declared dependency and a bundled one are different sets: esbuild inlines
+ * only what the entry point reaches, and that is what gets redistributed.
+ *
+ * Directories rather than names, because a nested `a/node_modules/b` is a
+ * different copy at a possibly different version than a hoisted `b`, and
+ * attributing the hoisted one would name a version that never shipped.
+ */
+function bundledPackageDirectories(metafile) {
+  const output = metafile.outputs[coreOutput];
+  if (output === undefined) {
+    throw new Error("Build failed: the bundle recorded no input metadata");
+  }
+  const marker = "node_modules/";
+  const directories = new Set();
+  for (const input of Object.keys(output.inputs)) {
+    // The last occurrence, so a nested copy resolves to itself.
+    const at = input.lastIndexOf(marker);
+    if (at === -1) continue;
+    const segments = input.slice(at + marker.length).split("/");
+    const depth = segments[0].startsWith("@") ? 2 : 1;
+    directories.add(
+      input.slice(0, at + marker.length) + segments.slice(0, depth).join("/"),
+    );
+  }
+  return [...directories].sort();
+}
+
+/** Filenames a package may use for the text its license requires be kept. */
+const licenseFilenames = new Set([
+  "copying",
+  "copying.md",
+  "copying.txt",
+  "licence",
+  "licence.md",
+  "licence.txt",
+  "license",
+  "license.md",
+  "license.txt",
+]);
+
+/**
+ * The license text a package ships, read from the installed package.
+ *
+ * MIT and the BSD licenses are permissive about everything except this: the
+ * notice travels with the copy. `legalComments: "none"` removes it from the
+ * bundle, so it is rebuilt here instead of left to survive minification.
+ */
+async function licenseNotice(packageDirectory) {
+  const directory = join(repositoryRoot, packageDirectory);
+  const declared = JSON.parse(
+    await readFile(join(directory, "package.json"), "utf8"),
+  );
+  if (typeof declared.license !== "string" || declared.license === "") {
+    throw new Error(
+      `Build failed: ${packageDirectory} is bundled but declares no license`,
+    );
+  }
+  const filename = (await readdir(directory)).find((entry) =>
+    licenseFilenames.has(entry.toLowerCase()),
+  );
+  if (filename === undefined) {
+    throw new Error(
+      `Build failed: ${packageDirectory} is bundled but ships no license text`,
+    );
+  }
+  const text = await readFile(join(directory, filename), "utf8");
+  return {
+    heading: `${declared.name} ${declared.version} (${declared.license})`,
+    // Line endings normalized so the file is byte-identical on every platform
+    // that builds it; the wording itself is copied exactly.
+    text: text.replaceAll("\r\n", "\n").trimEnd(),
+  };
+}
+
 await rm(pluginDirectory, { force: true, recursive: true });
 await mkdir(dirname(corePath), { recursive: true });
 
@@ -49,7 +136,7 @@ const result = await build({
   logLevel: "info",
   metafile: true,
   minify: true,
-  outfile: "dist/plugin/runtime/yoda.core.mjs",
+  outfile: coreOutput,
   platform: "node",
   sourcemap: false,
   target: "node24",
@@ -58,6 +145,33 @@ const result = await build({
 await writeFile(
   metadataFile,
   `${JSON.stringify(result.metafile, null, 2)}\n`,
+  "utf8",
+);
+
+const notices = await Promise.all(
+  bundledPackageDirectories(result.metafile).map(licenseNotice),
+);
+const rule = "=".repeat(78);
+await writeFile(
+  noticesPath,
+  [
+    "Mestre Yoda third-party notices",
+    "",
+    "runtime/yoda.core.mjs is a bundle. It carries the code of the packages",
+    "listed below, and their license terms follow, copied unmodified from the",
+    "package each one came from. Nothing else in this plugin is third-party.",
+    "",
+    ...(notices.length === 0
+      ? ["This build carries no third-party code.", ""]
+      : notices.flatMap(({ heading, text }) => [
+          rule,
+          heading,
+          rule,
+          "",
+          text,
+          "",
+        ])),
+  ].join("\n"),
   "utf8",
 );
 

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -23,6 +23,7 @@ const artifact = join(pluginDirectory, "runtime/yoda.mjs");
 const core = join(pluginDirectory, "runtime/yoda.core.mjs");
 // The exact set of files a plugin install contains. Anything else fails.
 const expectedInventory = [
+  "runtime/THIRD-PARTY-NOTICES.txt",
   "runtime/manifest.json",
   "runtime/yoda.core.mjs",
   "runtime/yoda.mjs",
@@ -130,6 +131,60 @@ function executeIsolated(
   return result.stdout;
 }
 
+/**
+ * Every third-party package directory the build metadata says was bundled.
+ *
+ * Directories rather than names: a nested copy is a different version than a
+ * hoisted one, and a notice naming the wrong version attributes nothing.
+ */
+function bundledPackageDirectories(metadata) {
+  const output = metadata.outputs["dist/plugin/runtime/yoda.core.mjs"];
+  if (output === undefined) {
+    fail("build metadata records no bundle output");
+  }
+  const marker = "node_modules/";
+  const directories = new Set();
+  for (const input of Object.keys(output.inputs)) {
+    const at = input.lastIndexOf(marker);
+    if (at === -1) continue;
+    const segments = input.slice(at + marker.length).split("/");
+    const depth = segments[0].startsWith("@") ? 2 : 1;
+    directories.add(
+      input.slice(0, at + marker.length) + segments.slice(0, depth).join("/"),
+    );
+  }
+  return [...directories].sort();
+}
+
+/**
+ * Each heading the notices file carries, mapped to the text under it.
+ *
+ * Sections are found by their rule lines rather than by scanning for anything
+ * heading-shaped, so a line inside a license cannot be read as the start of
+ * another package's notice.
+ */
+function attributions(notices) {
+  const heading = /^\S+ \S+ \([^)]+\)$/u;
+  const rule = "=".repeat(78);
+  const lines = notices.split("\n");
+  const found = new Map();
+  for (let index = 0; index + 2 < lines.length; index += 1) {
+    if (lines[index] !== rule || lines[index + 2] !== rule) continue;
+    if (!heading.test(lines[index + 1])) continue;
+    let end = index + 3;
+    while (end < lines.length && lines[end] !== rule) end += 1;
+    found.set(
+      lines[index + 1],
+      lines
+        .slice(index + 3, end)
+        .join("\n")
+        .trim(),
+    );
+    index = end - 1;
+  }
+  return found;
+}
+
 function acceptsHelp(output) {
   return (
     output.split("\n")[0] === expectedHelpFirstLine &&
@@ -177,18 +232,29 @@ if (distributionManifest.runtime.coreSha256 !== recordedDigest) {
   fail("runtime/manifest.json does not record the built core digest");
 }
 
+const noticesSource = await readFile(
+  join(pluginDirectory, "runtime/THIRD-PARTY-NOTICES.txt"),
+  "utf8",
+);
+
 const forbiddenReferences = [
   "node_modules",
   "/packages/",
   "\\packages\\",
   repositoryRoot,
 ];
+// The notices are read from paths under `node_modules` on the machine that
+// built them, so they are held to the same rule as the two files they ship
+// beside rather than trusted for being only license text.
 for (const reference of forbiddenReferences) {
-  if (bundle.includes(reference)) {
-    fail(`runtime/yoda.core.mjs contains forbidden reference: ${reference}`);
-  }
-  if (entrySource.includes(reference)) {
-    fail(`runtime/yoda.mjs contains forbidden reference: ${reference}`);
+  for (const [name, staged] of [
+    ["runtime/yoda.core.mjs", bundle],
+    ["runtime/yoda.mjs", entrySource],
+    ["runtime/THIRD-PARTY-NOTICES.txt", noticesSource],
+  ]) {
+    if (staged.includes(reference)) {
+      fail(`${name} contains forbidden reference: ${reference}`);
+    }
   }
 }
 
@@ -200,6 +266,39 @@ for (const output of Object.values(metadata.outputs)) {
     if (imported.external === true && !allowedBuiltins.has(imported.path)) {
       fail(`bundle has invalid external import: ${imported.path}`);
     }
+  }
+}
+
+// Re-derived here rather than taken from the builder. A notices file the build
+// wrote from its own idea of what it bundled would prove only that the build
+// agrees with itself; this reads the same metadata independently and checks
+// the staged file against it.
+const attributed = attributions(noticesSource);
+const expectedHeadings = [];
+for (const packageDirectory of bundledPackageDirectories(metadata)) {
+  const declared = JSON.parse(
+    await readFile(
+      join(repositoryRoot, packageDirectory, "package.json"),
+      "utf8",
+    ),
+  );
+  const heading = `${declared.name} ${declared.version} (${declared.license})`;
+  expectedHeadings.push(heading);
+  const notice = attributed.get(heading);
+  if (notice === undefined) {
+    fail(`runtime/THIRD-PARTY-NOTICES.txt does not attribute ${heading}`);
+  }
+  // A heading with nothing under it attributes nothing. The shortest license
+  // in the bundled set is over 400 characters.
+  if (notice.length < 200) {
+    fail(
+      `runtime/THIRD-PARTY-NOTICES.txt carries no license text for ${heading}`,
+    );
+  }
+}
+for (const heading of attributed.keys()) {
+  if (!expectedHeadings.includes(heading)) {
+    fail(`runtime/THIRD-PARTY-NOTICES.txt attributes unbundled ${heading}`);
   }
 }
 

--- a/tests/dependency-policy.test.ts
+++ b/tests/dependency-policy.test.ts
@@ -1,0 +1,316 @@
+import { execFileSync } from "node:child_process";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { parse } from "yaml";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = join(import.meta.dirname, "..");
+
+/**
+ * What a package the bundle carries may be licensed under.
+ *
+ * Every one of these permits redistribution in a modified, minified, combined
+ * form and asks for nothing back but the notice — which is why
+ * `runtime/THIRD-PARTY-NOTICES.txt` has to exist.
+ */
+const REDISTRIBUTED_LICENSES = [
+  "0BSD",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "MIT",
+  "Unlicense",
+];
+
+/**
+ * What a package that only builds or tests this project may add to that.
+ *
+ * File-scoped and weak-copyleft terms are acceptable here because nothing in
+ * this set reaches anything the project distributes.
+ */
+const DEVELOPMENT_LICENSES = [
+  ...REDISTRIBUTED_LICENSES,
+  "BlueOak-1.0.0",
+  "CC-BY-SA-4.0",
+  "MPL-2.0",
+  "Python-2.0",
+].sort();
+
+/**
+ * Declarations that name an allowed license without spelling it as SPDX does.
+ *
+ * Recorded one by one rather than normalized. A rule that rewrote whitespace
+ * and case before comparing would also accept spellings nobody has looked at.
+ */
+const SPELLING_EXCEPTIONS: Readonly<Record<string, string>> = {
+  "CC BY-SA 4.0": "CC-BY-SA-4.0",
+};
+
+async function read(relative: string): Promise<string> {
+  return await readFile(join(repositoryRoot, relative), "utf8");
+}
+
+interface InstalledPackage {
+  readonly name: string;
+  readonly license: string;
+}
+
+/**
+ * Every third-party package present in the installed tree.
+ *
+ * Symlinked entries are skipped, which is what leaves the four workspace
+ * packages out: they are this repository, not a dependency of it.
+ */
+async function installedPackages(
+  directory: string,
+): Promise<readonly InstalledPackage[]> {
+  const found: InstalledPackage[] = [];
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const child = join(directory, entry.name);
+    if (entry.name.startsWith("@")) {
+      found.push(...(await installedPackages(child)));
+      continue;
+    }
+    if (entry.name.startsWith(".")) continue;
+    let manifest: { name?: unknown; license?: unknown };
+    try {
+      manifest = JSON.parse(
+        await readFile(join(child, "package.json"), "utf8"),
+      ) as { name?: unknown; license?: unknown };
+    } catch {
+      continue;
+    }
+    if (typeof manifest.name === "string") {
+      found.push({
+        name: manifest.name,
+        license:
+          typeof manifest.license === "string" ? manifest.license : "UNKNOWN",
+      });
+    }
+    found.push(...(await installedPackages(join(child, "node_modules"))));
+  }
+  return found;
+}
+
+/**
+ * Every third-party package directory the build metadata says was bundled.
+ *
+ * Directories rather than names, matching `scripts/verify-package.mjs`: a
+ * nested copy is a different version than a hoisted one.
+ */
+function bundledDirectories(metadata: {
+  readonly outputs: Readonly<
+    Record<string, { readonly inputs: Readonly<Record<string, unknown>> }>
+  >;
+}): readonly string[] {
+  const output = metadata.outputs["dist/plugin/runtime/yoda.core.mjs"];
+  expect(output).toBeDefined();
+  const marker = "node_modules/";
+  const directories = new Set<string>();
+  for (const input of Object.keys(output?.inputs ?? {})) {
+    const at = input.lastIndexOf(marker);
+    if (at === -1) continue;
+    const [first, second] = input.slice(at + marker.length).split("/");
+    if (first === undefined) continue;
+    const name =
+      first.startsWith("@") && second !== undefined
+        ? `${first}/${second}`
+        : first;
+    directories.add(`${input.slice(0, at + marker.length)}${name}`);
+  }
+  return [...directories].sort();
+}
+
+interface DeclaredPackage {
+  readonly name: string;
+  readonly version: string;
+  readonly license: string;
+}
+
+async function declaredPackage(
+  packageDirectory: string,
+): Promise<DeclaredPackage> {
+  return JSON.parse(
+    await read(join(packageDirectory, "package.json")),
+  ) as DeclaredPackage;
+}
+
+describe("the dependency-review configuration", () => {
+  let configuration: Readonly<Record<string, unknown>>;
+
+  beforeAll(async () => {
+    configuration = parse(
+      await read(".github/dependency-review-config.yml"),
+    ) as Readonly<Record<string, unknown>>;
+  });
+
+  it("carries the license allowlist the policy document states", () => {
+    expect(configuration["allow-licenses"]).toEqual(DEVELOPMENT_LICENSES);
+    // Both lists are a decision about what may be introduced; only one of them
+    // can be in force, and `deny-licenses` alongside an allowlist is rejected
+    // by the action rather than merged with it.
+    expect(configuration["deny-licenses"]).toBeUndefined();
+  });
+
+  it("refuses at the lowest severity the API reports, in every scope", () => {
+    expect(configuration["fail-on-severity"]).toBe("low");
+    expect(configuration["fail-on-scopes"]).toEqual([
+      "development",
+      "runtime",
+      "unknown",
+    ]);
+    expect(configuration["license-check"]).toBe(true);
+    expect(configuration["vulnerability-check"]).toBe(true);
+  });
+
+  it("cannot pass a finding through as a warning", () => {
+    expect(configuration["warn-only"]).toBe(false);
+    // `always` and `on-failure` both require `pull-requests: write`, which no
+    // workflow in this repository has.
+    expect(configuration["comment-summary-in-pr"]).toBe("never");
+  });
+});
+
+describe("the dependency policy document", () => {
+  let policy: string;
+
+  beforeAll(async () => {
+    policy = await read("docs/security/dependency-policy.md");
+  });
+
+  it("names every license the configuration allows", () => {
+    for (const license of DEVELOPMENT_LICENSES) {
+      expect(policy, license).toContain(`\`${license}\``);
+    }
+  });
+
+  it("separates the redistributed list from the development one", () => {
+    // The two lists differ, and the document has to say so; a policy that
+    // stated one list would be permitting weak copyleft in the shipped bundle
+    // by omission.
+    for (const license of DEVELOPMENT_LICENSES.filter(
+      (value) => !REDISTRIBUTED_LICENSES.includes(value),
+    )) {
+      expect(policy, license).toContain(license);
+    }
+    expect(policy).toContain("A redistributed package may carry only");
+    expect(policy).toContain("A development-only package may additionally");
+  });
+
+  it("records each non-SPDX spelling it accepts", () => {
+    for (const declared of Object.keys(SPELLING_EXCEPTIONS)) {
+      expect(policy, declared).toContain(declared);
+    }
+  });
+});
+
+describe("the installed dependency tree", () => {
+  let installed: readonly InstalledPackage[];
+
+  beforeAll(async () => {
+    installed = await installedPackages(join(repositoryRoot, "node_modules"));
+  });
+
+  it("was actually walked", () => {
+    // Without this, a walk that returned nothing would satisfy every
+    // assertion below by having nothing to refuse.
+    expect(installed.length).toBeGreaterThan(200);
+    expect(installed.map(({ name }) => name)).toContain("ajv");
+    expect(installed.map(({ name }) => name)).not.toContain(
+      "@mestre-yoda/runtime",
+    );
+  });
+
+  it("carries no license outside the development allowlist", () => {
+    const refused = installed
+      .filter(
+        ({ license }) =>
+          !DEVELOPMENT_LICENSES.includes(license) &&
+          !DEVELOPMENT_LICENSES.includes(SPELLING_EXCEPTIONS[license] ?? ""),
+      )
+      .map(({ name, license }) => `${name}: ${license}`);
+    expect([...new Set(refused)].sort()).toEqual([]);
+  });
+
+  it("declares a license for every package", () => {
+    const undeclared = installed
+      .filter(({ license }) => license === "UNKNOWN")
+      .map(({ name }) => name);
+    // A package that declares nothing is refused rather than assumed
+    // permissive, so it has to be absent, not merely unnoticed.
+    expect([...new Set(undeclared)].sort()).toEqual([]);
+  });
+});
+
+describe("the redistributed dependency set", () => {
+  let metadata: {
+    readonly outputs: Readonly<
+      Record<string, { readonly inputs: Readonly<Record<string, unknown>> }>
+    >;
+  };
+  let notices: string;
+
+  beforeAll(async () => {
+    execFileSync(process.execPath, ["scripts/build.mjs"], {
+      cwd: repositoryRoot,
+      stdio: "pipe",
+    });
+    metadata = JSON.parse(
+      await read("dist/build-meta.json"),
+    ) as typeof metadata;
+    notices = await read("dist/plugin/runtime/THIRD-PARTY-NOTICES.txt");
+  });
+
+  it("is the four packages the policy document lists", () => {
+    expect(bundledDirectories(metadata)).toEqual([
+      "node_modules/ajv",
+      "node_modules/fast-deep-equal",
+      "node_modules/fast-uri",
+      "node_modules/json-schema-traverse",
+    ]);
+  });
+
+  it("carries no license outside the redistributed allowlist", async () => {
+    for (const directory of bundledDirectories(metadata)) {
+      const declared = await declaredPackage(directory);
+      expect(REDISTRIBUTED_LICENSES, directory).toContain(declared.license);
+    }
+  });
+
+  it("ships the notice each of those licenses asks for", async () => {
+    for (const directory of bundledDirectories(metadata)) {
+      const declared = await declaredPackage(directory);
+      expect(notices, directory).toContain(
+        `${declared.name} ${declared.version} (${declared.license})`,
+      );
+      // The heading alone attributes nothing; the terms have to be under it.
+      const licenseText = await read(join(directory, "LICENSE"));
+      expect(notices, directory).toContain(
+        licenseText.replaceAll("\r\n", "\n").trimEnd(),
+      );
+    }
+  });
+
+  it("attributes nothing it does not carry", async () => {
+    const expected: string[] = [];
+    for (const directory of bundledDirectories(metadata)) {
+      const declared = await declaredPackage(directory);
+      expected.push(
+        `${declared.name} ${declared.version} (${declared.license})`,
+      );
+    }
+    const headings = [...notices.matchAll(/^\S+ \S+ \([^)]+\)$/gmu)].map(
+      (match) => match[0],
+    );
+    expect(headings.sort()).toEqual(expected.sort());
+  });
+});

--- a/tests/package-verifier.test.ts
+++ b/tests/package-verifier.test.ts
@@ -19,6 +19,10 @@ const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 const artifact = join(repositoryRoot, "dist/plugin/runtime/yoda.mjs");
 const core = join(repositoryRoot, "dist/plugin/runtime/yoda.core.mjs");
 const manifestFile = join(repositoryRoot, "dist/plugin/runtime/manifest.json");
+const noticesFile = join(
+  repositoryRoot,
+  "dist/plugin/runtime/THIRD-PARTY-NOTICES.txt",
+);
 const metadataFile = join(repositoryRoot, "dist/build-meta.json");
 
 function build() {
@@ -123,12 +127,65 @@ describe("package verifier", () => {
     expect(verify).toThrow();
   });
 
-  it("runs every orientation command from an isolated three-file plugin", async () => {
+  it("rejects notices that leave a bundled package unattributed", async () => {
+    const notices = await readFile(noticesFile, "utf8");
+    // The heading is what names the package; removing it leaves the license
+    // text in place while attributing it to nobody.
+    const stripped = notices.replace(/^ajv \S+ \(MIT\)$/mu, "ajv");
+    expect(stripped).not.toBe(notices);
+    await writeFile(noticesFile, stripped, "utf8");
+
+    expect(verify).toThrow();
+  });
+
+  it("rejects notices that leak the path they were built from", async () => {
+    // The notices are read out of `node_modules` on the build machine, so the
+    // staged file is held to the same reference rule as the bundle beside it.
+    const notices = await readFile(noticesFile, "utf8");
+    await writeFile(
+      noticesFile,
+      `${notices}\nread from ${repositoryRoot}/node_modules/ajv\n`,
+      "utf8",
+    );
+
+    expect(verify).toThrow();
+  });
+
+  it("rejects notices that attribute a package the bundle does not carry", async () => {
+    const notices = await readFile(noticesFile, "utf8");
+    const rule = "=".repeat(78);
+    await writeFile(
+      noticesFile,
+      `${notices}\n${rule}\nleft-pad 1.3.0 (WTFPL)\n${rule}\n\n${"terms ".repeat(40)}\n`,
+      "utf8",
+    );
+
+    expect(verify).toThrow();
+  });
+
+  it("rejects a heading with no license text under it", async () => {
+    // Every section still names its package; the first one simply attributes
+    // it to an empty body, which is the failure a heading-only check misses.
+    const rule = "=".repeat(78);
+    const sections = (await readFile(noticesFile, "utf8")).split(`${rule}\n`);
+    expect(sections.length).toBeGreaterThan(3);
+    sections[2] = "\n";
+    await writeFile(noticesFile, sections.join(`${rule}\n`), "utf8");
+
+    expect(verify).toThrow();
+  });
+
+  it("runs every orientation command from an isolated plugin install", async () => {
     const cleanRoom = await mkdtemp(join(tmpdir(), "yoda-package-verifier-"));
     try {
       const runtime = join(cleanRoom, "runtime");
       await mkdir(runtime, { recursive: true });
-      for (const staged of ["manifest.json", "yoda.core.mjs", "yoda.mjs"]) {
+      for (const staged of [
+        "THIRD-PARTY-NOTICES.txt",
+        "manifest.json",
+        "yoda.core.mjs",
+        "yoda.mjs",
+      ]) {
         await copyFile(
           join(repositoryRoot, "dist/plugin/runtime", staged),
           join(runtime, staged),
@@ -136,6 +193,7 @@ describe("package verifier", () => {
       }
       expect((await readdir(cleanRoom)).sort()).toEqual(["runtime"]);
       expect((await readdir(runtime)).sort()).toEqual([
+        "THIRD-PARTY-NOTICES.txt",
         "manifest.json",
         "yoda.core.mjs",
         "yoda.mjs",

--- a/tests/runtime-distribution.test.ts
+++ b/tests/runtime-distribution.test.ts
@@ -181,8 +181,12 @@ describe("runtime distribution", () => {
     }
   });
 
-  it("stages exactly the manifest, core, and entry point", async () => {
+  it("stages exactly the manifest, core, entry point, and notices", async () => {
     expect((await readdir(join(plugin, "runtime"))).sort()).toEqual([
+      // The bundle inlines four third-party packages and is minified with
+      // `legalComments: "none"`, so the notices their licenses require
+      // travel as a file rather than as comments that no longer survive.
+      "THIRD-PARTY-NOTICES.txt",
       "manifest.json",
       "yoda.core.mjs",
       "yoda.mjs",

--- a/tests/supply-chain-contract.test.ts
+++ b/tests/supply-chain-contract.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import { parse } from "yaml";
@@ -8,6 +8,47 @@ const repositoryRoot = join(import.meta.dirname, "..");
 
 async function read(relative: string): Promise<string> {
   return await readFile(join(repositoryRoot, relative), "utf8");
+}
+
+interface Workflow {
+  readonly on?: unknown;
+  readonly permissions?: unknown;
+  readonly concurrency?: unknown;
+  readonly jobs: Readonly<
+    Record<
+      string,
+      {
+        readonly name?: unknown;
+        readonly permissions?: unknown;
+        readonly "runs-on"?: unknown;
+        readonly "timeout-minutes"?: unknown;
+        readonly steps: readonly {
+          readonly name?: unknown;
+          readonly uses?: string;
+          readonly with?: unknown;
+        }[];
+      }
+    >
+  >;
+}
+
+async function workflow(name: string): Promise<Workflow> {
+  return parse(await read(`.github/workflows/${name}`)) as Workflow;
+}
+
+async function workflowNames(): Promise<readonly string[]> {
+  return (await readdir(join(repositoryRoot, ".github/workflows"))).sort();
+}
+
+async function job(
+  workflowName: string,
+  jobName: string,
+): Promise<Workflow["jobs"][string]> {
+  const found = (await workflow(workflowName)).jobs[jobName];
+  if (found === undefined) {
+    throw new Error(`${workflowName} declares no job named ${jobName}`);
+  }
+  return found;
 }
 
 describe("the installer configuration", () => {
@@ -151,5 +192,191 @@ describe("the documentation workflow", () => {
     };
     const checkout = Object.values(workflow.jobs)[0]?.steps[0];
     expect(checkout?.with).toEqual({ "persist-credentials": false });
+  });
+});
+
+describe("every workflow", () => {
+  // Pinning, fork safety, and read-only authority were asserted per file,
+  // which meant a new workflow inherited none of them. Asserting them over the
+  // directory is what makes the next one arrive under the same rules.
+  it("is one of the four this repository publishes", async () => {
+    expect(await workflowNames()).toEqual([
+      "ci.yml",
+      "codeql.yml",
+      "dependency-review.yml",
+      "docs.yml",
+    ]);
+  });
+
+  it("pins every action to a commit rather than a moving tag", async () => {
+    for (const name of await workflowNames()) {
+      const uses = Object.values((await workflow(name)).jobs)
+        .flatMap((job) => job.steps)
+        .map((step) => step.uses)
+        .filter((value): value is string => value !== undefined);
+      expect(uses.length, name).toBeGreaterThan(0);
+      for (const value of uses) {
+        expect(value.split("@")[1], `${name}: ${value}`).toMatch(
+          /^[0-9a-f]{40}$/u,
+        );
+      }
+    }
+  });
+
+  it("never runs a fork's code with the base repository's authority", async () => {
+    for (const name of await workflowNames()) {
+      const raw = await read(`.github/workflows/${name}`);
+      expect(raw, name).not.toContain("pull_request_target");
+      expect(raw, name).not.toMatch(/\bsecrets\b/iu);
+      expect((await workflow(name)).permissions, name).toEqual({
+        contents: "read",
+      });
+    }
+  });
+
+  it("grants authority above read in exactly one place", async () => {
+    const elevated: string[] = [];
+    for (const name of await workflowNames()) {
+      for (const [jobName, job] of Object.entries(
+        (await workflow(name)).jobs,
+      )) {
+        if (job.permissions !== undefined) elevated.push(`${name}:${jobName}`);
+      }
+    }
+    // Uploading an analysis is the only thing this repository's automation
+    // does that a read-only token cannot. Anything else appearing here is a
+    // workflow that acquired write authority without being noticed.
+    expect(elevated).toEqual(["codeql.yml:analyze"]);
+  });
+
+  it("bounds every job in time", async () => {
+    for (const name of await workflowNames()) {
+      for (const [jobName, job] of Object.entries(
+        (await workflow(name)).jobs,
+      )) {
+        expect(job["timeout-minutes"], `${name}:${jobName}`).toEqual(
+          expect.any(Number),
+        );
+        expect(job["runs-on"], `${name}:${jobName}`).toBe("ubuntu-latest");
+      }
+    }
+  });
+});
+
+describe("the code-scanning workflow", () => {
+  it("scans the protected branches and a schedule, not pull requests", async () => {
+    const triggers = (await workflow("codeql.yml")).on as Readonly<
+      Record<string, unknown>
+    >;
+    // A fork pull request carries a read-only token and cannot upload an
+    // analysis. Every change still reaches a protected branch through a push
+    // this scans, and the schedule catches what a newer query pack finds in
+    // code that has not changed.
+    expect(Object.keys(triggers).sort()).toEqual([
+      "push",
+      "schedule",
+      "workflow_dispatch",
+    ]);
+    expect((triggers.push as { branches: string[] }).branches).toEqual([
+      "developer",
+      "main",
+    ]);
+    expect(triggers.schedule).toEqual([{ cron: "17 5 * * 1" }]);
+  });
+
+  it("asks for the one permission it needs and no other", async () => {
+    const analyze = await job("codeql.yml", "analyze");
+    expect(analyze.permissions).toEqual({
+      contents: "read",
+      "security-events": "write",
+    });
+    expect(analyze["timeout-minutes"]).toBe(30);
+  });
+
+  it("never cancels a scan in favour of a newer one", async () => {
+    // A cancelled scan leaves the branch showing the previous analysis, so
+    // cancelling would quietly age the results rather than refresh them.
+    expect((await workflow("codeql.yml")).concurrency).toEqual({
+      group: "codeql-${{ github.workflow }}-${{ github.ref }}",
+      "cancel-in-progress": false,
+    });
+  });
+
+  it("analyses the sources rather than the build output", async () => {
+    const { steps } = await job("codeql.yml", "analyze");
+    expect(steps.map((step) => step.name)).toEqual([
+      "Checkout",
+      "Initialize CodeQL",
+      "Analyze",
+    ]);
+    expect(steps[0]?.with).toEqual({ "persist-credentials": false });
+    expect(steps[1]?.with).toEqual({
+      languages: "javascript-typescript",
+      "build-mode": "none",
+      queries: "security-extended",
+      config: "paths-ignore:\n  - coverage\n  - dist\n  - node_modules\n",
+    });
+    expect(steps[2]?.with).toEqual({
+      category: "/language:javascript-typescript",
+      // Defaults to true, which would publish a queryable database of the
+      // sources as a side effect of asking for findings.
+      "upload-database": false,
+    });
+  });
+});
+
+describe("the dependency-review workflow", () => {
+  it("answers on the only event that has two revisions to diff", async () => {
+    const triggers = (await workflow("dependency-review.yml")).on as Readonly<
+      Record<string, unknown>
+    >;
+    expect(Object.keys(triggers)).toEqual(["pull_request"]);
+    expect((triggers.pull_request as { branches: string[] }).branches).toEqual([
+      "developer",
+      "main",
+    ]);
+  });
+
+  it("reads its thresholds from the file the policy document names", async () => {
+    const { steps } = await job("dependency-review.yml", "review");
+    expect(steps.map((step) => step.name)).toEqual([
+      "Checkout",
+      "Review dependency changes",
+    ]);
+    expect(steps[1]?.with).toEqual({
+      "config-file": "./.github/dependency-review-config.yml",
+    });
+  });
+});
+
+describe("the dependency-update configuration", () => {
+  it("proposes the updates exact pinning otherwise prevents", async () => {
+    const configuration = parse(await read(".github/dependabot.yml")) as {
+      readonly version: number;
+      readonly updates: readonly {
+        readonly "package-ecosystem": string;
+        readonly schedule: { readonly interval: string };
+        readonly labels: readonly string[];
+        readonly "commit-message": { readonly prefix: string };
+        readonly "open-pull-requests-limit": number;
+      }[];
+    };
+    expect(configuration.version).toBe(2);
+    expect(
+      configuration.updates.map((update) => update["package-ecosystem"]),
+    ).toEqual(["npm", "github-actions"]);
+    for (const update of configuration.updates) {
+      expect(update.schedule.interval).toBe("weekly");
+      expect(update["open-pull-requests-limit"]).toBe(5);
+      // Labels Dependabot cannot apply are labels the pull request arrives
+      // without, so these are asserted against the repository's own set.
+      for (const label of update.labels) {
+        expect(
+          ["area:quality", "type:ci", "type:maintenance"],
+          label,
+        ).toContain(label);
+      }
+      expect(["chore", "ci"]).toContain(update["commit-message"].prefix);
+    }
   });
 });


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #114

Work ID: `QAL-04a`

## Outcome and design

Vulnerable dependencies, unreviewed licenses, and code-level defects are now
found by a scheduled job rather than by someone remembering to look, and the
license set either half of the dependency tree may carry is written down and
enforced.

Three checks, each on the event that can answer it:

- **`dependency-review.yml`** runs on every pull request, which is the only
  event with two revisions to diff. It refuses at severity `low` in every
  scope, because a threshold above `low` is this repository deciding in
  advance, and without a reader, that some known vulnerable dependency is
  acceptable. Its thresholds live in `.github/dependency-review-config.yml`
  so the enforced policy is one file a reader can compare against the
  documented one.
- **`codeql.yml`** runs on the push a merge produces and weekly, not on the
  pull request. A fork carries a read-only token and cannot upload an
  analysis; a `pull_request` trigger would be a job that fails for every
  contributor outside the repository. `upload-database` is set to `false`
  rather than left at its default: the findings are the point, publishing a
  queryable database of the sources is a separate decision.
- **`dependabot.yml`** proposes the npm and Actions updates that exact
  pinning otherwise prevents, grouped so a toolchain that moves together is
  reviewed once.

`docs/security/dependency-policy.md` is the policy all three enforce: two
dependency sets governed by where a package ends up rather than by which
section of `package.json` declares it, an allowlist per set, severity-to-
remediation-window targets, and a named exception mechanism.

**Alternative rejected.** Re-enabling `npm audit` in CI. It makes every
`npm ci` depend on a network service and reports against the whole tree rather
than against the change; `audit=false` stays, and the check comes from the
dependency graph instead.

**Out of scope.** The SBOM the policy will apply to (#59, `BET-02`), and the
threat model and adversarial suites already delivered in #111.

## Compatibility and public contracts

**The plugin inventory changed from three files to four.** Writing the license
policy meant reading what the bundle actually carries, and the reading found a
real gap: `runtime/yoda.core.mjs` inlines four third-party packages licensed
`MIT` and `BSD-3-Clause`, which permit everything the build does to them except
dropping the notice — and the bundler is configured with
`legalComments: "none"`, so the released plugin carried none.

| Package | Version | License |
| --- | --- | --- |
| `ajv` | 8.20.0 | `MIT` |
| `fast-deep-equal` | 3.1.3 | `MIT` |
| `fast-uri` | 3.1.5 | `BSD-3-Clause` |
| `json-schema-traverse` | 1.0.0 | `MIT` |

`scripts/build.mjs` now writes `runtime/THIRD-PARTY-NOTICES.txt` from the
installed packages on every build, and it is in the plugin allowlist.
`docs/compatibility/runtime-distribution.md` publishes the new layout.

No parity row, command, schema, reason code, exit code, fixture, or host
contract changed. `npm run parity:check` remains `0 / 400 (0.00%)`.

## State, migration, security, and rollback

No project state, event, filesystem, Git, concurrency, or migration behaviour
is touched; the runtime is unchanged apart from the staged notices file.

**New trust boundary.** `codeql.yml` is the first job in this repository with
authority above `contents: read`. It holds exactly `security-events: write`,
and `tests/supply-chain-contract.test.ts` asserts over the whole workflow
directory that it is the *only* job with any job-level permissions at all — so
a second one cannot appear unnoticed.

No secret is referenced by any workflow, no artifact is uploaded by either new
one, and `comment-summary-in-pr: never` keeps dependency review from needing
`pull-requests: write`.

**Package verification does not trust the builder.** It re-derives the bundled
set from `dist/build-meta.json` and matches on the exact package *directory*,
so a nested copy cannot be attributed at a hoisted copy's version. The staged
notices file is held to the same forbidden-reference rule as the bundle it
ships beside.

**Rollback** is deleting the three new `.github` files; the notices half would
additionally revert `scripts/build.mjs`, `scripts/verify-package.mjs`, and the
inventory in `docs/compatibility/runtime-distribution.md`.

**Dependabot and the DCO gate.** A Dependabot pull request is a contribution
like any other, so `ci.yml`'s sign-off gate applies to it. The policy records
the remediation: `git rebase --signoff <base>` before merging. The gate is not
weakened for bots.

## Deterministic test evidence

```text
npm run verify
Test Files  134 passed (134)
Tests  3803 passed (3803)
Statements   : 100% ( 4749/4749 )
Branches     : 100% ( 3285/3285 )
Functions    : 100% ( 769/769 )
Lines        : 100% ( 4221/4221 )
parity overall: 0 / 400 (0.00%)
inventory: runtime/THIRD-PARTY-NOTICES.txt, runtime/manifest.json, runtime/yoda.core.mjs, runtime/yoda.mjs
```

```text
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/codeql.yml .github/workflows/dependency-review.yml .github/workflows/ci.yml .github/workflows/docs.yml
(no diagnostics, exit 0)
```

```text
npx markdownlint-cli2@0.20.0
Linting: 101 file(s)
Summary: 0 error(s)
```

New coverage:

- `tests/dependency-policy.test.ts` — 13 tests: the configuration's allowlist
  equals the documented one; the document names every identifier; the 266
  installed packages carry no license outside the development allowlist and
  none is undeclared; the bundled four carry none outside the narrower
  redistributed allowlist; the notices file attributes exactly them, with each
  license text under its heading.
- `tests/supply-chain-contract.test.ts` — 11 new tests across a per-directory
  `every workflow` suite and one suite per new workflow and configuration file.
- `tests/package-verifier.test.ts` — 4 new refusal tests.

Local run: Node.js `24.18.0`, npm `11.16.0`, Linux x64.
`docs/verification/issue-114-dependency-policy-evidence.md` records the license
census the allowlists were written from and the full failure campaign.

## Prompt and model evaluations

Not applicable. Every claim here is answered by a deterministic test or by a
recorded command.

## Failure evidence

Before this change, deleting the notices logic changed nothing CI would notice,
because there was no notices file to delete. The campaign below therefore runs
against the new verifier: each scenario starts from a clean `npm run build`,
changes one thing in the staged file, and runs `npm run package:verify`.

```text
Heading removed, license text left in place
  Package verification failed: runtime/THIRD-PARTY-NOTICES.txt does not attribute ajv 8.20.0 (MIT)

Section appended for a package the bundle does not carry
  Package verification failed: runtime/THIRD-PARTY-NOTICES.txt attributes unbundled left-pad 1.3.0 (WTFPL)

First section's license text emptied, heading kept
  Package verification failed: runtime/THIRD-PARTY-NOTICES.txt carries no license text for ajv 8.20.0 (MIT)

Build-machine path appended to the file
  Package verification failed: runtime/THIRD-PARTY-NOTICES.txt contains forbidden reference: node_modules
```

Each is held by a test in `tests/package-verifier.test.ts`, so the guard is
proven to reject rather than assumed to.

The workflow assertions were also written against the gap they close: pinning,
fork safety, and read-only authority were asserted against `ci.yml` and
`docs.yml` individually, so a new workflow inherited none of them. Adding
`codeql.yml` with an unpinned tag or a top-level write permission would have
passed before this change and fails now.

## Provenance

- Sources used: `github/codeql-action` (public, GitHub, MIT) and
  `actions/dependency-review-action` (public, GitHub, MIT) are referenced as
  pinned commits, not copied. The license texts in
  `runtime/THIRD-PARTY-NOTICES.txt` are copied verbatim from the installed
  `ajv`, `fast-deep-equal`, `fast-uri`, and `json-schema-traverse` packages —
  which is what those licenses require.
- Contribution method: `original`, except the license texts, which are
  `verbatim` by obligation.
- Publication authority: the `MIT` and `BSD-3-Clause` texts are reproduced
  under the terms that require their reproduction; no other third-party
  material is included.
- No secret, credential, customer or personal data, private infrastructure, or
  confidential business information is included. The one path that could have
  leaked a build machine's layout is refused by the verifier and by a test.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.

Made with [Orca](https://github.com/stablyai/orca) 🐋
