### PR TITLE
ci: keep a breaking release out of every dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,18 +29,32 @@ updates:
     # moves together — the linter and its plugin, the test runner and its
     # coverage provider — is reviewed once, against one CI run, instead of
     # arriving as four pull requests that each invalidate the others.
+    #
+    # A group carries compatible moves only. A major release is a breaking
+    # change the publisher has said is breaking, so it leaves the group and
+    # arrives as its own pull request, where the work it requires is visible
+    # against one package instead of hidden among three that need nothing.
     groups:
       lint:
+        update-types:
+          - minor
+          - patch
         patterns:
           - "@eslint/*"
           - eslint
           - eslint-*
           - typescript-eslint
       test:
+        update-types:
+          - minor
+          - patch
         patterns:
           - "@vitest/*"
           - vitest
       types:
+        update-types:
+          - minor
+          - patch
         patterns:
           - "@types/*"
 
@@ -61,7 +75,14 @@ updates:
     # Every action is pinned to a commit, so an update here is a pin change
     # with the version comment rewritten beside it — the only supported way to
     # move a pin without a person resolving a tag by hand.
+    #
+    # The same rule as the npm groups: a major release of an action changes
+    # inputs or runtime and arrives alone, because reviewing it means reading
+    # its release notes rather than the diff.
     groups:
       actions:
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -167,6 +167,16 @@ request as the bump:
 declared one, so a bump that leaves the approval behind now fails a test
 instead of an install.
 
+**A group carries compatible moves only.** Every group restricts itself to
+`minor` and `patch`, so a major release leaves the group and arrives as its own
+pull request. Grouping exists to spare a reviewer three pull requests that need
+nothing from them; a major needs the opposite, and a group hides it.
+[#119](https://github.com/thiagocorreanet/mestre-yoda/pull/119) bumped
+`@types/node` from 24 to 26 inside the `types` group, and the breaking change it
+carried surfaced as four `TS2722` errors in the worker fixtures rather than as
+anything the pull request said. The restriction does not refuse a major — it
+refuses to review one as routine.
+
 ## Absent
 
 Stated here rather than left for someone to discover:

--- a/tests/supply-chain-contract.test.ts
+++ b/tests/supply-chain-contract.test.ts
@@ -401,4 +401,29 @@ describe("the dependency-update configuration", () => {
       expect(["chore", "ci"]).toContain(update["commit-message"].prefix);
     }
   });
+
+  it("keeps a breaking release out of every group", async () => {
+    const configuration = parse(await read(".github/dependabot.yml")) as {
+      readonly updates: readonly {
+        readonly groups: Readonly<
+          Record<string, { readonly "update-types"?: readonly string[] }>
+        >;
+      }[];
+    };
+    const groups = configuration.updates.flatMap((update) =>
+      Object.entries(update.groups),
+    );
+    expect(groups.map(([name]) => name).sort()).toEqual([
+      "actions",
+      "lint",
+      "test",
+      "types",
+    ]);
+    // A group with no restriction carries a major silently, which is how
+    // #119 arrived: `@types/node` 24 to 26, breaking, inside a routine
+    // grouped bump. A major leaves the group and is reviewed on its own.
+    for (const [name, group] of groups) {
+      expect(group["update-types"], name).toEqual(["minor", "patch"]);
+    }
+  });
 });


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

No issue. This closes a gap that
[#119](https://github.com/thiagocorreanet/mestre-yoda/pull/119) exposed while it
was being merged.

Work ID: `QAL-04a` follow-up

## Outcome and design

A Dependabot group carries `minor` and `patch` only. A major release leaves the
group and arrives as its own pull request.

Every group in `.github/dependabot.yml` accepted whatever semver moved, so a
major could ride inside a routine grouped bump. #119 is the worked example: it
raised `@types/node` from 24.13.3 to 26.2.0 under the title of a `types` group
update. Nothing in the pull request said it was breaking. It surfaced only as
CI failure, after `@types/node` 26 typed `process.disconnect` as optional:

```text
tests/fixtures/locks/worker.ts(254,5): error TS2722: Cannot invoke an object which is possibly 'undefined'.
tests/fixtures/locks/worker.ts(258,5): error TS2722
tests/fixtures/transactions/worker.ts(165,5): error TS2722
tests/fixtures/transactions/worker.ts(169,5): error TS2722
```

The bump could not merge until the two worker fixtures were changed in the same
branch, which is the opposite of the routine review a grouped bump invites.

**The restriction does not refuse a major.** Dependabot still proposes it,
ungrouped, against one package — where the release notes to read and the code to
change are visible against that package alone.

Applied to all four groups (`lint`, `test`, `types`, `actions`) rather than to
`types` only. The property is about grouping, not about a package: a major
`eslint` or a major `actions/checkout` disappears into a group the same way.

**Alternative rejected.** `ignore` with
`update-types: ["version-update:semver-major"]`, which refuses majors outright.
It would mean this repository silently stops receiving major updates, including
the security-relevant ones, which is a worse failure than reviewing one
carelessly.

## Compatibility and public contracts

None. No parity row, command, schema, reason code, exit code, fixture, or host
contract changes. `npm run parity:check` remains `0 / 400 (0.00%)`, and the
plugin inventory is unchanged. The only behavior affected is how Dependabot
proposes future updates.

## State, migration, security, and rollback

No project state, event, filesystem, Git, concurrency, or migration behavior is
touched.

**Security.** This tightens review of incoming dependency changes rather than
relaxing it. A breaking change now arrives labelled as one. No new trust
boundary, permission, or secret. It does not change what may be installed or
what may run an install script — `.npmrc` and `allowScripts` remain the controls
for that.

**Rollback** is reverting this commit; groups return to accepting majors.

## Deterministic test evidence

```text
npx vitest run tests/supply-chain-contract.test.ts
Test Files  1 passed (1)
     Tests  21 passed (21)
```

```text
npm run verify
Test Files  134 passed (134)
Tests  3805 passed (3805)
Statements   : 100% ( 4749/4749 )
Branches     : 100% ( 3285/3285 )
Functions    : 100% ( 769/769 )
Lines        : 100% ( 4221/4221 )
parity overall: 0 / 400 (0.00%)
inventory: runtime/THIRD-PARTY-NOTICES.txt, runtime/manifest.json, runtime/yoda.core.mjs, runtime/yoda.mjs
```

Local run: Node.js `24.18.0`, npm `11.16.0`, Linux x64. The suite gains one
test; the count moves from 3804 to 3805.

## Prompt and model evaluations

Not applicable.

## Failure evidence

The new test was written against the unrestricted configuration and run with the
`.github/dependabot.yml` change stashed:

```text
git stash push -- .github/dependabot.yml
npx vitest run tests/supply-chain-contract.test.ts -t "breaking release"

- Expected:
[
  "minor",
  "patch",
]

+ Received:
undefined

 ❯ tests/supply-chain-contract.test.ts:426:43

 Test Files  1 failed (1)
      Tests  1 failed | 20 skipped (21)
```

It fails on the first group it reads, because no group declared `update-types`
at all. With the configuration restored it passes, and the assertion also pins
the four group names, so a fifth group added without the restriction fails here
rather than merging a breaking change quietly.

## Provenance

- Sources used: none beyond this repository, the merged #119, and the Dependabot
  configuration reference for `groups.*.update-types`.
- Contribution method: `original`.
- Publication authority: not applicable; no third-party material is included.
- No secret, credential, customer or personal data, private infrastructure, or
  confidential business information is included.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.

Made with [Orca](https://github.com/stablyai/orca) 🐋
