### PR TITLE
Add contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ Community policies are available in the [Contribution guide](CONTRIBUTING.md),
 [Code of Conduct](CODE_OF_CONDUCT.md), [Governance](GOVERNANCE.md),
 [Support policy](SUPPORT.md), and [Security policy](SECURITY.md).
 
+## Contributors
+
+Thanks to everyone who has contributed to Kratos.
+
+<a href="https://github.com/thiagocorreanet/kratos-harness/graphs/contributors">
+  <img
+    src="https://contrib.rocks/image?repo=thiagocorreanet/kratos-harness"
+    alt="Kratos contributors"
+  />
+</a>
+
 ## License
 
 MIT. The original copyright and permission notice are preserved in


### PR DESCRIPTION
## Summary

- add a dedicated Contributors section to the README
- render contributor avatars dynamically through contrib.rocks
- link the avatar panel to GitHub's contributors graph

## Why

Make community contributions visible from the project landing page without
maintaining a static image or contributor list.

## Impact

README-only documentation change. The contributor image updates from the
repository's GitHub contribution data.

## Validation

- `npx --no-install prettier --check README.md`
- `npm run english:check`
- `git diff --check`
- verified the contrib.rocks image endpoint returns HTTP 200 with SVG content

## Note

The repository-wide spellcheck currently reports existing project names such
as `Kratos`, `Mestre`, and `thiagocorreanet` as unknown words; this change adds
no new spelling category beyond the existing `Kratos` name.

Made with [Orca](https://github.com/stablyai/orca) 🐋
