### PR TITLE
fix: seed workflow replay from the lineage the run recorded

### DIFF
--- a/docs/architecture/workflow-state-machine.md
+++ b/docs/architecture/workflow-state-machine.md
@@ -20,6 +20,29 @@ detail used for idempotency. The event stream and snapshot are written by one
 managed transaction and remain protected by revision fingerprints and the run
 lease boundary.
 
+## Run lineage
+
+A run records the PRD and design digests it observed when `run.started` was
+sealed. That pair is the reducer seed, and every later command replays from the
+pair the run committed rather than from whatever the working tree holds now.
+
+The distinction matters because writing `00-prd.md` and `01-design.md` is the
+work the `prd` and `spec` phases exist to do. A seed re-read from disk changes
+the moment a phase succeeds, so replay stops reproducing the committed snapshot
+and the append refuses as corrupt before it can write the correction — a
+deadlock rather than a transient condition, and the happy path of the workflow
+would be the thing that triggers it.
+
+What the working tree holds now is observed separately and is what gates,
+approvals, and artifact lineage bind to. A PRD that changes invalidates the
+approvals bound to its old digest; it does not invalidate the run's history.
+
+One consequence is deliberate: replay cannot re-derive `lineage` from the event
+chain, so `audit` and `repair` compare every other snapshot field against replay
+and take this one as recorded. Binding lineage to the chain instead would mean a
+`state.event` contract change, which the frozen persisted contract does not
+allow at version 1.0.0.
+
 ## Command flow
 
 1. `kratos objective` records the active demand.

--- a/packages/runtime/src/composition/workflow.ts
+++ b/packages/runtime/src/composition/workflow.ts
@@ -48,6 +48,16 @@ import { anchorPorts, resolveCommandRoot } from "./root.js";
 const EMPTY_DIGEST =
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
+/**
+ * Where a run's files live. The helpers that only read those paths take this
+ * rather than the reducer configuration, so nothing can reach a lineage that
+ * is not theirs to read.
+ */
+interface RunReference {
+  readonly feature: string;
+  readonly runId: string;
+}
+
 export type ObservedWorkflow =
   | { readonly kind: "failure"; readonly result: Result }
   | {
@@ -81,19 +91,18 @@ export async function observeWorkflow(
   const runId =
     activeRun ??
     (typeof requestedRun === "string" ? requestedRun : anchored.ids.next());
-  const lineage =
+  const observedLineage =
     feature === null
       ? { prdDigest: EMPTY_DIGEST, specDigest: EMPTY_DIGEST }
       : await observeLineage(feature, anchored);
   const projectId = `project-${anchored.digests
     .sha256(anchored.environment.workingDirectory())
     .slice(0, 32)}`;
-  const configuration: WorkflowReducerConfiguration = {
+  const location = {
     projectId,
     feature: feature ?? "unselected",
     runId,
-    lineage,
-  };
+  } as const;
   const run =
     feature === null
       ? {
@@ -102,7 +111,17 @@ export async function observeWorkflow(
           persistedSnapshot: null,
           replayedSnapshot: null,
         }
-      : await observeRun(configuration, anchored, registry);
+      : await observeRun(location, anchored, registry);
+  /**
+   * Lineage is a fact of the run, not of the working tree the run is there to
+   * change. An open run replays from the digests it committed at `run.started`;
+   * only a run that does not exist yet takes the ones on disk, which is how
+   * that fact gets recorded in the first place.
+   */
+  const configuration: WorkflowReducerConfiguration = {
+    ...location,
+    lineage: run.persistedSnapshot?.lineage ?? observedLineage,
+  };
   const approvals = await observeApprovals(configuration, anchored, registry);
   const correlation = invocation.flags.get("--correlation-id");
   const host = invocation.flags.get("--host");
@@ -113,7 +132,11 @@ export async function observeWorkflow(
   const evidence = await observeEvidence(configuration, anchored, registry);
   const gateFacts = await observeGateFacts(configuration, anchored);
   const referencedFiles = await observeReferencedFiles(invocation, anchored);
-  const artifactLineage = await observeArtifactLineage(configuration, anchored);
+  const artifactLineage = await observeArtifactLineage(
+    configuration,
+    observedLineage,
+    anchored,
+  );
   const validApprovals = approvals.values.filter((approval, index, values) => {
     const seen = new Set(
       values.slice(0, index).map(({ approvalId }) => approvalId),
@@ -124,8 +147,8 @@ export async function observeWorkflow(
         {
           runId,
           gate: approval.gate,
-          prdDigest: lineage.prdDigest,
-          specDigest: lineage.specDigest,
+          prdDigest: observedLineage.prdDigest,
+          specDigest: observedLineage.specDigest,
           policyVersion: "workflow-v1",
           policyMode: policy.mode,
           objectiveDigest,
@@ -155,8 +178,14 @@ export async function observeWorkflow(
       artifactLineage.readable &&
       run.workflow.kind !== "corrupt",
     stopLoss: gateFacts.stopLoss,
-    prdDigest: lineage.prdDigest === EMPTY_DIGEST ? null : lineage.prdDigest,
-    specDigest: lineage.specDigest === EMPTY_DIGEST ? null : lineage.specDigest,
+    prdDigest:
+      observedLineage.prdDigest === EMPTY_DIGEST
+        ? null
+        : observedLineage.prdDigest,
+    specDigest:
+      observedLineage.specDigest === EMPTY_DIGEST
+        ? null
+        : observedLineage.specDigest,
     approvals: validApprovals,
     openGaps: gateFacts.openGaps,
     partitionRequired: gateFacts.partitionRequired,
@@ -215,6 +244,7 @@ export async function observeWorkflow(
       kind: "workflow",
       workflow: run.workflow,
       configuration,
+      observedLineage,
       correlationId:
         typeof correlation === "string" ? correlation : anchored.ids.next(),
       eventId: anchored.ids.next(),
@@ -244,8 +274,8 @@ export async function observeWorkflow(
         {
           runId,
           gate: invocation.positionals[0] ?? "final-acceptance",
-          prdDigest: lineage.prdDigest,
-          specDigest: lineage.specDigest,
+          prdDigest: observedLineage.prdDigest,
+          specDigest: observedLineage.specDigest,
           policyVersion: "workflow-v1",
           policyMode: policy.mode,
           objectiveDigest,
@@ -287,7 +317,8 @@ type ArtifactLineageCandidate = Omit<
 };
 
 async function observeArtifactLineage(
-  configuration: WorkflowReducerConfiguration,
+  configuration: RunReference,
+  observedLineage: RunLineage,
   ports: RuntimePorts,
 ): Promise<{
   readonly readable: boolean;
@@ -335,12 +366,11 @@ async function observeArtifactLineage(
       }
       values.push(parsed as ArtifactLineage);
     }
+    // Lineage files record the digests observed when their artifact was
+    // produced, so the roots they may descend from are the ones on disk.
     const validation = validateLineageDag(
       values,
-      new Set([
-        configuration.lineage.prdDigest,
-        configuration.lineage.specDigest,
-      ]),
+      new Set([observedLineage.prdDigest, observedLineage.specDigest]),
     );
     return validation.kind === "valid"
       ? { readable: true, values }
@@ -359,7 +389,7 @@ interface ObservedGateFacts {
 }
 
 async function observeGateFacts(
-  configuration: WorkflowReducerConfiguration,
+  configuration: RunReference,
   ports: RuntimePorts,
 ): Promise<ObservedGateFacts> {
   const empty = {
@@ -438,7 +468,7 @@ async function observePolicy(
 }
 
 async function observeEvidence(
-  configuration: WorkflowReducerConfiguration,
+  configuration: RunReference,
   ports: RuntimePorts,
   registry: SchemaRegistry,
 ): Promise<{
@@ -542,7 +572,7 @@ async function observeReferencedFiles(
 }
 
 async function observeApprovals(
-  configuration: WorkflowReducerConfiguration,
+  configuration: RunReference,
   ports: RuntimePorts,
   registry: SchemaRegistry,
 ): Promise<{
@@ -680,7 +710,7 @@ async function fileDigest(path: string, ports: RuntimePorts): Promise<string> {
 }
 
 async function observeRun(
-  configuration: WorkflowReducerConfiguration,
+  configuration: RunReference,
   ports: RuntimePorts,
   registry: SchemaRegistry,
 ): Promise<{
@@ -717,6 +747,9 @@ async function observeRun(
     });
     if (validated.kind !== "valid") return corruptRun();
     const state = validated.value;
+    // The run replays from the lineage it committed, exactly as every later
+    // append does. Re-observing the working tree here would make the two
+    // disagree the moment a phase wrote the file it exists to produce.
     const replayConfiguration: WorkflowReducerConfiguration = {
       projectId: state.projectId,
       feature: configuration.feature,

--- a/packages/runtime/src/domain/cli/approval.ts
+++ b/packages/runtime/src/domain/cli/approval.ts
@@ -101,8 +101,8 @@ function decideApproval(
     gate,
     decision:
       invocation.flags.get("--reject") === true ? "rejected" : "approved",
-    prdDigest: observation.configuration.lineage.prdDigest,
-    specDigest: observation.configuration.lineage.specDigest,
+    prdDigest: observation.observedLineage.prdDigest,
+    specDigest: observation.observedLineage.specDigest,
     policyVersion: "workflow-v1",
     approver,
     observation: note,

--- a/packages/runtime/src/domain/cli/spec.ts
+++ b/packages/runtime/src/domain/cli/spec.ts
@@ -15,6 +15,7 @@ import type {
 import type { ProjectResolution } from "../project/index.js";
 import type { Result } from "../result/index.js";
 import type {
+  RunLineage,
   WorkflowReducerConfiguration,
   WorkflowState,
   WorkflowObservation,
@@ -114,7 +115,18 @@ export type CommandObservation =
   | {
       readonly kind: "workflow";
       readonly workflow: WorkflowObservation;
+      /**
+       * The reducer seed, whose lineage is the fact the run recorded when it
+       * started. Replay reproduces the committed snapshot from it, so it must
+       * never move while the run is open.
+       */
       readonly configuration: WorkflowReducerConfiguration;
+      /**
+       * The PRD and design digests on disk right now. Gates, approvals, and
+       * artifact lineage bind to these, because the point of the `prd` and
+       * `spec` phases is to change them.
+       */
+      readonly observedLineage: RunLineage;
       readonly correlationId: string;
       readonly eventId: string;
       readonly occurredAt: string;

--- a/packages/runtime/src/domain/cli/workflow.ts
+++ b/packages/runtime/src/domain/cli/workflow.ts
@@ -226,8 +226,8 @@ export const doneCommand: CommandSpec = observingCommand(
       (approval) =>
         approval.gate === "final-acceptance" &&
         approval.runId === observation.configuration.runId &&
-        approval.prdDigest === observation.configuration.lineage.prdDigest &&
-        approval.specDigest === observation.configuration.lineage.specDigest &&
+        approval.prdDigest === observation.observedLineage.prdDigest &&
+        approval.specDigest === observation.observedLineage.specDigest &&
         approval.policyVersion === "workflow-v1" &&
         approval.challenge === observation.approvalChallenge &&
         approval.decision === "approved" &&
@@ -264,8 +264,8 @@ export const doneCommand: CommandSpec = observingCommand(
               artifactRef: artifactObservation.ref,
               artifactDigest: artifactObservation.sha256,
               parentDigests: [
-                observation.configuration.lineage.prdDigest,
-                observation.configuration.lineage.specDigest,
+                observation.observedLineage.prdDigest,
+                observation.observedLineage.specDigest,
               ],
               runId: observation.configuration.runId,
               phase: "acceptance",
@@ -396,8 +396,8 @@ function workflowDecision(
           artifactRef: artifact.ref,
           artifactDigest: artifact.sha256,
           parentDigests: [
-            observation.configuration.lineage.prdDigest,
-            observation.configuration.lineage.specDigest,
+            observation.observedLineage.prdDigest,
+            observation.observedLineage.specDigest,
           ].filter((digest, index, values) => values.indexOf(digest) === index),
           runId: observation.configuration.runId,
           phase:

--- a/tests/workflow-run-lineage.test.ts
+++ b/tests/workflow-run-lineage.test.ts
@@ -1,0 +1,267 @@
+import { runCommandLine } from "@kratos/runtime/composition/cli";
+import {
+  fixedClock,
+  fixedEnvironment,
+  memoryFileSystem,
+  memoryTransactionStorage,
+  memoryWorkspace,
+  pipedInput,
+  recordingOutput,
+  sequentialIds,
+  stubGit,
+} from "@kratos/runtime/infra/fake";
+import type { RuntimePorts } from "@kratos/runtime/ports";
+import { describe, expect, it } from "vitest";
+
+const ROOT = "/project";
+const NOW = "2026-08-14T12:00:00.000Z";
+const TEXT = "Ship the export pipeline";
+const FEATURE = "ship-the-export-pipeline";
+const PRD = `.brain/02-features/${FEATURE}/00-prd.md`;
+const SPEC = `.brain/02-features/${FEATURE}/01-design.md`;
+const ANSWERS = JSON.stringify({
+  contractVersion: "1.0.0",
+  hostContract: "1.0.0",
+  hosts: ["claude"],
+  language: "en",
+  policyMode: "standard",
+  snapshots: true,
+});
+const EMPTY_DIGEST =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+interface Subject {
+  readonly ports: RuntimePorts;
+  readonly storage: ReturnType<typeof memoryTransactionStorage>;
+  readonly output: ReturnType<typeof recordingOutput>;
+}
+
+function subject(
+  files: Readonly<Record<string, string>> = {},
+  directories: readonly string[] = [".brain", ".brain/transactions"],
+  answers: string | null = null,
+): Subject {
+  const storage = memoryTransactionStorage({ files, directories });
+  const output = recordingOutput();
+  return {
+    storage,
+    output,
+    ports: {
+      clock: fixedClock(NOW),
+      ids: sequentialIds("id"),
+      digests: storage.digests,
+      durableFileSystem: storage.durableFileSystem,
+      fileSystem: memoryFileSystem({}),
+      environment: fixedEnvironment({}, ROOT),
+      git: stubGit(),
+      output,
+      standardInput: pipedInput(answers),
+      workspace: memoryWorkspace({ directories: [ROOT] }),
+    } as unknown as RuntimePorts,
+  };
+}
+
+/** The settled project, with the transaction scratch space left behind. */
+function settled(run: Subject): {
+  readonly files: Readonly<Record<string, string>>;
+  readonly directories: readonly string[];
+} {
+  const snapshot = run.storage.snapshot();
+  return {
+    files: Object.fromEntries(
+      Object.entries(snapshot.files).filter(
+        ([path]) => !path.startsWith(".brain/transactions/"),
+      ),
+    ),
+    directories: snapshot.directories.filter(
+      (path) => !path.includes("/transactions/"),
+    ),
+  };
+}
+
+/** Carry the settled project forward, optionally writing phase artifacts. */
+function next(
+  run: Subject,
+  written: Readonly<Record<string, string>> = {},
+): Subject {
+  const state = settled(run);
+  return subject({ ...state.files, ...written }, state.directories);
+}
+
+/** A project initialized, given an objective, and started on the `prd` phase. */
+async function startedRun(): Promise<Subject> {
+  const initialized = subject({}, [".brain", ".brain/transactions"], ANSWERS);
+  expect(await runCommandLine(["init"], initialized.ports)).toBe(0);
+  const objective = next(initialized);
+  expect(await runCommandLine(["objective", TEXT], objective.ports)).toBe(0);
+  const started = next(objective);
+  expect(
+    await runCommandLine(["start", "--host", "claude-code"], started.ports),
+  ).toBe(0);
+  return started;
+}
+
+/**
+ * Record digest-bound evidence for one file, as `continue` requires.
+ *
+ * Every step names its own correlation identifier. Each step runs on a fresh
+ * subject, so the deterministic identifier sequence restarts, and two steps
+ * that shared one would read as a duplicate delivery of the first.
+ */
+async function recordEvidence(
+  run: Subject,
+  ref: string,
+  correlationId: string,
+): Promise<Subject> {
+  expect(
+    await runCommandLine(
+      ["evidence", "record", ref, "--correlation-id", correlationId],
+      run.ports,
+    ),
+  ).toBe(0);
+  return next(run);
+}
+
+/** Complete the current phase against one artifact and its recorded evidence. */
+function completePhase(
+  run: Subject,
+  ref: string,
+  correlationId: string,
+): Promise<number> {
+  return runCommandLine(
+    [
+      "continue",
+      "--complete",
+      "--artifact",
+      ref,
+      "--evidence",
+      ref,
+      "--correlation-id",
+      correlationId,
+    ],
+    run.ports,
+  );
+}
+
+function snapshotOf(run: Subject): {
+  readonly lineage: { readonly prdDigest: string; readonly specDigest: string };
+  readonly currentStep: string | null;
+  readonly status: string;
+  readonly eventCursor: number;
+} {
+  const path = Object.keys(settled(run).files).find(
+    (candidate) =>
+      candidate.includes("/runs/") && candidate.endsWith("/state.json"),
+  );
+  if (path === undefined) throw new Error("the run wrote no snapshot");
+  return JSON.parse(settled(run).files[path] ?? "") as ReturnType<
+    typeof snapshotOf
+  >;
+}
+
+/**
+ * Regression coverage for the run lineage the reducer is seeded with.
+ *
+ * Producing `00-prd.md` and `01-design.md` is the whole point of the `prd` and
+ * `spec` phases. When the reducer seed was re-observed from disk on every
+ * command, writing either file made the replay disagree with the snapshot the
+ * run had already committed, and every later transaction refused with
+ * `runtime.state_corrupt` before it could write the correction. The lineage a
+ * run records is a fact of that run, so replay reads it back rather than
+ * re-deriving it from a working tree the run itself is there to change.
+ */
+describe("a run whose phases write the lineage files", () => {
+  it("records the digests observed when the run started", async () => {
+    const run = await startedRun();
+
+    // Neither file exists yet, which is exactly what the `prd` phase is for.
+    expect(snapshotOf(run).lineage).toEqual({
+      prdDigest: EMPTY_DIGEST,
+      specDigest: EMPTY_DIGEST,
+    });
+    expect(snapshotOf(run).currentStep).toBe("prd");
+  });
+
+  it("advances to spec after the prd phase writes the PRD", async () => {
+    const started = await startedRun();
+    const run = await recordEvidence(
+      next(started, { [PRD]: "# PRD\n\nShip the export pipeline.\n" }),
+      PRD,
+      "evidence-prd",
+    );
+
+    const code = await completePhase(run, PRD, "complete-prd");
+
+    expect(run.output.human_.join("")).not.toContain("runtime.state_corrupt");
+    expect(code).toBe(0);
+    expect(snapshotOf(run).currentStep).toBe("spec");
+  });
+
+  it("advances to plan after the spec phase writes the design", async () => {
+    const started = await startedRun();
+    const prd = await recordEvidence(
+      next(started, { [PRD]: "# PRD\n\nShip the export pipeline.\n" }),
+      PRD,
+      "evidence-prd",
+    );
+    expect(await completePhase(prd, PRD, "complete-prd")).toBe(0);
+    const run = await recordEvidence(
+      next(prd, { [SPEC]: "# Design\n\nOne pipeline.\n" }),
+      SPEC,
+      "evidence-spec",
+    );
+
+    const code = await completePhase(run, SPEC, "complete-spec");
+
+    expect(run.output.human_.join("")).not.toContain("runtime.state_corrupt");
+    expect(code).toBe(0);
+    expect(snapshotOf(run).currentStep).toBe("plan");
+  });
+
+  it("keeps the recorded lineage when a phase artifact is edited later", async () => {
+    const started = await startedRun();
+    const first = await recordEvidence(
+      next(started, { [PRD]: "# PRD\n\nFirst draft.\n" }),
+      PRD,
+      "evidence-prd",
+    );
+    expect(await completePhase(first, PRD, "complete-prd")).toBe(0);
+    const recorded = snapshotOf(first).lineage;
+    const run = next(first, { [PRD]: "# PRD\n\nSecond draft, revised.\n" });
+
+    const code = await runCommandLine(["status"], run.ports);
+
+    expect(code).toBe(0);
+    // The edit is visible to gates and approvals, and it never rewrites the
+    // fact the run committed.
+    expect(snapshotOf(run).lineage).toEqual(recorded);
+  });
+
+  it("resumes a run whose working tree gained the PRD", async () => {
+    const started = await startedRun();
+    const run = next(started, {
+      [PRD]: "# PRD\n\nShip the export pipeline.\n",
+    });
+
+    const code = await runCommandLine(
+      ["start", "--host", "claude-code"],
+      run.ports,
+    );
+
+    expect(run.output.human_.join("")).not.toContain("runtime.state_corrupt");
+    expect(code).toBe(0);
+    expect(snapshotOf(run).status).toBe("active");
+  });
+
+  it("audits a run whose working tree gained the PRD", async () => {
+    const started = await startedRun();
+    const run = next(started, {
+      [PRD]: "# PRD\n\nShip the export pipeline.\n",
+    });
+
+    expect(await runCommandLine(["audit"], run.ports)).toBe(0);
+    expect(
+      `${run.output.structured_.join("")}${run.output.human_.join("")}`,
+    ).toContain("Replay verified revision 1");
+  });
+});


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #127

Work ID: `SDD-03a`

## Outcome and design

`kratos continue` now accepts the transition after the `prd` phase writes
`00-prd.md`, and the run advances to `spec`. The same holds for `01-design.md`
during `spec`, and for any later edit of either file.

The reducer seed carried a `lineage` re-observed from disk on every command.
The moment either file appeared, replay stopped reproducing the snapshot the run
had already committed, and every later transaction refused with
`runtime.state_corrupt`. Because the comparison happens before the write, the
snapshot could never be corrected — a deadlock, not a transient condition, and
the happy path of the workflow was the thing that triggered it. `audit` and
`repair` reported a healthy run throughout, because the read path already seeded
replay from the persisted snapshot; only the append path reached for the live
observation.

`configuration.lineage` was conflating two facts:

- replay needs the pair the run sealed at `run.started`, and needs it to hold
  still for the life of the run
- gates, approvals, and artifact lineage need the pair on disk right now,
  because changing that pair is the point of the `prd` and `spec` phases

An open run now replays from `persistedSnapshot.lineage`. Only a run that does
not exist yet takes the digests on disk, which is how the fact gets recorded in
the first place. The live pair moved to a separate `observedLineage` on the
command observation. The helpers that only resolve run paths (`observeRun`,
`observeApprovals`, `observeEvidence`, `observeGateFacts`) take a `RunReference`
instead of the reducer configuration, so they can no longer reach a lineage that
is not theirs to read.

Alternatives considered:

- **Persist lineage in the `run.started` event and seed replay from it** — the
  issue's first preference, and the design that would also let `audit` detect a
  tampered snapshot lineage. It requires adding a property to
  `schemas/state/event.v1.schema.json`, which declares
  `additionalProperties: false` and is frozen at `stateContract` 1.0.0. It
  changes `eventHash` for every event and the golden fixtures in roughly fifteen
  test files. That is a contract-version change with a migration path, not a
  bug fix. Rejected here, viable as its own issue.
- **Exclude lineage from snapshot equality and rebase it per transition** — the
  issue's second option. It puts a carve-out in the canonical-bytes comparison
  in `assertPersistedSnapshot`, weakening tamper evidence for the whole snapshot
  to fix one field. Rejected.

Out of scope: the four minor findings in the issue. Two are confirmed and worth
their own issues — see the closing comment on #127.

## Compatibility and public contracts

- **Schemas** — none. `state.snapshot` and `state.event` are untouched;
  `contracts:check` verifies 13 schemas and generated types as current.
- **Reason/exit codes** — none. `runtime.state_corrupt` keeps its meaning; runs
  that were never corrupt simply stop reporting it.
- **Commands** — no flag, positional, or help-text change. `cli-help` and
  `parity-inventory-contract` pass unchanged.
- **Go-v3 parity** — none. `oracle:verify` and `differential:check` pass
  unchanged.
- **Snapshot content** — a run started before this change keeps the lineage it
  recorded; nothing rewrites it. Runs already wedged at `runtime.state_corrupt`
  become usable again without intervention, because the refusal was computed
  from the live observation rather than from anything persisted.
- **Documentation** — `docs/architecture/workflow-state-machine.md` gains a
  `Run lineage` section stating the rule and its one deliberate limitation.

## State, migration, security, and rollback

- **Project state** — no new file, no new path, no format change. The run still
  owns exactly the two event-store destinations.
- **Event stream** — unchanged. No new event type, field, or policy version.
- **Migration** — none required. Existing runs are read exactly as before; the
  change is in which lineage the append path seeds replay with.
- **Concurrency** — unchanged. Revision fingerprints and the run lease boundary
  are untouched.
- **Security** — no new trust boundary, permission, secret, or data handling.
  Approvals stay content-bound to the digests on disk, so an edited PRD still
  invalidates the approvals bound to its old digest. Narrowing four helpers to
  `RunReference` removes their access to a lineage they never legitimately read.
- **Rollback** — revert the commit. No persisted state depends on it.

## Deterministic test evidence

```text
npx vitest run tests/workflow-run-lineage.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)

npx vitest run
Test Files  143 passed (143)
     Tests  3860 passed (3860)

npm run test:coverage
Statements   : 93.78% ( 5449/5810 )
Branches     : 89.73% ( 3916/4364 )
Functions    : 93.85% ( 931/992 )
Lines        : 93.84% ( 4892/5213 )

npm run format:check
All matched files use Prettier code style!

npm run lint
(no output, --max-warnings 0)

npx tsc --noEmit
(no output)

npm run spellcheck
CSpell: Files checked: 144, Issues found: 0 in 0 files.

npm run english:check
English-only source check passed.

npm run contracts:check
contract families v1.0.0: verified (13 schemas; 14 legacy profiles; generated types current)

npm run result:check
result contract v1.0.0: verified (76 reasons; exits 0,1,2,3,4,5; 6 examples)

npm run oracle:verify
oracle go-v3-v0.6.5: public catalog verified (12 surfaces, 4 PRD anchors, 3 binaries)

npm run differential:check
{"class":"self-test","equal":true,"oracleId":"synthetic-public-self-test","planned":12,...}

npm run mutation:check
gate mutation score: 3 / 3 (100.00%)

npm run performance:check
runtimeSourceBytes: 774698 / 1500000
contractSchemaBytes: 59338 / 250000

npm run build && npm run package:verify
Kratos package verification passed for Codex and Claude Code.

npm run benchmark
helpP95Ms 134.14, versionP95Ms 120.42, handshakeP95Ms 152.29, bundleBytes 783574

node scripts/check-dco.mjs --base origin/main --head HEAD
DCO: 1 commit signed off
```

Platform: Linux, Node 24.18.0, npm 11.16.0.

## Prompt and model evaluations

Not applicable. The behavior is fully determined by the event stream, the
snapshot, and the observed filesystem, and is covered by deterministic tests.

## Failure evidence

Minimal reproduction against the built plugin, before the fix:

```text
kratos init --root . --answers answers.json
kratos objective --root . "minha feature"
kratos start --root . --host claude-code
  → trail.ok, run created on phase prd
  → snapshot lineage.prdDigest = e3b0c442...b855 (EMPTY_DIGEST, no file existed)

printf '# PRD\n' > .brain/02-features/minha-feature/00-prd.md

kratos continue --root . --complete \
  --artifact .brain/02-features/minha-feature/00-prd.md \
  --evidence  .brain/02-features/minha-feature/00-prd.md

{"status":"blocked","exitCode":4,"reasonCode":"runtime.state_corrupt",
 "summary":"The managed transaction did not reach a committed state.","retryable":true}

kratos audit  --root .  → runtime.orientation_ok, "Replay verified revision 1"
kratos repair --root .  → runtime.orientation_ok, "Replay and the persisted snapshot already agree."
```

Deterministic, and the run stays unusable on every retry. `audit` and `repair`
pass because both replay from the persisted snapshot's own lineage, so they are
blind to the one field that diverged.

Regression test `tests/workflow-run-lineage.test.ts` drives the same sequence
through the composed CLI over the in-memory ports. With the source fix stashed
and the test kept:

```text
git stash push packages/runtime/src && npx vitest run tests/workflow-run-lineage.test.ts
× advances to spec after the prd phase writes the PRD
× advances to plan after the spec phase writes the design
× keeps the recorded lineage when a phase artifact is edited later
× resumes a run whose working tree gained the PRD
Tests  4 failed | 2 passed (6)
```

The first two fail with `runtime.state_corrupt` on the append; the last two fail
the same way on `start` and on a later observation, which is what shows the
deadlock reaches every command and not only `continue`.

The end-to-end path after the fix, against the built plugin:

```text
start                                        → trail.ok, phase prd
write 00-prd.md; evidence record; continue   → trail.ok accepted, phase spec
write 01-design.md; evidence record; continue → trail.ok accepted, phase plan
audit                                        → Replay verified revision 3
repair                                       → Replay and the persisted snapshot already agree.
```

## Provenance

- Sources used: this repository only, public, owned by the repository owner. No
  third-party code, documentation, or fixture was consulted or adapted.
- Contribution method: `original`.
- Publication authority and required notices: not applicable; no adapted or
  verbatim third-party material.
- Confirmed: no secret, credential, customer or personal data, private
  infrastructure detail, or confidential business information is included. The
  reproduction uses a throwaway project under a temporary directory.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
