### PR TITLE
fix(workflow): explain rejected transitions

### DIFF
--- a/packages/runtime/src/domain/cli/workflow.ts
+++ b/packages/runtime/src/domain/cli/workflow.ts
@@ -422,6 +422,12 @@ function workflowDecision(
   return {
     result: resultFor("trail.ok", {
       summary: `Workflow transition ${workflow.transition} was recorded.`,
+      why:
+        workflow.transition === "rejected"
+          ? (workflow.why ?? [
+              "The workflow transition was rejected by its persisted conditions.",
+            ])
+          : [],
       stateChanged: true,
       evidence: [
         { kind: "event", ref: `${runRoot}/events.jsonl` },

--- a/packages/runtime/src/domain/workflow/decision.ts
+++ b/packages/runtime/src/domain/workflow/decision.ts
@@ -210,6 +210,7 @@ export function decideContinueWorkflow(
       "rejected",
       request.action.artifactRefs,
       request.action.evidenceRefs,
+      ["explicit-reject"],
     );
   }
   if (
@@ -224,6 +225,7 @@ export function decideContinueWorkflow(
       "rejected",
       request.action.artifactRefs,
       request.action.evidenceRefs,
+      rejectionWhy(request.action),
     );
   }
   const finalPhase = state.currentStep === RUN_PHASES.at(-1);
@@ -235,6 +237,7 @@ export function decideContinueWorkflow(
       "rejected",
       request.action.artifactRefs,
       request.action.evidenceRefs,
+      ["final-completion-not-allowed"],
     );
   }
   return recorded(
@@ -247,6 +250,28 @@ export function decideContinueWorkflow(
   );
 }
 
+function rejectionWhy(
+  action: Extract<
+    ContinueWorkflowRequest["action"],
+    { readonly kind: "complete-phase" }
+  >,
+): readonly string[] {
+  const reasons = [...action.gateFailures];
+  if (
+    action.artifactRefs.length === 0 &&
+    !reasons.includes("artifact-unreadable")
+  ) {
+    reasons.push("artifact-missing");
+  }
+  if (
+    action.evidenceRefs.length === 0 &&
+    !reasons.includes("evidence-invalid")
+  ) {
+    reasons.push("evidence-missing");
+  }
+  return [...new Set(reasons)];
+}
+
 function recorded(
   request: ContinueWorkflowRequest,
   operation: string,
@@ -257,6 +282,7 @@ function recorded(
   >["transition"],
   artifactRefs: readonly string[] = [],
   evidenceRefs: readonly string[] = [],
+  why?: readonly string[],
 ): WorkflowDecision {
   return {
     kind: "recorded",
@@ -273,5 +299,6 @@ function recorded(
       artifactRefs,
       evidenceRefs,
     ),
+    ...(why === undefined ? {} : { why: [...why] }),
   };
 }

--- a/packages/runtime/src/domain/workflow/model.ts
+++ b/packages/runtime/src/domain/workflow/model.ts
@@ -102,6 +102,8 @@ export type WorkflowDecision =
       readonly transition:
         "started" | "resumed" | "accepted" | "rejected" | "completed";
       readonly event: EventDraftV1;
+      /** Stable identifiers explaining why a transition was rejected. */
+      readonly why?: readonly string[];
     }
   | {
       readonly kind: "unchanged";

--- a/tests/workflow-run-lineage.test.ts
+++ b/tests/workflow-run-lineage.test.ts
@@ -197,6 +197,35 @@ describe("a run whose phases write the lineage files", () => {
     expect(snapshotOf(run).currentStep).toBe("spec");
   });
 
+  it("reports the invalid evidence that rejected a continue", async () => {
+    const started = await startedRun();
+    const run = next(started, {
+      [PRD]: "# PRD\n\nShip the export pipeline.\n",
+    });
+
+    const code = await runCommandLine(
+      [
+        "--json",
+        "continue",
+        "--complete",
+        "--artifact",
+        PRD,
+        "--evidence",
+        PRD,
+        "--correlation-id",
+        "reject-prd",
+      ],
+      run.ports,
+    );
+
+    expect(code).toBe(0);
+    expect(JSON.parse(run.output.structured_.join(""))).toMatchObject({
+      reasonCode: "trail.ok",
+      summary: "Workflow transition rejected was recorded.",
+      why: ["evidence-invalid"],
+    });
+  });
+
   it("advances to plan after the spec phase writes the design", async () => {
     const started = await startedRun();
     const prd = await recordEvidence(

--- a/tests/workflow-state-machine.test.ts
+++ b/tests/workflow-state-machine.test.ts
@@ -139,6 +139,7 @@ describe("workflow start and continuation", () => {
     expect(decision).toMatchObject({
       kind: "recorded",
       transition: "rejected",
+      why: ["gate.prd_ausente", "artifact-missing", "evidence-missing"],
       event: { reasonCode: "run.transition.rejected" },
     });
   });


### PR DESCRIPTION
Fixes #152

## Summary

- Preserve rejection identifiers when `continue --complete` records a rejected transition.
- Return those identifiers in the result envelope's `why` field.
- Distinguish gate failures, unreadable or missing artifact/evidence references, explicit rejection, and disallowed final completion.

## Root cause

The CLI already computed gate failure identifiers such as `evidence-invalid`, but the workflow decision used them only as a boolean rejection condition. The recorded decision and result renderer discarded the diagnosis, leaving callers with the same generic summary for every rejection.

## Validation

- `npx vitest run tests/workflow-state-machine.test.ts tests/workflow-run-lineage.test.ts` (13 tests passed)
- `npm run typecheck` (passed)
- Targeted ESLint and Prettier checks (passed)
- `git diff --check` (passed)

The local runtime is Node 24.15.0/npm 11.12.1 while the repository declares Node >=24.18.0/npm 11.16.0; dependencies were installed with engine strictness disabled for verification.
