### PR TITLE
fix: read a scope generation retired under a listing as unpublished

### DIFF
--- a/packages/runtime/src/composition/locks.ts
+++ b/packages/runtime/src/composition/locks.ts
@@ -907,11 +907,14 @@ async function assertScopeClaimChildren(
     ];
     if (String(Number(expiresText)) !== expiresText) throw corrupt(claim);
     const generation = `${claim}/${generationName}`;
-    if (
-      (await services.durableFileSystem.inspect(generation)).kind !==
-      "directory"
-    )
-      throw corrupt(generation);
+    const generationEntry =
+      await services.durableFileSystem.inspect(generation);
+    // The generation leaves ahead of the `claim` directory that holds it, so a
+    // listing that just named it can be overtaken by its own retirement. The
+    // claim itself is still there, which is why the vanish check below cannot
+    // rescue this shape and it has to be read here.
+    if (generationEntry.kind === "missing") return;
+    if (generationEntry.kind !== "directory") throw corrupt(generation);
     const children = await services.durableFileSystem.list(generation);
     const markers = children
       .map((name) =>

--- a/tests/lock-claims.test.ts
+++ b/tests/lock-claims.test.ts
@@ -5427,6 +5427,34 @@ describe("durable lock claims", () => {
     },
   );
 
+  // The generation is the last thing a retirement removes, and the `claim`
+  // directory that held it survives. A reader that listed the generation a
+  // moment earlier therefore inspects a path that is already gone without the
+  // ancestor vanish check having anything to report.
+  it.each(["project", "run:run-01"] as const)(
+    "reads a %s generation unlinked under the listing that named it as unpublished",
+    async (resource) => {
+      const retiring: LockClaimRecord = {
+        ...observedRecord,
+        claimId: `unlinked-generation-${resource}`,
+        resource,
+      };
+      const generation = parentDirectory(publishedScopeRecord(retiring));
+      const storage = lockStorage({ directories: [generation] });
+      const baseInspect = storage.durableFileSystem.inspect;
+
+      await expect(
+        inspectLease(
+          resource,
+          withDurable(storage, {
+            inspect: async (path) =>
+              path === generation ? { kind: "missing" } : baseInspect(path),
+          }),
+        ),
+      ).resolves.toMatchObject({ kind: "empty", claim: null, lease: null });
+    },
+  );
+
   it.each(["project", "run:run-01"] as const)(
     "removes every partial expired %s scope candidate form",
     async (resource) => {


### PR DESCRIPTION
## Summary

- Read a scope generation unlinked under the listing that named it as unpublished rather than as `runtime.state_corrupt`.
- Pin the shape with a claim test, so the regression no longer depends on the race landing in CI.

## Root cause

`assertScopeClaimChildren` lists the `claim` directory, then inspects the generation the listing named. A scope retirement removes the record, then the cleanup marker, then the generation — and the `claim` directory that held it survives. A concurrent reader therefore inspects a generation its owner has already unlinked while every ancestor is still present.

That inspection raised `runtime.state_corrupt` against the generation path: a terminal reason no protocol repairs, aimed at a sibling that followed the protocol exactly. Because `corrupt` raises a `LockFailure`, the handler rethrows it before `vanishedUnderLocks` runs — and that check would not have rescued the shape anyway, since it walks ancestors and the ancestors are all there. The absence has to be read where it is seen.

dbcc3d8 (`RUN-07b`) closed the record and the empty generation. This is the third shape of the same retirement. The admission reader already spells it out at the matching inspection in `locateAdmission`.

## Impact

This is a pre-existing flake on `main`, not a regression from any open PR. `Native platforms` failed this way on `ac0e4b9` and `62bf90a`, and again on #153, always as `lock-process-contention` observing a `corrupt` outcome naming another worker's generation:

```
AssertionError: expected [ { kind: 'corrupt', ... } ] to deeply equal []
  evidence: .brain/locks/runs/cnVuLTAx/claim/.claim-1786406430000-b0c39dc9...
```

The new claim test reproduces that exact evidence and fails without the fix.

## Validation

- `npm test` (143 files, 3862 tests passed)
- `npm run test:coverage` (thresholds met)
- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run spellcheck`, `npm run english:check`
- `tests/lock-process-contention.test.ts` run 7 times in a row, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)