### PR TITLE
feat: define the agent output contract so replies enter the runtime typed

### DIFF
--- a/docs/architecture/agent-output-contract.md
+++ b/docs/architecture/agent-output-contract.md
@@ -1,0 +1,119 @@
+# Agent output contract
+
+Issue [#129](https://github.com/thiagocorreanet/kratos-harness/issues/129)
+defines what a phase agent produces, so an agent reply enters the runtime as
+typed, validated data instead of prose somebody has to scrape.
+
+Issue [#113](https://github.com/thiagocorreanet/kratos-harness/issues/113)
+covers the other direction: what the host tells the runtime about a session.
+This contract follows its envelope conventions and adds nothing to them.
+
+## The machine block
+
+An agent reply is Markdown written for a person. Exactly one machine block is
+appended to it, delimited by two lines that have no meaning in Markdown:
+
+```text
+===KRATOS-AGENT-OUTPUT-V1===
+{ "contractVersion": "1.0.0", "hostContract": "1.0.0", ... }
+===END-KRATOS-AGENT-OUTPUT-V1===
+```
+
+The rules the extractor enforces:
+
+- each delimiter is recognized only as a whole line with no indentation;
+- exactly one opening and one closing delimiter may appear in a reply;
+- the closing delimiter is the last thing in the reply, and only whitespace may
+  follow it;
+- between them is one JSON object.
+
+The delimiter is deliberately not a Markdown fence. A reply may contain fenced
+examples, including fenced JSON, and a fence-shaped delimiter would make the
+extractor's answer depend on what the surrounding prose happened to illustrate.
+A reply that repeats a delimiter, for instance inside an example of this very
+contract, is refused rather than guessed at.
+
+Line endings are normalized before the delimiters are matched, so a host that
+writes CRLF and a host that writes LF extract the same block.
+
+## Envelope
+
+Every block fixes:
+
+- `contractVersion` and `hostContract`, validated before the payload;
+- `agent`, one of `prd`, `spec`, `plan`, `code`, `review`, `acceptance`;
+- `outcome.status`, one of `completed`, `awaiting-input`, `blocked`;
+- `outcome.next`, the routing hint: `proceed`, `wait`, `retry`, `finish`, or
+  `stop`;
+- `outcome.questions`, the blocking questions, as objects a host renders;
+- `outcome.blockers`, why the agent stopped;
+- `artifacts`, the specification documents the agent wrote;
+- `changedFiles`, the source and test files it touched, each with its change;
+- `payload`, chosen by `agent`.
+
+The routing hint is a hint. The runtime decides; an agent that says `proceed`
+past a failing gate is describing its own view, not authorizing a transition.
+
+Status and hint have to agree, and the schema enforces it: `completed` routes
+to `proceed` or `finish` and carries no questions and no blockers;
+`awaiting-input` routes to `wait` and carries at least one question;
+`blocked` routes to `retry` or `stop` and carries at least one blocker.
+
+`artifacts` and `changedFiles` stay separate fields. The scope check reads the
+difference between a document the agent wrote and a source file it edited, and
+a block that claims one path as both is refused.
+
+A question is an object, not a formatted string: a `questionId`, a `prompt`, a
+`kind` of `free-text`, `single-choice`, or `multiple-choice`, and `options`
+carrying an identifier and a label each. A choice question requires at least
+two options; a free-text question carries none. Every host renders the same
+object into whatever prompt widget it has.
+
+## Payloads
+
+One closed payload per phase agent, selected by the `agent` discriminator, each
+with `additionalProperties: false`. The document validates as one closed object
+rather than as a union of six, so a refusal names the offending path instead of
+the document root.
+
+| Agent | Payload |
+| --- | --- |
+| `prd` | `objective`, `requirementIds`, `gapIds` |
+| `spec` | `requirementIds`, `gapIds`, `approvalRequired` |
+| `plan` | `steps`, each with `stepId`, `summary`, `dependsOn` |
+| `code` | `stepId`, `testsAdded`, `testsPassed` |
+| `review` | `verdict`, `findings` with severity and reference |
+| `acceptance` | `verdict`, `criteria` with outcome and evidence reference |
+
+## Extraction, validation, recording
+
+`kratos agent record REF` runs three steps in this order and never reorders
+them:
+
+1. **Extract.** Three exits: no block found, a block found that is not usable
+   before parsing, or a block. The second exit names which rule broke, from
+   `duplicate-open` to `invalid-json`.
+2. **Validate.** The extracted document is checked against
+   `host.agent-output@1.0.0` through the schema registry, then against the
+   agreements the schema cannot state: a path claimed as both artifact and
+   changed file, a repeated question, option, or step identifier, a dependency
+   on a step the plan does not contain, a review that passes while carrying a
+   high finding, and an acceptance that accepts while a criterion did not pass.
+3. **Record.** The validated block is written verbatim to
+   `runs/RUN/agent-output/AGENT.json` and one `run.agent.recorded` event is
+   appended. Recording a fact does not move the run through its phases.
+
+Every refusal reports `trail.output_invalido` and names its cause. A reply with
+no block, a malformed block, or a schema-invalid block all fail closed and
+leave the run exactly where it was.
+
+Extraction and validation perform no model call and no network access. The
+extractor is a pure function of the reply text, and the module reaches nothing
+but the published contracts and the schema types.
+
+## Reading it back
+
+A derived view reads `agent-output/AGENT.json` through the same contract that
+admitted it, so it reads typed data rather than re-reading the reply. A
+recorded document that no longer satisfies the contract fails closed rather
+than reading as nothing recorded.

--- a/docs/user/commands.md
+++ b/docs/user/commands.md
@@ -13,6 +13,7 @@ also accept `--root PATH` where shown by `kratos help`.
 | `continue` | Resume, reject, or complete one phase | Conditional |
 | `approve GATE` | Record digest-bound approval or rejection | Yes |
 | `evidence record ID REF` | Register classified, digest-bound evidence | Yes |
+| `agent record REF` | Extract, validate, and record one agent reply | Yes |
 | `gaps record REF` | Receive proposed gaps and derive the gate facts | Yes |
 | `gaps resolve ID` | Record the owner's verdict on one gap | Yes |
 | `gaps waive ID` | Record proceeding over a gap nobody answered | Yes |

--- a/docs/verification/issue-129-agent-output-evidence.md
+++ b/docs/verification/issue-129-agent-output-evidence.md
@@ -1,0 +1,66 @@
+# Issue #129 Agent Output Contract Evidence
+
+Issue [#129](https://github.com/thiagocorreanet/kratos-harness/issues/129)
+(`ADP-01b`) records verification for the agent output contract: the machine
+block a phase agent appends to its reply, its extraction, its validation, and
+its recording as run state. This record claims no compatibility parity credit.
+
+## Environment
+
+| | |
+| --- | --- |
+| Date | 2026-08-18 |
+| Platform | Linux 7.0.0-28-generic |
+| Node.js | v24.18.0 |
+| npm | 11.16.0 |
+
+## Verification commands
+
+```bash
+npx vitest run tests/agent-output-contract.test.ts
+npx vitest run tests/agent-output-recording.test.ts
+npx vitest run tests/contract-schemas.test.ts tests/contract-manifest.test.ts
+npx vitest run tests/schema-registry-fixtures.test.ts
+npx vitest run tests/contract-documentation.test.ts
+npm run contracts:check
+npm run verify
+```
+
+`npm run verify` exits 0 on this branch: 148 test files, 3992 tests, contract
+families verified at 17 schemas, and package verification passing for Codex and
+Claude Code.
+
+## Acceptance criteria
+
+| Criterion | Evidence |
+| --- | --- |
+| A reply with no machine block is reported as such and does not advance the run | `agent-output-recording`: "reports a reply with no machine block without advancing the run" asserts exit 3, `trail.output_invalido`, `stateChanged: false`, no recorded document, and no `run.agent.recorded` event |
+| A reply with a malformed block fails closed and names the parse failure | `agent-output-recording`: "names the parse failure of a malformed block" asserts the reported cause is "The machine block is not a single JSON document."; `agent-output-contract` covers all ten malformations |
+| A reply with a schema-invalid block is refused, and the reason names the offending path | `agent-output-recording`: "names the offending path of a schema-invalid block" asserts the reported cause contains `outcome.status` |
+| A reply containing an ordinary fenced example plus one machine block extracts the machine block | `agent-output-contract`: "ignores an ordinary fenced example and extracts the machine block" reads `replies/decoy.md`, whose fence claims `blocked` while the block reports `completed` |
+| Extraction and validation perform no model call and no network access | `agent-output-contract`: "performs no model call and no network access" asserts the whole `domain/agent` module imports nothing but `@kratos/contracts`, the schema types, and its own files |
+| The same reply extracts identically under both hosts | `agent-output-recording`: "reads the same reply identically whichever host relayed it" records the same reply as `claude-code` with LF and as `codex` with CRLF and compares the persisted bytes |
+
+## Required tests and evidence
+
+| Requirement | Evidence |
+| --- | --- |
+| A valid and an invalid fixture for every agent payload type | `fixtures/agent-output/v1/valid` and `fixtures/agent-output/v1/invalid`, six files each, asserted exhaustive against `AGENTS` |
+| A fixture with no block, a malformed block, and a decoy | `fixtures/agent-output/v1/replies/absent.md`, `malformed.md`, `decoy.md`, plus `trailing.md` and `invalid.md` |
+| Round-trip test proving the persisted block equals the validated block | `agent-output-recording`: "persists exactly the block the validator accepted" re-validates the recorded file through the registry and compares both the value and the bytes |
+
+## Compatibility, state, and security
+
+Compatibility: additive. `host.agent-output@1.0.0` is a new registered
+contract; no existing schema, reason code, or command changed shape. The
+manifest bound moves from 16 to 17 registered schemas.
+
+State: additive. A run gains `runs/RUN/agent-output/AGENT.json` and a
+`run.agent.recorded` fact event. Recording a fact does not move the run through
+its phases, and a run that never records one is unchanged.
+
+Security: the extractor is a pure function over untrusted model output with a
+bounded block size, no platform imports, and no network reach. Every reference
+the contract accepts is project-relative: absolute paths, drive letters,
+backslashes, parent traversal, and URL schemes are refused by the schema, and
+every text field refuses control characters.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -27,7 +27,14 @@ The [`contracts/v1`](contracts/v1) directory contains valid current examples:
 - `operation-hook.json`;
 - `operation-timeout.json`;
 - `operation-cancellation.json`;
-- `operation-error.json`.
+- `operation-error.json`;
+- `agent-output.json`.
+
+The [`agent-output/v1`](agent-output/v1) directory contains the agent output
+corpus: one valid and one invalid payload per phase agent under `valid/` and
+`invalid/`, and whole agent replies under `replies/` covering a reply with no
+machine block, a malformed block, a block followed by more prose, a decoy whose
+ordinary fenced example must be ignored, and a schema-invalid block.
 
 Its `version-cases.json` table covers current, previous, future, malformed,
 untrimmed, non-string, and missing family identities. These fixtures are

--- a/fixtures/agent-output/v1/invalid/acceptance.json
+++ b/fixtures/agent-output/v1/invalid/acceptance.json
@@ -1,0 +1,23 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "acceptance",
+  "outcome": {
+    "status": "completed",
+    "next": "finish",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/05-acceptance.md"],
+  "changedFiles": [],
+  "payload": {
+    "verdict": "accepted",
+    "criteria": [
+      {
+        "criterionId": "criterion-refund-window",
+        "outcome": "mostly-passed",
+        "evidenceRef": ".brain/02-features/refunds/runs/run-01/evidence/tests.json"
+      }
+    ]
+  }
+}

--- a/fixtures/agent-output/v1/invalid/code.json
+++ b/fixtures/agent-output/v1/invalid/code.json
@@ -1,0 +1,18 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "code",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [],
+  "changedFiles": [{ "ref": "src/refunds/window.ts", "change": "modified" }],
+  "payload": {
+    "stepId": "step-window",
+    "testsAdded": -1,
+    "testsPassed": true
+  }
+}

--- a/fixtures/agent-output/v1/invalid/plan.json
+++ b/fixtures/agent-output/v1/invalid/plan.json
@@ -1,0 +1,16 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "plan",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/02-plan.md"],
+  "changedFiles": [],
+  "payload": {
+    "steps": []
+  }
+}

--- a/fixtures/agent-output/v1/invalid/prd.json
+++ b/fixtures/agent-output/v1/invalid/prd.json
@@ -1,0 +1,19 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "prd",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/00-prd.md"],
+  "changedFiles": [],
+  "payload": {
+    "objective": "Refund an order within the published window.",
+    "requirementIds": ["req-refund-window"],
+    "gapIds": [],
+    "confidence": "high"
+  }
+}

--- a/fixtures/agent-output/v1/invalid/review.json
+++ b/fixtures/agent-output/v1/invalid/review.json
@@ -1,0 +1,23 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "review",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/04-review.md"],
+  "changedFiles": [],
+  "payload": {
+    "verdict": "changes-requested",
+    "findings": [
+      {
+        "findingId": "finding-window-boundary",
+        "severity": "high",
+        "summary": "The window comparison excludes the final day."
+      }
+    ]
+  }
+}

--- a/fixtures/agent-output/v1/invalid/spec.json
+++ b/fixtures/agent-output/v1/invalid/spec.json
@@ -1,0 +1,18 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+  "outcome": {
+    "status": "awaiting-input",
+    "next": "wait",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/01-design.md"],
+  "changedFiles": [],
+  "payload": {
+    "requirementIds": ["req-refund-window"],
+    "gapIds": [],
+    "approvalRequired": true
+  }
+}

--- a/fixtures/agent-output/v1/replies/absent.md
+++ b/fixtures/agent-output/v1/replies/absent.md
@@ -1,0 +1,12 @@
+# Design review
+
+I finished reading the refund specification and wrote the design document.
+Nothing about the refund window changed, so the plan can proceed.
+
+Here is the shape the configuration file will take:
+
+```json
+{ "refundWindowDays": 30 }
+```
+
+That is everything.

--- a/fixtures/agent-output/v1/replies/decoy.md
+++ b/fixtures/agent-output/v1/replies/decoy.md
@@ -1,0 +1,39 @@
+# Design review
+
+The design document is written and the run can proceed.
+
+Other tools in this repository read fenced JSON, and one of them expects a
+document shaped like the example below. It is documentation, not the machine
+block, and the extractor must ignore it:
+
+```json
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+  "outcome": { "status": "blocked", "next": "stop" }
+}
+```
+
+The fence above is prose. The block below is the contract.
+
+===KRATOS-AGENT-OUTPUT-V1===
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/01-design.md"],
+  "changedFiles": [],
+  "payload": {
+    "requirementIds": ["req-refund-window"],
+    "gapIds": [],
+    "approvalRequired": true
+  }
+}
+===END-KRATOS-AGENT-OUTPUT-V1===

--- a/fixtures/agent-output/v1/replies/invalid.md
+++ b/fixtures/agent-output/v1/replies/invalid.md
@@ -1,0 +1,25 @@
+# Design review
+
+The design document is written, but the block below reports a status the
+contract does not carry.
+
+===KRATOS-AGENT-OUTPUT-V1===
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+  "outcome": {
+    "status": "nearly-done",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/01-design.md"],
+  "changedFiles": [],
+  "payload": {
+    "requirementIds": ["req-refund-window"],
+    "gapIds": [],
+    "approvalRequired": true
+  }
+}
+===END-KRATOS-AGENT-OUTPUT-V1===

--- a/fixtures/agent-output/v1/replies/malformed.md
+++ b/fixtures/agent-output/v1/replies/malformed.md
@@ -1,0 +1,10 @@
+# Design review
+
+The design document is written and the run can proceed.
+
+===KRATOS-AGENT-OUTPUT-V1===
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+===END-KRATOS-AGENT-OUTPUT-V1===

--- a/fixtures/agent-output/v1/replies/trailing.md
+++ b/fixtures/agent-output/v1/replies/trailing.md
@@ -1,0 +1,26 @@
+# Design review
+
+The design document is written and the run can proceed.
+
+===KRATOS-AGENT-OUTPUT-V1===
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/01-design.md"],
+  "changedFiles": [],
+  "payload": {
+    "requirementIds": ["req-refund-window"],
+    "gapIds": [],
+    "approvalRequired": true
+  }
+}
+===END-KRATOS-AGENT-OUTPUT-V1===
+
+One more thought: we should revisit the ledger naming later.

--- a/fixtures/agent-output/v1/valid/acceptance.json
+++ b/fixtures/agent-output/v1/valid/acceptance.json
@@ -1,0 +1,23 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "acceptance",
+  "outcome": {
+    "status": "completed",
+    "next": "finish",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/05-acceptance.md"],
+  "changedFiles": [],
+  "payload": {
+    "verdict": "accepted",
+    "criteria": [
+      {
+        "criterionId": "criterion-refund-window",
+        "outcome": "passed",
+        "evidenceRef": ".brain/02-features/refunds/runs/run-01/evidence/tests.json"
+      }
+    ]
+  }
+}

--- a/fixtures/agent-output/v1/valid/code.json
+++ b/fixtures/agent-output/v1/valid/code.json
@@ -1,0 +1,21 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "code",
+  "outcome": {
+    "status": "blocked",
+    "next": "retry",
+    "questions": [],
+    "blockers": ["The refund ledger migration has not been applied yet."]
+  },
+  "artifacts": [],
+  "changedFiles": [
+    { "ref": "src/refunds/window.ts", "change": "modified" },
+    { "ref": "tests/refund-window.test.ts", "change": "added" }
+  ],
+  "payload": {
+    "stepId": "step-window",
+    "testsAdded": 3,
+    "testsPassed": false
+  }
+}

--- a/fixtures/agent-output/v1/valid/plan.json
+++ b/fixtures/agent-output/v1/valid/plan.json
@@ -1,0 +1,27 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "plan",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/02-plan.md"],
+  "changedFiles": [],
+  "payload": {
+    "steps": [
+      {
+        "stepId": "step-window",
+        "summary": "Read the refund window from configuration.",
+        "dependsOn": []
+      },
+      {
+        "stepId": "step-ledger",
+        "summary": "Record every refund against the audit ledger.",
+        "dependsOn": ["step-window"]
+      }
+    ]
+  }
+}

--- a/fixtures/agent-output/v1/valid/prd.json
+++ b/fixtures/agent-output/v1/valid/prd.json
@@ -1,0 +1,18 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "prd",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/00-prd.md"],
+  "changedFiles": [],
+  "payload": {
+    "objective": "Refund an order within the published window.",
+    "requirementIds": ["req-refund-window", "req-refund-audit"],
+    "gapIds": []
+  }
+}

--- a/fixtures/agent-output/v1/valid/review.json
+++ b/fixtures/agent-output/v1/valid/review.json
@@ -1,0 +1,24 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "review",
+  "outcome": {
+    "status": "completed",
+    "next": "proceed",
+    "questions": [],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/04-review.md"],
+  "changedFiles": [],
+  "payload": {
+    "verdict": "changes-requested",
+    "findings": [
+      {
+        "findingId": "finding-window-boundary",
+        "severity": "high",
+        "summary": "The window comparison excludes the final day.",
+        "ref": "src/refunds/window.ts"
+      }
+    ]
+  }
+}

--- a/fixtures/agent-output/v1/valid/spec.json
+++ b/fixtures/agent-output/v1/valid/spec.json
@@ -1,0 +1,34 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+  "outcome": {
+    "status": "awaiting-input",
+    "next": "wait",
+    "questions": [
+      {
+        "questionId": "q-refund-window",
+        "prompt": "Which refund window should the design implement?",
+        "kind": "single-choice",
+        "options": [
+          { "optionId": "days-14", "label": "Fourteen days from delivery" },
+          { "optionId": "days-30", "label": "Thirty days from delivery" }
+        ]
+      },
+      {
+        "questionId": "q-refund-owner",
+        "prompt": "Who owns the refund ledger after this change?",
+        "kind": "free-text",
+        "options": []
+      }
+    ],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/01-design.md"],
+  "changedFiles": [],
+  "payload": {
+    "requirementIds": ["req-refund-window"],
+    "gapIds": ["gap-refund-window"],
+    "approvalRequired": true
+  }
+}

--- a/fixtures/contracts/v1/agent-output.json
+++ b/fixtures/contracts/v1/agent-output.json
@@ -1,0 +1,34 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.0.0",
+  "agent": "spec",
+  "outcome": {
+    "status": "awaiting-input",
+    "next": "wait",
+    "questions": [
+      {
+        "questionId": "q-refund-window",
+        "prompt": "Which refund window should the design implement?",
+        "kind": "single-choice",
+        "options": [
+          { "optionId": "days-14", "label": "Fourteen days from delivery" },
+          { "optionId": "days-30", "label": "Thirty days from delivery" }
+        ]
+      },
+      {
+        "questionId": "q-refund-owner",
+        "prompt": "Who owns the refund ledger after this change?",
+        "kind": "free-text",
+        "options": []
+      }
+    ],
+    "blockers": []
+  },
+  "artifacts": [".brain/02-features/refunds/01-design.md"],
+  "changedFiles": [],
+  "payload": {
+    "requirementIds": ["req-refund-window"],
+    "gapIds": ["gap-refund-window"],
+    "approvalRequired": true
+  }
+}

--- a/packages/contracts/catalogs/contract-families.v1.json
+++ b/packages/contracts/catalogs/contract-families.v1.json
@@ -22,6 +22,14 @@
       "typeName": "AdapterMessageV1"
     },
     {
+      "id": "host.agent-output",
+      "family": "host",
+      "version": "1.0.0",
+      "path": "schemas/host/agent-output.v1.schema.json",
+      "boundary": "cross-process",
+      "typeName": "AgentOutputV1"
+    },
+    {
       "id": "host.gap-proposal",
       "family": "host",
       "version": "1.0.0",

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -1,6 +1,7 @@
 // Generated from registered JSON Schemas. Do not edit.
 // dependency: https://kratos.dev/schemas/result/v1 sha256:6ad1a8b5f56b324184f7cb3b760ed7d6a921fef98f4857130e15a6c0825236b9
 // source: https://kratos.dev/schemas/host/adapter-message/v1 sha256:40e9d8e3bc053fe706ff7b92743370bf892522d267eca1f2cbc12e4c808bfecd
+// source: https://kratos.dev/schemas/host/agent-output/v1 sha256:7d95ea2c2541c12b8e960094bb3bd197b35f5f55ffd6412581449efacde54d3a
 // source: https://kratos.dev/schemas/host/gap-proposal/v1 sha256:d84197ce78d147136c8ad92396bed4c75130cce6c1736a8213ed30d1cd7d5b6c
 // source: https://kratos.dev/schemas/host/init-answers/v1 sha256:c816614cac9e6c5dd43f4f6f5bbab01dbcfb6e7bf58af4e30c6c311d57411806
 // source: https://kratos.dev/schemas/host/operation-message/v1 sha256:8c31f1bc77a84c5a7e0955bff0931c5ceab9588c9aa2229502370ef2ba7205c4
@@ -109,6 +110,190 @@ export namespace AdapterMessageV1Contract {
   }
 }
 export type AdapterMessageV1 = AdapterMessageV1Contract.AdapterMessageV1;
+export namespace AgentOutputV1Contract {
+  export type AgentOutputV1 =
+    | {
+        contractVersion: "1.0.0";
+        hostContract: "1.0.0";
+        agent: "prd";
+        outcome: Outcome;
+        artifacts: Artifacts;
+        changedFiles: ChangedFiles;
+        payload: PrdPayload;
+      }
+    | {
+        contractVersion: "1.0.0";
+        hostContract: "1.0.0";
+        agent: "spec";
+        outcome: Outcome;
+        artifacts: Artifacts;
+        changedFiles: ChangedFiles;
+        payload: SpecPayload;
+      }
+    | {
+        contractVersion: "1.0.0";
+        hostContract: "1.0.0";
+        agent: "plan";
+        outcome: Outcome;
+        artifacts: Artifacts;
+        changedFiles: ChangedFiles;
+        payload: PlanPayload;
+      }
+    | {
+        contractVersion: "1.0.0";
+        hostContract: "1.0.0";
+        agent: "code";
+        outcome: Outcome;
+        artifacts: Artifacts;
+        changedFiles: ChangedFiles;
+        payload: CodePayload;
+      }
+    | {
+        contractVersion: "1.0.0";
+        hostContract: "1.0.0";
+        agent: "review";
+        outcome: Outcome;
+        artifacts: Artifacts;
+        changedFiles: ChangedFiles;
+        payload: ReviewPayload;
+      }
+    | {
+        contractVersion: "1.0.0";
+        hostContract: "1.0.0";
+        agent: "acceptance";
+        outcome: Outcome;
+        artifacts: Artifacts;
+        changedFiles: ChangedFiles;
+        payload: AcceptancePayload;
+      };
+  export type Outcome = {
+    [k: string]: unknown | undefined;
+  } & {
+    status: "completed" | "awaiting-input" | "blocked";
+    next: "proceed" | "wait" | "retry" | "finish" | "stop";
+    /**
+     * @maxItems 64
+     */
+    questions: Question[];
+    /**
+     * @maxItems 64
+     */
+    blockers: Text[];
+  };
+  export type Question = {
+    [k: string]: unknown | undefined;
+  } & {
+    questionId: Id;
+    prompt: Text;
+    kind: "free-text" | "single-choice" | "multiple-choice";
+    /**
+     * @maxItems 32
+     */
+    options: Option[];
+  };
+  export type Id = string;
+  export type Text = string;
+  export type Reference = string;
+  /**
+   * @maxItems 64
+   */
+  export type Artifacts = Reference[];
+  /**
+   * @maxItems 256
+   */
+  export type ChangedFiles = {
+    ref: Reference;
+    change: "added" | "modified" | "deleted";
+  }[];
+
+  export interface Option {
+    optionId: Id;
+    label: Text;
+  }
+  export interface PrdPayload {
+    objective: Text;
+    /**
+     * @maxItems 256
+     */
+    requirementIds: Id[];
+    /**
+     * @maxItems 64
+     */
+    gapIds: Id[];
+  }
+  export interface SpecPayload {
+    /**
+     * @maxItems 256
+     */
+    requirementIds: Id[];
+    /**
+     * @maxItems 64
+     */
+    gapIds: Id[];
+    approvalRequired: boolean;
+  }
+  export interface PlanPayload {
+    /**
+     * @minItems 1
+     * @maxItems 256
+     */
+    steps: [
+      {
+        stepId: Id;
+        summary: Text;
+        /**
+         * @maxItems 64
+         */
+        dependsOn: Id[];
+      },
+      ...{
+        stepId: Id;
+        summary: Text;
+        /**
+         * @maxItems 64
+         */
+        dependsOn: Id[];
+      }[],
+    ];
+  }
+  export interface CodePayload {
+    stepId: Id;
+    testsAdded: number;
+    testsPassed: boolean;
+  }
+  export interface ReviewPayload {
+    verdict: "pass" | "changes-requested" | "fail";
+    /**
+     * @maxItems 128
+     */
+    findings: {
+      findingId: Id;
+      severity: "high" | "medium" | "low";
+      summary: Text;
+      ref: Reference;
+    }[];
+  }
+  export interface AcceptancePayload {
+    verdict: "accepted" | "rejected";
+    /**
+     * @minItems 1
+     * @maxItems 256
+     */
+    criteria: [
+      {
+        criterionId: Id;
+        outcome: "passed" | "failed" | "not-run";
+        evidenceRef: Reference;
+      },
+      ...{
+        criterionId: Id;
+        outcome: "passed" | "failed" | "not-run";
+        evidenceRef: Reference;
+      }[],
+    ];
+  }
+}
+export type AgentOutputV1 = AgentOutputV1Contract.AgentOutputV1;
 export namespace GapProposalV1Contract {
   export type Id = string;
   export type Text = string;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -14,6 +14,7 @@ export { REASON_CATALOG, reasonPolicy } from "./reasons.js";
 export type { ReasonPolicy } from "./reasons.js";
 export type {
   AdapterMessageV1,
+  AgentOutputV1,
   ApprovalV1,
   InitAnswersV1,
   HostOperationMessageV1,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -14,6 +14,7 @@
     "./composition/objective": "./src/composition/objective.ts",
     "./composition/schema": "./src/composition/schema.ts",
     "./composition/workflow": "./src/composition/workflow.ts",
+    "./domain/agent": "./src/domain/agent/index.ts",
     "./domain/cli": "./src/domain/cli/index.ts",
     "./domain/diagnostics": "./src/domain/diagnostics/index.ts",
     "./domain/effects": "./src/domain/effects.ts",

--- a/packages/runtime/src/composition/workflow.ts
+++ b/packages/runtime/src/composition/workflow.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentOutputV1,
   ApprovalV1,
   EventV1,
   EvidenceV1,
@@ -35,6 +36,10 @@ import {
 } from "../domain/workflow/index.js";
 import type { GitPath } from "../domain/git/index.js";
 import { verifyEvidence } from "../domain/evidence/index.js";
+import {
+  extractAgentBlock,
+  type AgentOutputObservation,
+} from "../domain/agent/index.js";
 import type { GapProposalObservation } from "../domain/gaps/index.js";
 import { evaluateGates, type GateMode } from "../domain/gates/index.js";
 import {
@@ -140,6 +145,12 @@ export async function observeWorkflow(
   const gateFacts = await observeGateFacts(configuration, anchored, registry);
   const gaps = await observeGaps(configuration, anchored, registry);
   const gapProposal = await observeGapProposal(invocation, anchored, registry);
+  const agentOutput = await observeAgentReply(invocation, anchored, registry);
+  const agentOutputs = await observeAgentOutputs(
+    configuration,
+    anchored,
+    registry,
+  );
   const referencedFiles = await observeReferencedFiles(invocation, anchored);
   const artifactLineage = await observeArtifactLineage(
     configuration,
@@ -301,6 +312,9 @@ export async function observeWorkflow(
       gaps: gaps.values,
       gapsReadable: gaps.readable,
       gapProposal,
+      agentOutput,
+      agentOutputs: agentOutputs.values,
+      agentOutputsReadable: agentOutputs.readable,
       gateFacts,
       openGaps,
       specApproved,
@@ -563,6 +577,98 @@ async function observeGapProposal(
       : { kind: "invalid", ref, diagnostics: validated.diagnostics };
   } catch {
     return { kind: "unreadable", ref };
+  }
+}
+
+/**
+ * Read the agent reply an output-recording command was pointed at.
+ *
+ * Extraction happens here, at the boundary, and the decision receives an
+ * outcome rather than prose. Nothing below this line ever sees the reply text,
+ * which is what keeps a domain decision from depending on phrasing.
+ */
+async function observeAgentReply(
+  invocation: Invocation,
+  ports: RuntimePorts,
+  registry: SchemaRegistry,
+): Promise<AgentOutputObservation> {
+  if (invocation.command.path.join(" ") !== "agent record") {
+    return { kind: "none" };
+  }
+  const ref = invocation.positionals[0];
+  if (ref === undefined) return { kind: "none" };
+  let reply: string;
+  try {
+    const entry = await ports.durableFileSystem.inspect(ref);
+    if (entry.kind !== "file") return { kind: "unreadable", ref };
+    reply = await ports.durableFileSystem.readText(ref);
+  } catch {
+    return { kind: "unreadable", ref };
+  }
+  const extracted = extractAgentBlock(reply);
+  if (extracted.kind === "absent") return { kind: "absent", ref };
+  if (extracted.kind === "malformed") {
+    return { kind: "malformed", ref, reason: extracted.reason };
+  }
+  const validated = registry.validate({
+    id: "host.agent-output",
+    version: "1.0.0",
+    value: extracted.value,
+    structuralReasonCode: "trail.output_invalido",
+  });
+  return validated.kind === "valid"
+    ? { kind: "valid", ref, value: validated.value }
+    : { kind: "invalid", ref, diagnostics: validated.diagnostics };
+}
+
+/**
+ * Read every agent output the run recorded.
+ *
+ * Recorded blocks are read back through the contract that admitted them, so a
+ * derived view reads typed data and a file that no longer satisfies the
+ * contract fails closed instead of reading as nothing recorded.
+ */
+async function observeAgentOutputs(
+  configuration: RunReference,
+  ports: RuntimePorts,
+  registry: SchemaRegistry,
+): Promise<{
+  readonly readable: boolean;
+  readonly values: readonly AgentOutputV1[];
+}> {
+  const root = `${runRoot(configuration)}/agent-output`;
+  const entry = await ports.durableFileSystem.inspect(root);
+  if (entry.kind === "missing") return { readable: true, values: [] };
+  if (entry.kind !== "directory") return { readable: false, values: [] };
+  try {
+    const values: AgentOutputV1[] = [];
+    for (const name of await ports.durableFileSystem.list(root)) {
+      if (!name.endsWith(".json")) return { readable: false, values: [] };
+      const path = `${root}/${name}`;
+      const file = await ports.durableFileSystem.inspect(path);
+      if (file.kind !== "file") return { readable: false, values: [] };
+      const validated = registry.validate({
+        id: "host.agent-output",
+        version: "1.0.0",
+        value: JSON.parse(
+          await ports.durableFileSystem.readText(path),
+        ) as unknown,
+        structuralReasonCode: "trail.output_invalido",
+      });
+      if (
+        validated.kind !== "valid" ||
+        `${validated.value.agent}.json` !== name
+      ) {
+        return { readable: false, values: [] };
+      }
+      values.push(validated.value);
+    }
+    values.sort((left, right) =>
+      left.agent.localeCompare(right.agent, "en-US"),
+    );
+    return { readable: true, values };
+  } catch {
+    return { readable: false, values: [] };
   }
 }
 

--- a/packages/runtime/src/domain/agent/coherence.ts
+++ b/packages/runtime/src/domain/agent/coherence.ts
@@ -1,0 +1,107 @@
+import type { AgentOutputV1 } from "@kratos/contracts";
+
+/**
+ * The agreements a schema cannot state.
+ *
+ * Every one of these is a contradiction between two fields the schema
+ * validates independently. They are refusals rather than warnings because a
+ * runtime that routes on a self-contradicting block routes on whichever field
+ * it happened to read first.
+ */
+export type AgentOutputRefusal =
+  | "artifact-also-changed"
+  | "duplicate-changed-file"
+  | "duplicate-option-id"
+  | "duplicate-question-id"
+  | "duplicate-step-id"
+  | "unknown-step-dependency"
+  | "verdict-contradicts-criteria"
+  | "verdict-contradicts-findings";
+
+/** One sentence per refusal, so every surface reports the same cause. */
+export function describeAgentOutputRefusal(reason: AgentOutputRefusal): string {
+  switch (reason) {
+    case "artifact-also-changed":
+      return "A path is listed both as a written artifact and as a changed file.";
+    case "duplicate-changed-file":
+      return "A changed file is listed more than once.";
+    case "duplicate-option-id":
+      return "A question offers the same option identifier twice.";
+    case "duplicate-question-id":
+      return "A blocking question identifier is used more than once.";
+    case "duplicate-step-id":
+      return "A plan step identifier is used more than once.";
+    case "unknown-step-dependency":
+      return "A plan step depends on a step the plan does not contain.";
+    case "verdict-contradicts-criteria":
+      return "The acceptance verdict accepts a run whose criteria did not all pass.";
+    case "verdict-contradicts-findings":
+      return "The review verdict passes a change that still carries a high finding.";
+  }
+}
+
+/**
+ * Why this block contradicts itself, or null when it does not.
+ *
+ * Runs after schema validation and before any domain decision, so a caller can
+ * assume both the shape and the internal agreement of what it reads.
+ */
+export function checkAgentOutput(
+  output: AgentOutputV1,
+): AgentOutputRefusal | null {
+  const changed = output.changedFiles.map(({ ref }) => ref);
+  if (new Set(changed).size !== changed.length) {
+    return "duplicate-changed-file";
+  }
+  // Artifacts are the specification documents the agent wrote; changed files
+  // are the source and tests it touched. A path claimed as both erases exactly
+  // the distinction the scope check reads.
+  const artifacts = new Set(output.artifacts);
+  if (changed.some((ref) => artifacts.has(ref))) {
+    return "artifact-also-changed";
+  }
+
+  const questions = output.outcome.questions;
+  if (
+    new Set(questions.map(({ questionId }) => questionId)).size !==
+    questions.length
+  ) {
+    return "duplicate-question-id";
+  }
+  for (const question of questions) {
+    const options = question.options.map(({ optionId }) => optionId);
+    if (new Set(options).size !== options.length) {
+      return "duplicate-option-id";
+    }
+  }
+
+  return checkPayload(output);
+}
+
+function checkPayload(output: AgentOutputV1): AgentOutputRefusal | null {
+  if (output.agent === "plan") {
+    const steps = output.payload.steps;
+    const ids = steps.map(({ stepId }) => stepId);
+    if (new Set(ids).size !== ids.length) return "duplicate-step-id";
+    const known = new Set(ids);
+    if (steps.some(({ dependsOn }) => dependsOn.some((id) => !known.has(id)))) {
+      return "unknown-step-dependency";
+    }
+    return null;
+  }
+  if (
+    output.agent === "review" &&
+    output.payload.verdict === "pass" &&
+    output.payload.findings.some(({ severity }) => severity === "high")
+  ) {
+    return "verdict-contradicts-findings";
+  }
+  if (
+    output.agent === "acceptance" &&
+    output.payload.verdict === "accepted" &&
+    output.payload.criteria.some(({ outcome }) => outcome !== "passed")
+  ) {
+    return "verdict-contradicts-criteria";
+  }
+  return null;
+}

--- a/packages/runtime/src/domain/agent/extract.ts
+++ b/packages/runtime/src/domain/agent/extract.ts
@@ -1,0 +1,95 @@
+import {
+  AGENT_BLOCK_CLOSE,
+  AGENT_BLOCK_OPEN,
+  MAX_BLOCK_LENGTH,
+  type BlockExtraction,
+  type BlockMalformation,
+} from "./model.js";
+
+/**
+ * Read one agent reply and return the machine block it carries.
+ *
+ * Pure by construction: it takes the reply text and returns a decision. There
+ * is no model call, no clock, and no filesystem here, which is what lets the
+ * same reply extract identically whichever host produced it.
+ *
+ * Line endings are normalized first. A host that writes CRLF and a host that
+ * writes LF are describing the same reply, and a delimiter that matched only
+ * one of them would make the contract host-specific.
+ */
+export function extractAgentBlock(reply: string): BlockExtraction {
+  const lines = reply.split("\n").map(stripCarriageReturn);
+  const opens = indicesOf(lines, AGENT_BLOCK_OPEN);
+  const closes = indicesOf(lines, AGENT_BLOCK_CLOSE);
+
+  const structural = classifyDelimiters(opens, closes);
+  if (structural !== null) return structural;
+
+  // `classifyDelimiters` returning null means exactly one of each was found in
+  // the right order, so both lookups below are inhabited.
+  const open = opens[0] ?? 0;
+  const close = closes[0] ?? 0;
+
+  if (lines.slice(close + 1).some((line) => line.trim() !== "")) {
+    return malformed("trailing-content");
+  }
+
+  const text = lines.slice(open + 1, close).join("\n");
+  if (text.length > MAX_BLOCK_LENGTH) return malformed("block-too-large");
+  if (text.trim() === "") return malformed("empty-block");
+
+  let value: unknown;
+  try {
+    value = JSON.parse(text) as unknown;
+  } catch {
+    return malformed("invalid-json");
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return malformed("non-object");
+  }
+  return { kind: "extracted", value, text };
+}
+
+/**
+ * Why the delimiters alone already refuse this reply, or null when they do not.
+ *
+ * Absence of both markers is the only case that is not a failure: a reply that
+ * never claims to carry a block is a reply the runtime cannot route on, which
+ * is a different thing from a reply that carries a broken one.
+ */
+function classifyDelimiters(
+  opens: readonly number[],
+  closes: readonly number[],
+): Extract<BlockExtraction, { readonly kind: "absent" | "malformed" }> | null {
+  if (opens.length === 0 && closes.length === 0) return { kind: "absent" };
+  if (opens.length > 1) return malformed("duplicate-open");
+  if (closes.length > 1) return malformed("duplicate-close");
+  if (opens.length === 0) return malformed("unopened");
+  if (closes.length === 0) return malformed("unterminated");
+  return (closes[0] ?? 0) < (opens[0] ?? 0) ? malformed("misordered") : null;
+}
+
+function indicesOf(
+  lines: readonly string[],
+  marker: string,
+): readonly number[] {
+  const found: number[] = [];
+  lines.forEach((line, index) => {
+    if (line === marker) found.push(index);
+  });
+  return found;
+}
+
+/**
+ * A delimiter is recognized only as a whole line, so a trailing carriage
+ * return has to go before the comparison rather than be tolerated inside it.
+ */
+function stripCarriageReturn(line: string): string {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function malformed(
+  reason: BlockMalformation,
+): Extract<BlockExtraction, { readonly kind: "malformed" }> {
+  return { kind: "malformed", reason };
+}

--- a/packages/runtime/src/domain/agent/index.ts
+++ b/packages/runtime/src/domain/agent/index.ts
@@ -1,0 +1,21 @@
+export { checkAgentOutput, describeAgentOutputRefusal } from "./coherence.js";
+export type { AgentOutputRefusal } from "./coherence.js";
+export { extractAgentBlock } from "./extract.js";
+export {
+  AGENT_BLOCK_CLOSE,
+  AGENT_BLOCK_OPEN,
+  AGENT_STATUSES,
+  AGENTS,
+  MAX_BLOCK_LENGTH,
+  ROUTING_HINTS,
+  describeAgentOutputFailure,
+  describeBlockMalformation,
+} from "./model.js";
+export type {
+  Agent,
+  AgentOutputObservation,
+  AgentStatus,
+  BlockExtraction,
+  BlockMalformation,
+  RoutingHint,
+} from "./model.js";

--- a/packages/runtime/src/domain/agent/model.ts
+++ b/packages/runtime/src/domain/agent/model.ts
@@ -1,0 +1,171 @@
+import type { AgentOutputV1 } from "@kratos/contracts";
+
+import type { ValidationDiagnostic } from "../schema/index.js";
+
+/**
+ * The agents that may address the runtime, one per run phase.
+ *
+ * Kept as its own list rather than reused from `RUN_PHASES` because the two
+ * answer different questions: `RUN_PHASES` is the order a run walks, and this
+ * is who is allowed to speak. They coincide today, and a test asserts that
+ * they still do, which is what makes the coincidence a decision rather than an
+ * accident.
+ */
+export const AGENTS = [
+  "prd",
+  "spec",
+  "plan",
+  "code",
+  "review",
+  "acceptance",
+] as const;
+
+export type Agent = (typeof AGENTS)[number];
+
+/** What the agent says about itself. */
+export const AGENT_STATUSES = [
+  "completed",
+  "awaiting-input",
+  "blocked",
+] as const;
+
+export type AgentStatus = (typeof AGENT_STATUSES)[number];
+
+/**
+ * What the agent suggests the runtime does next.
+ *
+ * A hint, never a decision. The runtime reads it alongside the gates and the
+ * recorded state; an agent that says `proceed` past a failing gate is
+ * describing its own view, not authorizing a transition.
+ */
+export const ROUTING_HINTS = [
+  "proceed",
+  "wait",
+  "retry",
+  "finish",
+  "stop",
+] as const;
+
+export type RoutingHint = (typeof ROUTING_HINTS)[number];
+
+/**
+ * The one delimiter that marks the machine block.
+ *
+ * Deliberately not a Markdown fence. A reply is allowed to contain fenced
+ * examples, including fenced JSON and fenced examples of this very contract,
+ * and a fence-shaped delimiter would make the extractor's answer depend on
+ * what the surrounding prose happened to illustrate. These two lines have no
+ * meaning in Markdown, so nothing renders them by accident.
+ */
+export const AGENT_BLOCK_OPEN = "===KRATOS-AGENT-OUTPUT-V1===";
+export const AGENT_BLOCK_CLOSE = "===END-KRATOS-AGENT-OUTPUT-V1===";
+
+/**
+ * The largest machine block the extractor will read, in code units.
+ *
+ * Extraction runs on untrusted model output on every phase completion, so the
+ * work it can be asked to do is bounded before the parser sees it rather than
+ * after.
+ */
+export const MAX_BLOCK_LENGTH = 262_144;
+
+/** Every way a block can be present and still unusable before parsing. */
+export type BlockMalformation =
+  | "block-too-large"
+  | "duplicate-close"
+  | "duplicate-open"
+  | "empty-block"
+  | "invalid-json"
+  | "misordered"
+  | "non-object"
+  | "trailing-content"
+  | "unopened"
+  | "unterminated";
+
+/**
+ * What the extractor found in one reply.
+ *
+ * Three exits, because a caller acts differently on each: nothing was emitted,
+ * something was emitted that is not a block, and a block was emitted. Schema
+ * validity is a separate question asked afterwards, on the value this carries.
+ */
+export type BlockExtraction =
+  | { readonly kind: "absent" }
+  | { readonly kind: "malformed"; readonly reason: BlockMalformation }
+  | {
+      readonly kind: "extracted";
+      /** The parsed document, still untrusted and not yet validated. */
+      readonly value: unknown;
+      /** Exactly the characters between the delimiters, for digesting. */
+      readonly text: string;
+    };
+
+/** One sentence per malformation, so every surface reports the same cause. */
+export function describeBlockMalformation(reason: BlockMalformation): string {
+  switch (reason) {
+    case "block-too-large":
+      return `The machine block exceeds the ${String(MAX_BLOCK_LENGTH)} character limit.`;
+    case "duplicate-close":
+      return "The reply closes the machine block more than once.";
+    case "duplicate-open":
+      return "The reply opens the machine block more than once.";
+    case "empty-block":
+      return "The machine block carries no content.";
+    case "invalid-json":
+      return "The machine block is not a single JSON document.";
+    case "misordered":
+      return "The machine block closes before it opens.";
+    case "non-object":
+      return "The machine block carries a JSON value that is not an object.";
+    case "trailing-content":
+      return "The reply continues after the machine block closes.";
+    case "unopened":
+      return "The reply closes a machine block it never opened.";
+    case "unterminated":
+      return "The reply opens a machine block it never closes.";
+  }
+}
+
+/**
+ * What the runtime found where one agent reply was expected.
+ *
+ * A reply is untrusted model output, so absence, malformation, and schema
+ * invalidity are three different answers, and each names a different thing for
+ * the caller to fix.
+ */
+export type AgentOutputObservation =
+  | { readonly kind: "none" }
+  | { readonly kind: "unreadable"; readonly ref: string }
+  | { readonly kind: "absent"; readonly ref: string }
+  | {
+      readonly kind: "malformed";
+      readonly ref: string;
+      readonly reason: BlockMalformation;
+    }
+  | {
+      readonly kind: "invalid";
+      readonly ref: string;
+      readonly diagnostics: readonly ValidationDiagnostic[];
+    }
+  | {
+      readonly kind: "valid";
+      readonly ref: string;
+      readonly value: AgentOutputV1;
+    };
+
+/** Name the first thing the block got wrong, without quoting its content. */
+export function describeAgentOutputFailure(
+  observation: Extract<AgentOutputObservation, { readonly kind: "invalid" }>,
+): string {
+  const first = observation.diagnostics[0];
+  if (first === undefined) {
+    return "The machine block does not satisfy the published agent output contract.";
+  }
+  // The pointer is rendered as a dotted path rather than a JSON pointer: the
+  // result contract refuses publishable text that reads as a filesystem path,
+  // and a leading slash is exactly that.
+  const location = first.pointer.split("/").filter(Boolean).join(".");
+  return `The machine block violates ${first.contract}@${first.version ?? "unknown"} at ${
+    location === "" ? "the document root" : location
+  } (${first.keyword}).`;
+}

--- a/packages/runtime/src/domain/cli/agent.ts
+++ b/packages/runtime/src/domain/cli/agent.ts
@@ -1,0 +1,278 @@
+import type { AgentOutputV1 } from "@kratos/contracts";
+
+import {
+  checkAgentOutput,
+  describeAgentOutputFailure,
+  describeAgentOutputRefusal,
+  describeBlockMalformation,
+  type AgentOutputObservation,
+} from "../agent/index.js";
+import { planOf, type Effect } from "../effects.js";
+import { resultFor, type Result } from "../result/index.js";
+import {
+  decideRecordFact,
+  workflowReducerRegistry,
+  type WorkflowDecision,
+} from "../workflow/index.js";
+
+import { observingCommand } from "./observed.js";
+import type { CommandObservation, CommandSpec, Decision } from "./spec.js";
+
+type Observation = Extract<CommandObservation, { readonly kind: "workflow" }>;
+
+export const agentRecordCommand: CommandSpec = observingCommand(
+  "workflow",
+  {
+    path: ["agent", "record"],
+    summary: "Extract, validate, and persist one agent reply's machine block.",
+    flags: [
+      {
+        name: "--correlation-id",
+        kind: "value",
+        valueLabel: "<id>",
+        summary: "Use this idempotency correlation identifier.",
+      },
+      {
+        name: "--host",
+        kind: "value",
+        valueLabel: "<id>",
+        summary: "Record the host that observed this operation.",
+      },
+      {
+        name: "--model",
+        kind: "value",
+        valueLabel: "<id>",
+        summary: "Record the model that observed this operation.",
+      },
+      {
+        name: "--root",
+        kind: "value",
+        valueLabel: "<path>",
+        summary: "Operate on the project rooted at this path.",
+      },
+    ],
+    positionals: { min: 1, max: 1 },
+    jsonContract: "result@1.0.0",
+  },
+  (_invocation, observation) => decideRecord(observation),
+);
+
+/**
+ * Turn one agent reply into recorded, typed run state.
+ *
+ * The reply is model output, so the order here is the whole point: extract the
+ * block, validate it against its published contract, check that it does not
+ * contradict itself, and only then let any of it reach a decision. Every step
+ * before the last one can only refuse; none of them can advance the run.
+ */
+function decideRecord(observation: Observation): Decision {
+  const unusable = unusableState(observation);
+  if (unusable !== null) return unusable;
+
+  const observed = observation.agentOutput;
+  if (observed.kind !== "valid") return refuseReply(observed);
+
+  const refusal = checkAgentOutput(observed.value);
+  if (refusal !== null) {
+    return invalidOutput(observed.ref, describeAgentOutputRefusal(refusal));
+  }
+
+  const phase =
+    observation.workflow.kind === "present"
+      ? observation.workflow.state.currentStep
+      : null;
+  if (observed.value.agent !== phase) {
+    return invalidOutput(
+      observed.ref,
+      `The ${observed.value.agent} agent addressed a run in the ${phase ?? "unselected"} phase.`,
+    );
+  }
+
+  const path = outputPath(observation, observed.value.agent);
+  const recorded = observation.agentOutputs.find(
+    (candidate) => candidate.agent === observed.value.agent,
+  );
+  if (
+    recorded !== undefined &&
+    serialize(recorded) === serialize(observed.value)
+  ) {
+    return settled(
+      `The ${observed.value.agent} agent output was already recorded.`,
+      [path],
+    );
+  }
+
+  return commit(
+    observation,
+    [
+      {
+        kind: "write_file",
+        path,
+        content: serialize(observed.value),
+      },
+    ],
+    `Recorded the ${observed.value.agent} agent output as ${observed.value.outcome.status}.`,
+    [path],
+  );
+}
+
+/**
+ * Report a reply the runtime cannot route on.
+ *
+ * The three answers stay apart on purpose. "Nothing was emitted", "something
+ * was emitted that is not a block", and "a block was emitted that is not the
+ * contract" are three different things to fix, and collapsing them would make
+ * the caller guess which one happened.
+ */
+function refuseReply(
+  observed: Exclude<AgentOutputObservation, { readonly kind: "valid" }>,
+): Decision {
+  switch (observed.kind) {
+    case "none":
+      return usage(["No agent reply was supplied to record."]);
+    case "unreadable":
+      return usage(["The agent reply could not be read as text."]);
+    case "absent":
+      return invalidOutput(observed.ref, "The reply carries no machine block.");
+    case "malformed":
+      return invalidOutput(
+        observed.ref,
+        describeBlockMalformation(observed.reason),
+      );
+    case "invalid":
+      return invalidOutput(observed.ref, describeAgentOutputFailure(observed));
+  }
+}
+
+/**
+ * Persisted blocks are written exactly as validated, so reading one back
+ * through the same contract yields the value the decision saw.
+ */
+function serialize(value: AgentOutputV1): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function runRoot(observation: Observation): string {
+  return `.brain/02-features/${observation.configuration.feature}/runs/${observation.configuration.runId}`;
+}
+
+function outputPath(observation: Observation, agent: string): string {
+  return `${runRoot(observation)}/agent-output/${agent}.json`;
+}
+
+function commit(
+  observation: Observation,
+  effects: readonly Effect[],
+  summary: string,
+  artifactRefs: readonly string[],
+): Decision {
+  const workflow = decideRecordFact(observation.workflow, {
+    feature: observation.configuration.feature,
+    runId: observation.configuration.runId,
+    correlationId: observation.correlationId,
+    eventId: observation.eventId,
+    occurredAt: observation.occurredAt,
+    expectedRevision:
+      observation.workflow.kind === "present"
+        ? observation.workflow.state.revision
+        : 0,
+    operation: "agent.record",
+    artifactRefs,
+    observedIdentity: observation.observedIdentity,
+  });
+  if (workflow.kind === "refused") return refused(workflow, observation);
+  if (workflow.kind === "unchanged") {
+    return settled(
+      "The recording was already reflected in the run history.",
+      artifactRefs,
+    );
+  }
+  return {
+    result: resultFor("trail.ok", {
+      summary,
+      stateChanged: true,
+      evidence: [
+        ...artifactRefs.map((ref) => ({ kind: "artifact" as const, ref })),
+        { kind: "event" as const, ref: `${runRoot(observation)}/events.jsonl` },
+      ],
+    }),
+    plan: planOf(...effects, {
+      kind: "append_event",
+      feature: observation.configuration.feature,
+      runId: observation.configuration.runId,
+      event: workflow.event,
+    }),
+    humanStdout: null,
+    payload: null,
+    eventReducers: workflowReducerRegistry(observation.configuration),
+  };
+}
+
+/** Why this run cannot record an agent output right now, or null when it can. */
+function unusableState(observation: Observation): Decision | null {
+  if (
+    observation.workflow.kind === "corrupt" ||
+    !observation.agentOutputsReadable
+  ) {
+    return decisionOf(
+      resultFor("runtime.state_corrupt", {
+        why: ["The recorded agent output could not be read as its contract."],
+        evidence: [{ kind: "artifact", ref: ".brain/02-features" }],
+      }),
+    );
+  }
+  if (observation.workflow.kind === "absent") {
+    return decisionOf(
+      resultFor("blocked.context_unreadable", {
+        why: ["No active run exists to record an agent output against."],
+        evidence: [{ kind: "artifact", ref: ".brain/02-features/active" }],
+      }),
+    );
+  }
+  return null;
+}
+
+function settled(summary: string, refs: readonly string[]): Decision {
+  return {
+    result: resultFor("trail.ok", {
+      summary,
+      stateChanged: false,
+      evidence: refs.map((ref) => ({ kind: "artifact" as const, ref })),
+    }),
+    plan: planOf(),
+    humanStdout: null,
+    payload: null,
+  };
+}
+
+function invalidOutput(ref: string, why: string): Decision {
+  return decisionOf(
+    resultFor("trail.output_invalido", {
+      why: [why],
+      evidence: [{ kind: "observation", ref }],
+    }),
+  );
+}
+
+function usage(why: readonly string[]): Decision {
+  return decisionOf(resultFor("trail.uso", { why: [...why], evidence: [] }));
+}
+
+function refused(
+  workflow: Extract<WorkflowDecision, { readonly kind: "refused" }>,
+  observation: Observation,
+): Decision {
+  return decisionOf(
+    resultFor(workflow.reasonCode, {
+      why: ["The run refused to record the agent output."],
+      evidence:
+        workflow.reasonCode === "trail.uso"
+          ? []
+          : [{ kind: "artifact", ref: `${runRoot(observation)}/state.json` }],
+    }),
+  );
+}
+
+function decisionOf(result: Result): Decision {
+  return { result, plan: planOf(), humanStdout: null, payload: null };
+}

--- a/packages/runtime/src/domain/cli/commands.ts
+++ b/packages/runtime/src/domain/cli/commands.ts
@@ -18,6 +18,7 @@ import {
 } from "./diagnostics.js";
 import { RETIRED_COMMAND_SPECS } from "./retired.js";
 import { adaptersCommand } from "./adapters.js";
+import { agentRecordCommand } from "./agent.js";
 import { approveCommand } from "./approval.js";
 import { evidenceRecordCommand } from "./evidence.js";
 import {
@@ -96,6 +97,7 @@ const handshakeCommand: CommandSpec = {
 
 export const DEFAULT_REGISTRY: CommandRegistry = [
   adaptersCommand,
+  agentRecordCommand,
   approveCommand,
   auditCommand,
   budgetsCommand,

--- a/packages/runtime/src/domain/cli/index.ts
+++ b/packages/runtime/src/domain/cli/index.ts
@@ -5,6 +5,7 @@ export { initCommand } from "./init.js";
 export { hookCommand } from "./hook.js";
 export { objectiveCommand } from "./objective.js";
 export { adaptersCommand } from "./adapters.js";
+export { agentRecordCommand } from "./agent.js";
 export { approveCommand } from "./approval.js";
 export {
   auditCommand,

--- a/packages/runtime/src/domain/cli/spec.ts
+++ b/packages/runtime/src/domain/cli/spec.ts
@@ -5,6 +5,7 @@ import type {
 } from "../init/index.js";
 import type { ObjectiveObservation } from "../objective/index.js";
 import type {
+  AgentOutputV1,
   ApprovalV1,
   EventV1,
   EvidenceV1,
@@ -27,6 +28,7 @@ import type {
   IntegrityAudit,
   RepairPlan,
 } from "../observability/index.js";
+import type { AgentOutputObservation } from "../agent/index.js";
 import type { GapProposalObservation } from "../gaps/index.js";
 import type { GateDecision, GateMode } from "../gates/index.js";
 import type { MigrationPlan } from "../migration/index.js";
@@ -153,6 +155,11 @@ export type CommandObservation =
       readonly gapsReadable: boolean;
       /** The proposal a gap-recording command was pointed at, if any. */
       readonly gapProposal: GapProposalObservation;
+      /** The agent reply an output-recording command was pointed at, if any. */
+      readonly agentOutput: AgentOutputObservation;
+      /** Every agent output the run recorded, in agent order. */
+      readonly agentOutputs: readonly AgentOutputV1[];
+      readonly agentOutputsReadable: boolean;
       /** The gate facts exactly as recorded, before the approval boundary. */
       readonly gateFacts: {
         readonly readable: boolean;

--- a/packages/runtime/src/domain/schema/contracts.ts
+++ b/packages/runtime/src/domain/schema/contracts.ts
@@ -1,5 +1,6 @@
 import type {
   AdapterMessageV1,
+  AgentOutputV1,
   ApprovalV1,
   HostOperationMessageV1,
   InitAnswersV1,
@@ -19,6 +20,7 @@ import type {
 
 export interface ContractValues {
   readonly "host.adapter-message": AdapterMessageV1;
+  readonly "host.agent-output": AgentOutputV1;
   readonly "host.gap-proposal": GapProposalV1;
   readonly "host.init-answers": InitAnswersV1;
   readonly "host.operation-message": HostOperationMessageV1;

--- a/packages/runtime/src/domain/workflow/model.ts
+++ b/packages/runtime/src/domain/workflow/model.ts
@@ -104,6 +104,7 @@ export type WorkflowRefusal =
  * recorded gap look like a phase transition in the history.
  */
 export const FACT_EVENT_REASONS = {
+  "agent.record": "run.agent.recorded",
   "gaps.record": "run.gap.recorded",
   "gaps.resolve": "run.gap.resolved",
   "gaps.waive": "run.gap.waived",

--- a/packages/runtime/src/domain/workflow/reducer.ts
+++ b/packages/runtime/src/domain/workflow/reducer.ts
@@ -74,6 +74,7 @@ export function reduceWorkflow(
       }
       status = "blocked";
       break;
+    case "run.agent.recorded":
     case "run.gap.recorded":
     case "run.gap.resolved":
     case "run.gap.waived":

--- a/packages/runtime/src/infra/schema/catalog.ts
+++ b/packages/runtime/src/infra/schema/catalog.ts
@@ -1,5 +1,6 @@
 import manifest from "../../../../contracts/catalogs/contract-families.v1.json" with { type: "json" };
 import adapterMessageSchema from "../../../../../schemas/host/adapter-message.v1.schema.json" with { type: "json" };
+import agentOutputSchema from "../../../../../schemas/host/agent-output.v1.schema.json" with { type: "json" };
 import gapProposalSchema from "../../../../../schemas/host/gap-proposal.v1.schema.json" with { type: "json" };
 import initAnswersSchema from "../../../../../schemas/host/init-answers.v1.schema.json" with { type: "json" };
 import operationMessageSchema from "../../../../../schemas/host/operation-message.v1.schema.json" with { type: "json" };
@@ -40,6 +41,13 @@ export const EMBEDDED_SCHEMA_CATALOG: readonly EmbeddedSchemaEntry[] =
       version: "1.0.0",
       path: "schemas/host/adapter-message.v1.schema.json",
       schema: adapterMessageSchema,
+    },
+    {
+      id: "host.agent-output",
+      family: "host",
+      version: "1.0.0",
+      path: "schemas/host/agent-output.v1.schema.json",
+      schema: agentOutputSchema,
     },
     {
       id: "host.gap-proposal",
@@ -154,6 +162,7 @@ export const EMBEDDED_SCHEMA_DEPENDENCIES = deepFreeze([
 
 const EXPECTED_SCHEMA_IDS = {
   "host.adapter-message": "https://kratos.dev/schemas/host/adapter-message/v1",
+  "host.agent-output": "https://kratos.dev/schemas/host/agent-output/v1",
   "host.gap-proposal": "https://kratos.dev/schemas/host/gap-proposal/v1",
   "host.init-answers": "https://kratos.dev/schemas/host/init-answers/v1",
   "host.operation-message":

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -40,7 +40,11 @@ The host family contains
 [`gap-proposal.v1.schema.json`](host/gap-proposal.v1.schema.json), and
 [`init-answers.v1.schema.json`](host/init-answers.v1.schema.json), plus
 [`operation-message.v1.schema.json`](host/operation-message.v1.schema.json) for
-approval, hook, timeout, cancellation, and error delivery. The
+approval, hook, timeout, cancellation, and error delivery, and
+[`agent-output.v1.schema.json`](host/agent-output.v1.schema.json), the machine
+block one phase agent appends to its reply. See the
+[agent output contract](../docs/architecture/agent-output-contract.md) for the
+delimiter, the envelope, and the extraction rules. The
 registry format is
 [`contract-manifest.v1.schema.json`](contracts/contract-manifest.v1.schema.json).
 

--- a/schemas/contracts/contract-manifest.v1.schema.json
+++ b/schemas/contracts/contract-manifest.v1.schema.json
@@ -58,8 +58,8 @@
     },
     "schemas": {
       "type": "array",
-      "minItems": 16,
-      "maxItems": 16,
+      "minItems": 17,
+      "maxItems": 17,
       "uniqueItems": true,
       "items": {
         "$ref": "#/$defs/schemaEntry"

--- a/schemas/host/agent-output.v1.schema.json
+++ b/schemas/host/agent-output.v1.schema.json
@@ -1,0 +1,541 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kratos.dev/schemas/host/agent-output/v1",
+  "title": "Kratos agent output v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contractVersion",
+    "hostContract",
+    "agent",
+    "outcome",
+    "artifacts",
+    "changedFiles",
+    "payload"
+  ],
+  "properties": {
+    "contractVersion": {
+      "const": "1.0.0"
+    },
+    "hostContract": {
+      "const": "1.0.0"
+    },
+    "agent": {
+      "enum": ["prd", "spec", "plan", "code", "review", "acceptance"]
+    },
+    "outcome": {
+      "$ref": "#/$defs/outcome"
+    },
+    "artifacts": {
+      "$ref": "#/$defs/artifacts"
+    },
+    "changedFiles": {
+      "$ref": "#/$defs/changedFiles"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "agent": {
+            "const": "prd"
+          }
+        },
+        "required": ["agent"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/prdPayload"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "agent": {
+            "const": "spec"
+          }
+        },
+        "required": ["agent"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/specPayload"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "agent": {
+            "const": "plan"
+          }
+        },
+        "required": ["agent"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/planPayload"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "agent": {
+            "const": "code"
+          }
+        },
+        "required": ["agent"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/codePayload"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "agent": {
+            "const": "review"
+          }
+        },
+        "required": ["agent"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/reviewPayload"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "agent": {
+            "const": "acceptance"
+          }
+        },
+        "required": ["agent"]
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "$ref": "#/$defs/acceptancePayload"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$"
+    },
+    "text": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "reference": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))(?![a-z][a-z0-9+.-]*://)[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "option": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["optionId", "label"],
+      "properties": {
+        "optionId": {
+          "$ref": "#/$defs/id"
+        },
+        "label": {
+          "$ref": "#/$defs/text"
+        }
+      }
+    },
+    "question": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["questionId", "prompt", "kind", "options"],
+      "properties": {
+        "questionId": {
+          "$ref": "#/$defs/id"
+        },
+        "prompt": {
+          "$ref": "#/$defs/text"
+        },
+        "kind": {
+          "enum": ["free-text", "single-choice", "multiple-choice"]
+        },
+        "options": {
+          "type": "array",
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/option"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "free-text"
+              }
+            },
+            "required": ["kind"]
+          },
+          "then": {
+            "properties": {
+              "options": {
+                "type": "array",
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "enum": ["single-choice", "multiple-choice"]
+              }
+            },
+            "required": ["kind"]
+          },
+          "then": {
+            "properties": {
+              "options": {
+                "type": "array",
+                "minItems": 2
+              }
+            }
+          }
+        }
+      ]
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "next", "questions", "blockers"],
+      "properties": {
+        "status": {
+          "enum": ["completed", "awaiting-input", "blocked"]
+        },
+        "next": {
+          "enum": ["proceed", "wait", "retry", "finish", "stop"]
+        },
+        "questions": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/question"
+          }
+        },
+        "blockers": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/text"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "completed"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "next": {
+                "type": "string",
+                "enum": ["proceed", "finish"]
+              },
+              "questions": {
+                "type": "array",
+                "maxItems": 0
+              },
+              "blockers": {
+                "type": "array",
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "awaiting-input"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "next": {
+                "type": "string",
+                "const": "wait"
+              },
+              "questions": {
+                "type": "array",
+                "minItems": 1
+              },
+              "blockers": {
+                "type": "array",
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "blocked"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "next": {
+                "type": "string",
+                "enum": ["retry", "stop"]
+              },
+              "questions": {
+                "type": "array",
+                "maxItems": 0
+              },
+              "blockers": {
+                "type": "array",
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "artifacts": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/reference"
+      }
+    },
+    "changedFiles": {
+      "type": "array",
+      "maxItems": 256,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ref", "change"],
+        "properties": {
+          "ref": {
+            "$ref": "#/$defs/reference"
+          },
+          "change": {
+            "enum": ["added", "modified", "deleted"]
+          }
+        }
+      }
+    },
+    "prdPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["objective", "requirementIds", "gapIds"],
+      "properties": {
+        "objective": {
+          "$ref": "#/$defs/text"
+        },
+        "requirementIds": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "gapIds": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        }
+      }
+    },
+    "specPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requirementIds", "gapIds", "approvalRequired"],
+      "properties": {
+        "requirementIds": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "gapIds": {
+          "type": "array",
+          "maxItems": 64,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "approvalRequired": {
+          "type": "boolean"
+        }
+      }
+    },
+    "planPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["steps"],
+      "properties": {
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["stepId", "summary", "dependsOn"],
+            "properties": {
+              "stepId": {
+                "$ref": "#/$defs/id"
+              },
+              "summary": {
+                "$ref": "#/$defs/text"
+              },
+              "dependsOn": {
+                "type": "array",
+                "maxItems": 64,
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "#/$defs/id"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "codePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stepId", "testsAdded", "testsPassed"],
+      "properties": {
+        "stepId": {
+          "$ref": "#/$defs/id"
+        },
+        "testsAdded": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        },
+        "testsPassed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "reviewPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict", "findings"],
+      "properties": {
+        "verdict": {
+          "enum": ["pass", "changes-requested", "fail"]
+        },
+        "findings": {
+          "type": "array",
+          "maxItems": 128,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["findingId", "severity", "summary", "ref"],
+            "properties": {
+              "findingId": {
+                "$ref": "#/$defs/id"
+              },
+              "severity": {
+                "enum": ["high", "medium", "low"]
+              },
+              "summary": {
+                "$ref": "#/$defs/text"
+              },
+              "ref": {
+                "$ref": "#/$defs/reference"
+              }
+            }
+          }
+        }
+      }
+    },
+    "acceptancePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verdict", "criteria"],
+      "properties": {
+        "verdict": {
+          "enum": ["accepted", "rejected"]
+        },
+        "criteria": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["criterionId", "outcome", "evidenceRef"],
+            "properties": {
+              "criterionId": {
+                "$ref": "#/$defs/id"
+              },
+              "outcome": {
+                "enum": ["passed", "failed", "not-run"]
+              },
+              "evidenceRef": {
+                "$ref": "#/$defs/reference"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate-contract-types.mjs
+++ b/scripts/generate-contract-types.mjs
@@ -134,7 +134,35 @@ function transactionProgressTypeSchema(schema) {
   };
 }
 
+/**
+ * The agent output contract validates as one closed object whose payload is
+ * chosen by the `agent` discriminator, because that is what makes a refusal
+ * name the offending path instead of the document root. TypeScript wants the
+ * same contract as a discriminated union, so the union is rebuilt here from
+ * the very conditionals the validator reads.
+ */
+function agentOutputTypeSchema(schema) {
+  const variants = schema.allOf.map((rule) => {
+    const agent = rule.if?.properties?.agent;
+    const payload = rule.then?.properties?.payload;
+    if (agent === undefined || payload === undefined) {
+      throw new Error("agent output conditional branch is incomplete");
+    }
+    return closedObjectVariant(schema, { agent, payload });
+  });
+  return {
+    $schema: schema.$schema,
+    $id: schema.$id,
+    title: schema.title,
+    oneOf: variants,
+    $defs: schema.$defs,
+  };
+}
+
 function schemaForTypeGeneration(id, schema) {
+  if (id === "host.agent-output") {
+    return agentOutputTypeSchema(schema);
+  }
   if (id === "state.transaction-manifest") {
     return transactionManifestTypeSchema(schema);
   }

--- a/tests/agent-output-contract.test.ts
+++ b/tests/agent-output-contract.test.ts
@@ -1,0 +1,475 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { AgentOutputV1 } from "@kratos/contracts";
+import {
+  AGENT_BLOCK_CLOSE,
+  AGENT_BLOCK_OPEN,
+  AGENTS,
+  MAX_BLOCK_LENGTH,
+  checkAgentOutput,
+  describeAgentOutputFailure,
+  describeAgentOutputRefusal,
+  describeBlockMalformation,
+  extractAgentBlock,
+  type AgentOutputRefusal,
+  type BlockMalformation,
+} from "@kratos/runtime/domain/agent";
+import { createSchemaRegistry } from "@kratos/runtime/composition/schema";
+import { RUN_PHASES } from "@kratos/runtime/domain/workflow";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { collectImports } from "./support/architecture.js";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const fixtureRoot = join(repositoryRoot, "fixtures/agent-output/v1");
+const registry = createSchemaRegistry();
+
+let valid: Readonly<Record<string, unknown>>;
+let invalid: Readonly<Record<string, unknown>>;
+let replies: Readonly<Record<string, string>>;
+
+async function readDirectory(
+  name: string,
+): Promise<Readonly<Record<string, string>>> {
+  const directory = join(fixtureRoot, name);
+  const entries = await readdir(directory);
+  const pairs = await Promise.all(
+    entries.map(async (entry): Promise<readonly [string, string]> => [
+      entry.replace(/\.(?:json|md)$/u, ""),
+      await readFile(join(directory, entry), "utf8"),
+    ]),
+  );
+  return Object.fromEntries(pairs);
+}
+
+async function readJsonDirectory(
+  name: string,
+): Promise<Readonly<Record<string, unknown>>> {
+  return Object.fromEntries(
+    Object.entries(await readDirectory(name)).map(([key, text]) => [
+      key,
+      JSON.parse(text) as unknown,
+    ]),
+  );
+}
+
+function validate(value: unknown) {
+  return registry.validate({
+    id: "host.agent-output",
+    version: "1.0.0",
+    value,
+    structuralReasonCode: "trail.output_invalido",
+  });
+}
+
+/** The block a reply carries, or a failure naming which exit it took. */
+function accepted(reply: string): AgentOutputV1 {
+  const extracted = extractAgentBlock(reply);
+  if (extracted.kind !== "extracted") {
+    throw new Error(`extraction exited as ${extracted.kind}`);
+  }
+  const validated = validate(extracted.value);
+  if (validated.kind !== "valid") {
+    throw new Error(
+      describeAgentOutputFailure({
+        kind: "invalid",
+        ref: "x",
+        diagnostics: validated.diagnostics,
+      }),
+    );
+  }
+  return validated.value;
+}
+
+function block(body: string, before = "", after = ""): string {
+  return `${before}${AGENT_BLOCK_OPEN}\n${body}\n${AGENT_BLOCK_CLOSE}${after}`;
+}
+
+beforeAll(async () => {
+  [valid, invalid, replies] = await Promise.all([
+    readJsonDirectory("valid"),
+    readJsonDirectory("invalid"),
+    readDirectory("replies"),
+  ]);
+});
+
+describe("the published agent output contract", () => {
+  it("accepts a valid payload for every phase agent", () => {
+    expect(Object.keys(valid).sort()).toEqual([...AGENTS].sort());
+    for (const agent of AGENTS) {
+      const result = validate(valid[agent]);
+      expect(result.kind, agent).toBe("valid");
+    }
+  });
+
+  it("refuses an invalid payload for every phase agent", () => {
+    expect(Object.keys(invalid).sort()).toEqual([...AGENTS].sort());
+    for (const agent of AGENTS) {
+      const result = validate(invalid[agent]);
+      expect(result.kind, agent).toBe("invalid");
+      if (result.kind !== "invalid") throw new Error("unreachable");
+      // A refusal that cannot name where it happened is not actionable.
+      expect(result.diagnostics.length, agent).toBeGreaterThan(0);
+      expect(
+        describeAgentOutputFailure({
+          kind: "invalid",
+          ref: "reply.md",
+          diagnostics: result.diagnostics,
+        }),
+        agent,
+      ).toContain("host.agent-output@1.0.0");
+    }
+  });
+
+  it("addresses exactly the phases a run walks", () => {
+    expect([...AGENTS]).toEqual([...RUN_PHASES]);
+  });
+
+  it("refuses an unexpected field rather than warning about it", () => {
+    const candidate = { ...(valid.prd as object), surprise: true };
+    expect(validate(candidate).kind).toBe("invalid");
+  });
+
+  it("keeps artifacts and changed files as separate fields", () => {
+    const code = valid.code as AgentOutputV1;
+    expect(code.artifacts).toEqual([]);
+    expect(code.changedFiles.map(({ ref }) => ref)).toEqual([
+      "src/refunds/window.ts",
+      "tests/refund-window.test.ts",
+    ]);
+  });
+
+  it("shapes a blocking question as an object a host can render", () => {
+    const spec = valid.spec as AgentOutputV1;
+    expect(spec.outcome.questions).toEqual([
+      {
+        questionId: "q-refund-window",
+        prompt: "Which refund window should the design implement?",
+        kind: "single-choice",
+        options: [
+          { optionId: "days-14", label: "Fourteen days from delivery" },
+          { optionId: "days-30", label: "Thirty days from delivery" },
+        ],
+      },
+      {
+        questionId: "q-refund-owner",
+        prompt: "Who owns the refund ledger after this change?",
+        kind: "free-text",
+        options: [],
+      },
+    ]);
+  });
+
+  it.each([
+    ["completed", "wait"],
+    ["completed", "retry"],
+    ["awaiting-input", "proceed"],
+    ["blocked", "finish"],
+  ])("refuses status %s routed as %s", (status, next) => {
+    const candidate = structuredClone(valid.prd) as AgentOutputV1;
+    const mutated = {
+      ...candidate,
+      outcome: { ...candidate.outcome, status, next },
+    };
+    expect(validate(mutated).kind).toBe("invalid");
+  });
+
+  it("requires a question when the agent awaits input", () => {
+    const candidate = structuredClone(valid.spec) as AgentOutputV1;
+    expect(
+      validate({
+        ...candidate,
+        outcome: { ...candidate.outcome, questions: [] },
+      }).kind,
+    ).toBe("invalid");
+  });
+
+  it("requires a blocker when the agent reports itself blocked", () => {
+    const candidate = structuredClone(valid.code) as AgentOutputV1;
+    expect(
+      validate({
+        ...candidate,
+        outcome: { ...candidate.outcome, blockers: [] },
+      }).kind,
+    ).toBe("invalid");
+  });
+
+  it("requires options on a choice question and forbids them otherwise", () => {
+    const spec = structuredClone(valid.spec) as AgentOutputV1;
+    const [choice, free] = spec.outcome.questions;
+    if (choice === undefined || free === undefined) {
+      throw new Error("the specification fixture lost its questions");
+    }
+    expect(
+      validate({
+        ...spec,
+        outcome: {
+          ...spec.outcome,
+          questions: [{ ...choice, options: [] }, free],
+        },
+      }).kind,
+    ).toBe("invalid");
+    expect(
+      validate({
+        ...spec,
+        outcome: {
+          ...spec.outcome,
+          questions: [choice, { ...free, options: choice.options }],
+        },
+      }).kind,
+    ).toBe("invalid");
+  });
+
+  it("refuses an escaping reference in either path field", () => {
+    const prd = structuredClone(valid.prd) as AgentOutputV1;
+    expect(validate({ ...prd, artifacts: ["../secret"] }).kind).toBe("invalid");
+    expect(
+      validate({
+        ...prd,
+        changedFiles: [{ ref: "/etc/passwd", change: "modified" }],
+      }).kind,
+    ).toBe("invalid");
+  });
+});
+
+describe("machine block extraction", () => {
+  it("reports a reply that carries no block", () => {
+    expect(extractAgentBlock(replies.absent ?? "")).toEqual({ kind: "absent" });
+  });
+
+  it("ignores an ordinary fenced example and extracts the machine block", () => {
+    const output = accepted(replies.decoy ?? "");
+    expect(output.agent).toBe("spec");
+    // The decoy fence claims the run is blocked; the machine block does not.
+    expect(output.outcome.status).toBe("completed");
+  });
+
+  it("names the parse failure of a malformed block", () => {
+    const extracted = extractAgentBlock(replies.malformed ?? "");
+    expect(extracted).toEqual({ kind: "malformed", reason: "invalid-json" });
+  });
+
+  it("refuses a block that is not the last thing in the reply", () => {
+    const extracted = extractAgentBlock(replies.trailing ?? "");
+    expect(extracted).toEqual({
+      kind: "malformed",
+      reason: "trailing-content",
+    });
+  });
+
+  it("names the offending path of a schema-invalid block", () => {
+    const extracted = extractAgentBlock(replies.invalid ?? "");
+    if (extracted.kind !== "extracted") throw new Error("block not extracted");
+    const result = validate(extracted.value);
+    if (result.kind !== "invalid") throw new Error("block was accepted");
+    expect(
+      describeAgentOutputFailure({
+        kind: "invalid",
+        ref: "reply.md",
+        diagnostics: result.diagnostics,
+      }),
+    ).toContain("outcome.status");
+  });
+
+  it("tolerates the line endings of either host", () => {
+    const reply = replies.decoy ?? "";
+    expect(extractAgentBlock(reply.split("\n").join("\r\n"))).toEqual(
+      extractAgentBlock(reply),
+    );
+  });
+
+  it("allows trailing whitespace after the closing delimiter", () => {
+    expect(extractAgentBlock(block("{}", "", "\n\n  \n")).kind).toBe(
+      "extracted",
+    );
+  });
+
+  it.each<[string, BlockMalformation]>([
+    [block("{}", `${AGENT_BLOCK_OPEN}\n`), "duplicate-open"],
+    [`${block("{}")}\n${AGENT_BLOCK_CLOSE}`, "duplicate-close"],
+    [`${AGENT_BLOCK_OPEN}\n{}`, "unterminated"],
+    [`prose\n${AGENT_BLOCK_CLOSE}`, "unopened"],
+    [block("", "", ""), "empty-block"],
+    [block("not json"), "invalid-json"],
+    [block("[1, 2]"), "non-object"],
+    [block(`"${"x".repeat(MAX_BLOCK_LENGTH)}"`), "block-too-large"],
+  ])("refuses a reply whose block is %#", (reply, reason) => {
+    expect(extractAgentBlock(reply)).toEqual({ kind: "malformed", reason });
+  });
+
+  it("refuses a block that closes before it opens", () => {
+    expect(
+      extractAgentBlock(`${AGENT_BLOCK_CLOSE}\n{}\n${AGENT_BLOCK_OPEN}`),
+    ).toEqual({ kind: "malformed", reason: "misordered" });
+  });
+
+  it("recognizes a delimiter only as a whole unindented line", () => {
+    expect(extractAgentBlock(`  ${AGENT_BLOCK_OPEN}\n{}`)).toEqual({
+      kind: "absent",
+    });
+  });
+
+  it("describes every malformation in one sentence", () => {
+    const reasons: readonly BlockMalformation[] = [
+      "block-too-large",
+      "duplicate-close",
+      "duplicate-open",
+      "empty-block",
+      "invalid-json",
+      "misordered",
+      "non-object",
+      "trailing-content",
+      "unopened",
+      "unterminated",
+    ];
+    for (const reason of reasons) {
+      expect(describeBlockMalformation(reason)).toMatch(/^[A-Z].*\.$/u);
+    }
+  });
+});
+
+describe("agreements the schema cannot state", () => {
+  it("accepts every valid fixture", () => {
+    for (const agent of AGENTS) {
+      expect(checkAgentOutput(valid[agent] as AgentOutputV1), agent).toBeNull();
+    }
+  });
+
+  it("refuses a path claimed as both an artifact and a changed file", () => {
+    const prd = structuredClone(valid.prd) as AgentOutputV1;
+    expect(
+      checkAgentOutput({
+        ...prd,
+        changedFiles: [{ ref: prd.artifacts[0] ?? "", change: "modified" }],
+      }),
+    ).toBe("artifact-also-changed");
+  });
+
+  it("refuses a changed file listed twice", () => {
+    const code = structuredClone(valid.code) as AgentOutputV1;
+    const first = code.changedFiles[0];
+    if (first === undefined) throw new Error("the code fixture lost its files");
+    expect(
+      checkAgentOutput({
+        ...code,
+        changedFiles: [first, { ...first, change: "deleted" }],
+      }),
+    ).toBe("duplicate-changed-file");
+  });
+
+  it("refuses a repeated question or option identifier", () => {
+    const spec = structuredClone(valid.spec) as AgentOutputV1;
+    const [choice] = spec.outcome.questions;
+    if (choice === undefined) throw new Error("the fixture lost its question");
+    expect(
+      checkAgentOutput({
+        ...spec,
+        outcome: { ...spec.outcome, questions: [choice, choice] },
+      }),
+    ).toBe("duplicate-question-id");
+    const option = choice.options[0];
+    if (option === undefined) throw new Error("the fixture lost its option");
+    expect(
+      checkAgentOutput({
+        ...spec,
+        outcome: {
+          ...spec.outcome,
+          questions: [
+            { ...choice, options: [option, { ...option, label: "Other" }] },
+          ],
+        },
+      }),
+    ).toBe("duplicate-option-id");
+  });
+
+  it("refuses a plan whose steps repeat or depend on nothing known", () => {
+    const plan = structuredClone(valid.plan) as AgentOutputV1;
+    if (plan.agent !== "plan")
+      throw new Error("the plan fixture changed agent");
+    const [first, second] = plan.payload.steps;
+    if (second === undefined) {
+      throw new Error("the plan fixture lost its second step");
+    }
+    expect(
+      checkAgentOutput({ ...plan, payload: { steps: [first, first] } }),
+    ).toBe("duplicate-step-id");
+    expect(
+      checkAgentOutput({
+        ...plan,
+        payload: { steps: [first, { ...second, dependsOn: ["step-unknown"] }] },
+      }),
+    ).toBe("unknown-step-dependency");
+  });
+
+  it("refuses a verdict that contradicts what it reports", () => {
+    const review = structuredClone(valid.review) as AgentOutputV1;
+    if (review.agent !== "review")
+      throw new Error("the review fixture changed");
+    expect(
+      checkAgentOutput({
+        ...review,
+        payload: { ...review.payload, verdict: "pass" },
+      }),
+    ).toBe("verdict-contradicts-findings");
+
+    const acceptance = structuredClone(valid.acceptance) as AgentOutputV1;
+    if (acceptance.agent !== "acceptance") {
+      throw new Error("the acceptance fixture changed");
+    }
+    const [criterion] = acceptance.payload.criteria;
+    expect(
+      checkAgentOutput({
+        ...acceptance,
+        payload: {
+          ...acceptance.payload,
+          criteria: [{ ...criterion, outcome: "failed" }],
+        },
+      }),
+    ).toBe("verdict-contradicts-criteria");
+  });
+
+  it("describes every refusal in one sentence", () => {
+    const reasons: readonly AgentOutputRefusal[] = [
+      "artifact-also-changed",
+      "duplicate-changed-file",
+      "duplicate-option-id",
+      "duplicate-question-id",
+      "duplicate-step-id",
+      "unknown-step-dependency",
+      "verdict-contradicts-criteria",
+      "verdict-contradicts-findings",
+    ];
+    for (const reason of reasons) {
+      expect(describeAgentOutputRefusal(reason)).toMatch(/^[A-Z].*\.$/u);
+    }
+  });
+});
+
+describe("what extraction and validation are allowed to reach", () => {
+  it("performs no model call and no network access", async () => {
+    const directory = join(repositoryRoot, "packages/runtime/src/domain/agent");
+    const modules = await readdir(directory);
+    const imports = (
+      await Promise.all(
+        modules.map((name) => collectImports(join(directory, name))),
+      )
+    ).flat();
+    // The extractor and its model reach the published contracts, the schema
+    // types, and each other. A platform module here would be the first step
+    // towards a boundary that can call out; there is none to call.
+    expect([...new Set(imports)].sort()).toEqual([
+      "../schema/index.js",
+      "./coherence.js",
+      "./extract.js",
+      "./model.js",
+      "@kratos/contracts",
+    ]);
+  });
+
+  it("returns the same answer for the same reply every time", () => {
+    const reply = replies.decoy ?? "";
+    expect(extractAgentBlock(reply)).toEqual(extractAgentBlock(reply));
+  });
+});

--- a/tests/agent-output-recording.test.ts
+++ b/tests/agent-output-recording.test.ts
@@ -1,0 +1,349 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { AgentOutputV1, EventV1 } from "@kratos/contracts";
+import { runCommandLine } from "@kratos/runtime/composition/cli";
+import type { Result } from "@kratos/runtime/domain/result";
+import { createSchemaRegistry } from "@kratos/runtime/composition/schema";
+import {
+  AGENT_BLOCK_CLOSE,
+  AGENT_BLOCK_OPEN,
+} from "@kratos/runtime/domain/agent";
+import {
+  fixedClock,
+  fixedEnvironment,
+  memoryFileSystem,
+  memoryTransactionStorage,
+  memoryWorkspace,
+  pipedInput,
+  recordingOutput,
+  sequentialIds,
+  stubGit,
+} from "@kratos/runtime/infra/fake";
+import type { RuntimePorts } from "@kratos/runtime/ports";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const replyRoot = join(repositoryRoot, "fixtures/agent-output/v1/replies");
+const ROOT = "/project";
+const NOW = "2026-08-18T09:00:00.000Z";
+const TEXT = "Ship the refund pipeline";
+const FEATURE = "ship-the-refund-pipeline";
+const RUN_ROOT = `.brain/02-features/${FEATURE}/runs`;
+const REPLY = `.brain/02-features/${FEATURE}/agent-reply.md`;
+const registry = createSchemaRegistry();
+
+const PRD_BLOCK = {
+  contractVersion: "1.0.0",
+  hostContract: "1.0.0",
+  agent: "prd",
+  outcome: {
+    status: "completed",
+    next: "proceed",
+    questions: [],
+    blockers: [],
+  },
+  artifacts: [`.brain/02-features/${FEATURE}/00-prd.md`],
+  changedFiles: [],
+  payload: {
+    objective: TEXT,
+    requirementIds: ["req-refund-window"],
+    gapIds: [],
+  },
+} as const satisfies AgentOutputV1;
+
+/** One agent reply: prose, an ordinary fenced example, then the machine block. */
+function reply(block: unknown = PRD_BLOCK): string {
+  return [
+    "# Product requirements",
+    "",
+    "The requirements document is written.",
+    "",
+    "```json",
+    '{ "note": "this fenced example is prose, not the machine block" }',
+    "```",
+    "",
+    AGENT_BLOCK_OPEN,
+    JSON.stringify(block, null, 2),
+    AGENT_BLOCK_CLOSE,
+    "",
+  ].join("\n");
+}
+
+interface Subject {
+  readonly ports: RuntimePorts;
+  readonly storage: ReturnType<typeof memoryTransactionStorage>;
+  readonly output: ReturnType<typeof recordingOutput>;
+}
+
+function subject(
+  files: Readonly<Record<string, string>> = {},
+  directories: readonly string[] = [".brain", ".brain/transactions"],
+  piped: string | null = null,
+): Subject {
+  const storage = memoryTransactionStorage({ files, directories });
+  const output = recordingOutput();
+  return {
+    storage,
+    output,
+    ports: {
+      clock: fixedClock(NOW),
+      ids: sequentialIds("id"),
+      digests: storage.digests,
+      durableFileSystem: storage.durableFileSystem,
+      fileSystem: memoryFileSystem({}),
+      environment: fixedEnvironment({}, ROOT),
+      git: stubGit(),
+      output,
+      standardInput: pipedInput(piped),
+      workspace: memoryWorkspace({ directories: [ROOT] }),
+    } as unknown as RuntimePorts,
+  };
+}
+
+function settled(run: Subject): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    Object.entries(run.storage.snapshot().files).filter(
+      ([path]) => !path.startsWith(".brain/transactions/"),
+    ),
+  );
+}
+
+function next(
+  run: Subject,
+  written: Readonly<Record<string, string>> = {},
+): Subject {
+  const snapshot = run.storage.snapshot();
+  return subject(
+    { ...settled(run), ...written },
+    snapshot.directories.filter((path) => !path.includes("/transactions/")),
+  );
+}
+
+async function startedRun(): Promise<Subject> {
+  const initialized = subject(
+    {},
+    [".brain", ".brain/transactions"],
+    JSON.stringify({
+      contractVersion: "1.0.0",
+      hostContract: "1.0.0",
+      hosts: ["claude"],
+      language: "en",
+      policyMode: "standard",
+      snapshots: true,
+    }),
+  );
+  expect(await runCommandLine(["init"], initialized.ports)).toBe(0);
+  const objective = next(initialized);
+  expect(await runCommandLine(["objective", TEXT], objective.ports)).toBe(0);
+  const started = next(objective);
+  expect(
+    await runCommandLine(["start", "--host", "claude-code"], started.ports),
+  ).toBe(0);
+  return started;
+}
+
+function runId(run: Subject): string {
+  const path = Object.keys(settled(run)).find(
+    (candidate) =>
+      candidate.startsWith(RUN_ROOT) && candidate.endsWith("/state.json"),
+  );
+  if (path === undefined) throw new Error("the run wrote no snapshot");
+  return path.slice(RUN_ROOT.length + 1, path.lastIndexOf("/"));
+}
+
+function outputPath(run: Subject, agent: string): string {
+  return `${RUN_ROOT}/${runId(run)}/agent-output/${agent}.json`;
+}
+
+function events(run: Subject): readonly EventV1[] {
+  return (settled(run)[`${RUN_ROOT}/${runId(run)}/events.jsonl`] ?? "")
+    .split("\n")
+    .filter((line) => line !== "")
+    .map((line) => JSON.parse(line) as EventV1);
+}
+
+/** Record one reply against a started run and report what the runtime said. */
+async function record(
+  run: Subject,
+  text: string,
+  options: { readonly host?: string; readonly correlationId?: string } = {},
+): Promise<{
+  readonly exitCode: number;
+  readonly result: Result;
+  readonly after: Subject;
+}> {
+  const recording = next(run, { [REPLY]: text });
+  const exitCode = await runCommandLine(
+    [
+      "--json",
+      "agent",
+      "record",
+      REPLY,
+      "--correlation-id",
+      options.correlationId ?? "agent-first",
+      "--host",
+      options.host ?? "claude-code",
+    ],
+    recording.ports,
+  );
+  return {
+    exitCode,
+    result: JSON.parse(recording.output.structured_.join("")) as Result,
+    after: next(recording),
+  };
+}
+
+let started: Subject;
+
+beforeAll(async () => {
+  started = await startedRun();
+});
+
+describe("recording one agent reply", () => {
+  it("extracts the machine block past an ordinary fenced example", async () => {
+    const { exitCode, result, after } = await record(started, reply());
+    expect(exitCode).toBe(0);
+    expect(result.reasonCode).toBe("trail.ok");
+    expect(result.stateChanged).toBe(true);
+    expect(JSON.parse(settled(after)[outputPath(after, "prd")] ?? "")).toEqual(
+      PRD_BLOCK,
+    );
+  });
+
+  it("persists exactly the block the validator accepted", async () => {
+    const { after } = await record(started, reply());
+    const persisted = settled(after)[outputPath(after, "prd")] ?? "";
+    const validated = registry.validate({
+      id: "host.agent-output",
+      version: "1.0.0",
+      value: JSON.parse(persisted) as unknown,
+      structuralReasonCode: "trail.output_invalido",
+    });
+    if (validated.kind !== "valid")
+      throw new Error("state does not round-trip");
+    expect(validated.value).toEqual(PRD_BLOCK);
+    // Byte equality too: a derived view reads the recorded document, so a
+    // re-serialization that reordered keys would still be a contract change.
+    expect(persisted).toBe(`${JSON.stringify(PRD_BLOCK, null, 2)}\n`);
+  });
+
+  it("appends one fact event that does not move the run", async () => {
+    const { after } = await record(started, reply());
+    const recorded = events(after).at(-1);
+    expect(recorded?.reasonCode).toBe("run.agent.recorded");
+    expect(recorded?.effect).toBe("state-and-artifact");
+    expect(
+      JSON.parse(
+        settled(after)[`${RUN_ROOT}/${runId(after)}/state.json`] ?? "",
+      ),
+    ).toMatchObject({ status: "active", currentStep: "prd" });
+  });
+
+  it("treats a repeated delivery as already recorded", async () => {
+    const first = await record(started, reply());
+    const again = await record(first.after, reply());
+    expect(again.exitCode).toBe(0);
+    expect(again.result.stateChanged).toBe(false);
+  });
+
+  it("reads the same reply identically whichever host relayed it", async () => {
+    const claude = await record(started, reply(), { host: "claude-code" });
+    const codex = await record(started, reply().split("\n").join("\r\n"), {
+      host: "codex",
+    });
+    expect(codex.exitCode).toBe(claude.exitCode);
+    expect(codex.result.reasonCode).toBe(claude.result.reasonCode);
+    expect(settled(codex.after)[outputPath(codex.after, "prd")]).toBe(
+      settled(claude.after)[outputPath(claude.after, "prd")],
+    );
+  });
+});
+
+describe("replies the runtime refuses to route on", () => {
+  it("reports a reply with no machine block without advancing the run", async () => {
+    const text = await readFile(join(replyRoot, "absent.md"), "utf8");
+    const { exitCode, result, after } = await record(started, text);
+    expect(exitCode).toBe(3);
+    expect(result.reasonCode).toBe("trail.output_invalido");
+    expect(result.stateChanged).toBe(false);
+    expect(result.why).toEqual(["The reply carries no machine block."]);
+    expect(settled(after)[outputPath(after, "prd")]).toBeUndefined();
+    expect(
+      events(after).some((e) => e.reasonCode === "run.agent.recorded"),
+    ).toBe(false);
+  });
+
+  it("names the parse failure of a malformed block", async () => {
+    const text = await readFile(join(replyRoot, "malformed.md"), "utf8");
+    const { exitCode, result } = await record(started, text);
+    expect(exitCode).toBe(3);
+    expect(result.reasonCode).toBe("trail.output_invalido");
+    expect(result.why).toEqual([
+      "The machine block is not a single JSON document.",
+    ]);
+  });
+
+  it("names the offending path of a schema-invalid block", async () => {
+    const text = await readFile(join(replyRoot, "invalid.md"), "utf8");
+    const { exitCode, result } = await record(started, text);
+    expect(exitCode).toBe(3);
+    expect(result.reasonCode).toBe("trail.output_invalido");
+    expect(result.why[0]).toContain("outcome.status");
+  });
+
+  it("refuses a block whose agent is not the phase the run is in", async () => {
+    const { exitCode, result } = await record(
+      started,
+      reply({
+        ...PRD_BLOCK,
+        agent: "review",
+        payload: { verdict: "pass", findings: [] },
+      }),
+    );
+    expect(exitCode).toBe(3);
+    expect(result.why).toEqual([
+      "The review agent addressed a run in the prd phase.",
+    ]);
+  });
+
+  it("refuses a block that contradicts itself", async () => {
+    const { exitCode, result } = await record(
+      started,
+      reply({
+        ...PRD_BLOCK,
+        changedFiles: [
+          { ref: `.brain/02-features/${FEATURE}/00-prd.md`, change: "added" },
+        ],
+      }),
+    );
+    expect(exitCode).toBe(3);
+    expect(result.why).toEqual([
+      "A path is listed both as a written artifact and as a changed file.",
+    ]);
+  });
+
+  it("fails closed when recorded output no longer satisfies its contract", async () => {
+    const first = await record(started, reply());
+    const corrupted = next(first.after, {
+      [outputPath(first.after, "prd")]: "{}\n",
+    });
+    expect(
+      await runCommandLine(
+        ["--json", "agent", "record", REPLY, "--correlation-id", "second"],
+        next(corrupted, { [REPLY]: reply() }).ports,
+      ),
+    ).toBe(4);
+  });
+
+  it("refuses to record against a project with no active run", async () => {
+    const bare = subject({ [REPLY]: reply() }, [
+      ".brain",
+      ".brain/transactions",
+    ]);
+    expect(
+      await runCommandLine(["--json", "agent", "record", REPLY], bare.ports),
+    ).not.toBe(0);
+  });
+});

--- a/tests/cli-commands.test.ts
+++ b/tests/cli-commands.test.ts
@@ -23,6 +23,7 @@ describe("implemented commands", () => {
         .sort(),
     ).toEqual([
       "adapters",
+      "agent record",
       "approve",
       "audit",
       "budgets",

--- a/tests/command-observation.test.ts
+++ b/tests/command-observation.test.ts
@@ -50,6 +50,7 @@ describe("commands that observe before deciding", () => {
     ).map((command) => command.path.join(" "));
 
     expect(observing).toEqual([
+      "agent record",
       "approve",
       "audit",
       "budgets",

--- a/tests/contract-documentation.test.ts
+++ b/tests/contract-documentation.test.ts
@@ -15,6 +15,7 @@ let projectDiscovery: string;
 let runtimeBoundaries: string;
 let concurrencyLocks: string;
 let reasonCatalog: string;
+let agentOutput: string;
 
 beforeAll(async () => {
   [
@@ -27,6 +28,7 @@ beforeAll(async () => {
     runtimeBoundaries,
     concurrencyLocks,
     reasonCatalog,
+    agentOutput,
   ] = await Promise.all([
     readFile(
       join(repositoryRoot, "docs/compatibility/contract-versioning.md"),
@@ -56,6 +58,10 @@ beforeAll(async () => {
         repositoryRoot,
         "packages/contracts/catalogs/reason-codes.v1.3.json",
       ),
+      "utf8",
+    ),
+    readFile(
+      join(repositoryRoot, "docs/architecture/agent-output-contract.md"),
       "utf8",
     ),
   ]);
@@ -137,6 +143,26 @@ describe("contract versioning documentation", () => {
     expect(readme).toContain("schema registry contract");
   });
 
+  it("publishes the delimiter, the envelope, and the extraction rules", () => {
+    for (const token of [
+      "===KRATOS-AGENT-OUTPUT-V1===",
+      "===END-KRATOS-AGENT-OUTPUT-V1===",
+      "deliberately not a Markdown fence",
+      "kratos agent record REF",
+      "host.agent-output@1.0.0",
+      "run.agent.recorded",
+      "trail.output_invalido",
+      "no model call and no network access",
+      "additionalProperties: false",
+      "issues/113",
+    ]) {
+      expect(agentOutput).toContain(token);
+    }
+    // The two path fields exist to stay apart; documentation that stopped
+    // saying so would be documenting a different contract.
+    expect(agentOutput).toContain("stay separate fields");
+  });
+
   it("indexes all current artifact families and commands", () => {
     for (const token of [
       "project-config.v1.schema.json",
@@ -150,6 +176,7 @@ describe("contract versioning documentation", () => {
       "transaction-manifest.v1.schema.json",
       "transaction-progress.v1.schema.json",
       "adapter-message.v1.schema.json",
+      "agent-output.v1.schema.json",
       "operation-message.v1.schema.json",
       "contract-manifest.v1.schema.json",
       "npm run contracts:generate",
@@ -173,6 +200,7 @@ describe("contract versioning documentation", () => {
       "operation-timeout.json",
       "operation-cancellation.json",
       "operation-error.json",
+      "agent-output.json",
       "version-cases.json",
     ]) {
       expect(fixtureIndex).toContain(token);

--- a/tests/contract-manifest.test.ts
+++ b/tests/contract-manifest.test.ts
@@ -123,7 +123,7 @@ describe("contract family manifest", () => {
   });
 
   it("registers every current payload schema once with safe paths", async () => {
-    expect(manifest.schemas).toHaveLength(16);
+    expect(manifest.schemas).toHaveLength(17);
     const ids = manifest.schemas.map(({ id }) => id);
     const paths = manifest.schemas.map(({ path }) => path);
     expect(ids).toEqual([...ids].sort());

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -29,6 +29,7 @@ const artifacts = [
     "state",
   ],
   ["host/adapter-message.v1.schema.json", "adapter-message.json", "host"],
+  ["host/agent-output.v1.schema.json", "agent-output.json", "host"],
   ["host/gap-proposal.v1.schema.json", "gap-proposal.json", "host"],
   ["state/gap.v1.schema.json", "gap.json", "state"],
   ["state/gates.v1.schema.json", "gates.json", "state"],
@@ -78,6 +79,26 @@ describe("versioned state and host schemas", () => {
           );
         }
       } else {
+        if (fixtureName === "agent-output.json") {
+          // One closed payload per phase agent, chosen by the `agent`
+          // discriminator, so an unexpected field is a contract violation for
+          // every agent rather than only the one the fixture exercises.
+          const definitions = schema.$defs as JsonObject;
+          expect(schema.allOf, fixtureName).toHaveLength(6);
+          for (const name of [
+            "prdPayload",
+            "specPayload",
+            "planPayload",
+            "codePayload",
+            "reviewPayload",
+            "acceptancePayload",
+          ]) {
+            expect(
+              (definitions[name] as JsonObject).additionalProperties,
+              name,
+            ).toBe(false);
+          }
+        }
         expect(schema.additionalProperties, fixtureName).toBe(false);
       }
       const validate = ajv.compile(schema);

--- a/tests/contract-type-generation.test.ts
+++ b/tests/contract-type-generation.test.ts
@@ -29,7 +29,7 @@ describe("schema-derived contract declarations", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe(
-      "contract families v1.0.0: verified (16 schemas; 14 legacy profiles; generated types current)\n",
+      "contract families v1.0.0: verified (17 schemas; 14 legacy profiles; generated types current)\n",
     );
     expect(after).toBe(before);
     expect(after).toContain("Generated from registered JSON Schemas.");

--- a/tests/schema-registry-fixtures.test.ts
+++ b/tests/schema-registry-fixtures.test.ts
@@ -1,6 +1,7 @@
 import manifest from "../packages/contracts/catalogs/contract-families.v1.json" with { type: "json" };
 import versionCases from "../fixtures/contracts/v1/version-cases.json" with { type: "json" };
 import adapterMessage from "../fixtures/contracts/v1/adapter-message.json" with { type: "json" };
+import agentOutput from "../fixtures/contracts/v1/agent-output.json" with { type: "json" };
 import gapProposal from "../fixtures/contracts/v1/gap-proposal.json" with { type: "json" };
 import initAnswers from "../fixtures/contracts/v1/init-answers.json" with { type: "json" };
 import operationApproval from "../fixtures/contracts/v1/operation-approval.json" with { type: "json" };
@@ -44,6 +45,16 @@ const fixtures = [
     requiredField: "messageId",
     structuralReasonCode: "trail.output_invalido",
     fixture: adapterMessage,
+    invalidVersionReason: "contract.host_version_invalid",
+    unsupportedVersionReason: "contract.host_version_unsupported",
+  },
+  {
+    id: "host.agent-output",
+    version: "1.0.0",
+    versionField: "hostContract",
+    requiredField: "payload",
+    structuralReasonCode: "trail.output_invalido",
+    fixture: agentOutput,
     invalidVersionReason: "contract.host_version_invalid",
     unsupportedVersionReason: "contract.host_version_unsupported",
   },


### PR DESCRIPTION
Closes #129 (`ADP-01b`).

## What this adds

`host.agent-output@1.0.0`, the contract a phase agent's reply carries, plus the
extraction, validation, and recording that turn one reply into typed run state.

Before this, the repository had twenty schemas and every one of them described
state or a host message. None described what a phase agent produces. #113
(`ADP-01a`) covers what the host tells the runtime about a session; this covers
the other direction, and it is the piece #128 (`SDD-12`), #132 (`SDD-13`), and
#134 (`ADP-02a`) would otherwise each have to invent for themselves.

### The machine block

One block per reply, delimited by `===KRATOS-AGENT-OUTPUT-V1===` and
`===END-KRATOS-AGENT-OUTPUT-V1===`. Deliberately not a Markdown fence: a reply
may contain fenced examples, including fenced examples of this very contract,
and a fence-shaped delimiter would make the extractor's answer depend on what
the surrounding prose illustrated. Delimiters are recognized only as whole
unindented lines, exactly one of each may appear, and the closing line is the
last thing in the reply. Line endings are normalized before matching.

### The envelope

Contract version, agent, `outcome.status` (`completed`, `awaiting-input`,
`blocked`), and `outcome.next` (`proceed`, `wait`, `retry`, `finish`, `stop`).
The hint is a hint; the runtime decides and the host relays. Status and hint
have to agree and the schema enforces it.

`artifacts` and `changedFiles` stay separate, because the scope check reads the
difference. A blocking question is an object a host renders directly, not a
string one host happens to parse.

### One payload per agent

Six closed payloads selected by the `agent` discriminator. The document
validates as one closed object rather than a union of six, which is what makes
a refusal name the offending path instead of the document root; the
discriminated union TypeScript wants is rebuilt for type generation from the
same conditionals the validator reads.

### `kratos agent record REF`

Extract → validate → record, never reordered. Extraction has three exits and
the middle one names which of ten rules broke. Validation runs the schema, then
the agreements a schema cannot state. The validated block is written verbatim
to `runs/RUN/agent-output/AGENT.json` and one `run.agent.recorded` fact event is
appended, which changes what the next decision sees without moving the run.

## Compatibility, state, and security impact

**Compatibility: additive.** `host.agent-output@1.0.0` is a new registered
contract. No existing schema, reason code, result shape, or command changed.
The manifest bound moves from 16 to 17 registered schemas. No new reason code
was invented: refusals use the published `trail.output_invalido`.

**State: additive.** A run gains `runs/RUN/agent-output/AGENT.json` and a
`run.agent.recorded` fact event. A run that never records one is unchanged, and
recording never moves a run through its phases.

**Security.** The extractor is a pure function over untrusted model output with
a bounded block size and no platform imports — a test asserts the whole
`domain/agent` module imports nothing but `@kratos/contracts`, the schema types,
and its own files. Every reference the contract accepts is project-relative:
absolute paths, drive letters, backslashes, parent traversal, and URL schemes
are refused by the schema; every text field refuses control characters.

## Verification commands

```bash
npx vitest run tests/agent-output-contract.test.ts
npx vitest run tests/agent-output-recording.test.ts
npx vitest run tests/contract-schemas.test.ts tests/contract-manifest.test.ts
npx vitest run tests/schema-registry-fixtures.test.ts
npx vitest run tests/contract-documentation.test.ts
npm run contracts:check
npm run verify
```

`npm run verify` exits 0: 148 test files, 3992 tests, contract families verified
at 17 schemas, package verification passing for Codex and Claude Code.

## Evidence per acceptance criterion

| Criterion | Evidence |
| --- | --- |
| A reply with no machine block is reported as such and does not advance the run | `agent-output-recording`: "reports a reply with no machine block without advancing the run" asserts exit 3, `trail.output_invalido`, `stateChanged: false`, no recorded document, no `run.agent.recorded` event |
| A reply with a malformed block fails closed and names the parse failure | `agent-output-recording`: "names the parse failure of a malformed block"; `agent-output-contract` covers all ten malformations |
| A reply with a schema-invalid block is refused, and the reason names the offending path | `agent-output-recording`: "names the offending path of a schema-invalid block" asserts the cause contains `outcome.status` |
| A reply containing an ordinary fenced example plus one machine block extracts the machine block | `agent-output-contract`: "ignores an ordinary fenced example and extracts the machine block" — the decoy's fence claims `blocked` while the block reports `completed` |
| Extraction and validation perform no model call and no network access | `agent-output-contract`: "performs no model call and no network access" asserts the module's complete import set |
| The same reply extracts identically under both hosts | `agent-output-recording`: "reads the same reply identically whichever host relayed it" records the same reply as `claude-code` with LF and as `codex` with CRLF and compares persisted bytes |

| Required test artifact | Where |
| --- | --- |
| Valid and invalid fixture per agent payload type | `fixtures/agent-output/v1/valid`, `fixtures/agent-output/v1/invalid` — six each, asserted exhaustive against `AGENTS` |
| No-block, malformed, and decoy fixtures | `fixtures/agent-output/v1/replies/{absent,malformed,decoy,trailing,invalid}.md` |
| Round-trip test proving the persisted block equals the validated block | `agent-output-recording`: "persists exactly the block the validator accepted" — re-validates through the registry and compares both value and bytes |

Full record: `docs/verification/issue-129-agent-output-evidence.md`.
Contract reference: `docs/architecture/agent-output-contract.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
