### PR TITLE
fix(ci): allow quality pipeline to complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   quality:
     name: Node quality and package
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       CI: "true"
     steps:

--- a/docs/specs/2026-08-27-ci-quality-timeout-spec.md
+++ b/docs/specs/2026-08-27-ci-quality-timeout-spec.md
@@ -1,0 +1,54 @@
+# Objective Spec: Restore Dependabot Pull-Request CI
+
+Date: 2026-08-27
+Status: APPROVED
+
+## Problem and desired outcome
+
+The `Node quality and package` job on pull requests #161 and #162 reached its
+15-minute job timeout after earlier steps had passed. The quality pipeline has
+grown beyond the original bound, so otherwise mergeable dependency updates are
+reported as unstable.
+
+Increase the quality job's bounded execution window to 30 minutes, rerun the
+repository verification, and then rerun the affected pull-request checks.
+
+## Scope
+
+- Update the executable CI contract and workflow timeout together.
+- Update documentation that states the old 15-minute quality-job limit.
+- Rerun, approve, and merge pull requests #161 and #162 only after their checks
+  pass.
+
+## Non-goals
+
+- Do not create the absent `developer` branch.
+- Do not activate repository rulesets whose declared CodeQL requirement cannot
+  currently run on pull requests.
+- Do not add automatic Dependabot approval authority.
+- Do not restructure the quality pipeline.
+
+## Acceptance criteria
+
+- [ ] The CI contract requires a 30-minute timeout for `Node quality and
+  package`.
+- [ ] The workflow configures the quality job with that 30-minute timeout.
+- [ ] Relevant documentation no longer claims that this job has a 15-minute
+  limit.
+- [ ] Formatting, linting, type-checking, tests, build, and package verification
+  pass locally.
+- [ ] Pull requests #161 and #162 complete all checks successfully before merge.
+
+## Test strategy and failure modes
+
+- RED: change the contract expectation to 30 while the workflow still contains
+  15; the focused contract test must fail on the mismatch.
+- GREEN: update the workflow to 30; the focused contract test must pass.
+- Run `npm run verify` and the repository workflow-contract tests.
+- A cancelled or failed remote check blocks approval and merge.
+
+## Compatibility and risk
+
+The commands, permissions, runner, event triggers, and dependency graph remain
+unchanged. The only runtime effect is allowing the existing quality job up to
+30 minutes before GitHub cancels it.

--- a/docs/verification/issue-7-ci-evidence.md
+++ b/docs/verification/issue-7-ci-evidence.md
@@ -105,7 +105,7 @@ least-privilege controls regress.
 
 ## Current timeout bound
 
-The initial campaign below proved the original 15-minute bound. The quality
+The initial campaign above proved the original 15-minute bound. The quality
 pipeline later grew enough that valid Dependabot runs
 [`32696973676`](https://github.com/thiagocorreanet/kratos-harness/actions/runs/32696973676)
 and

--- a/docs/verification/issue-7-ci-evidence.md
+++ b/docs/verification/issue-7-ci-evidence.md
@@ -103,13 +103,24 @@ withholds them from fork-originated code and the workflow contains no expression
 that requests them. `tests/ci-workflow-contract.test.ts` fails if these
 least-privilege controls regress.
 
+## Current timeout bound
+
+The initial campaign below proved the original 15-minute bound. The quality
+pipeline later grew enough that valid Dependabot runs
+[`32696973676`](https://github.com/thiagocorreanet/kratos-harness/actions/runs/32696973676)
+and
+[`32697062714`](https://github.com/thiagocorreanet/kratos-harness/actions/runs/32697062714)
+reached that limit after their preceding steps passed. The current executable
+contract therefore allows 30 minutes while retaining a finite GitHub-hosted job
+bound.
+
 ## Acceptance mapping
 
 | Requirement | Evidence |
 | --- | --- |
 | Pull requests to `developer` and `main` | Exact trigger contract plus actionlint validation |
 | Install, format, lint, type, unit, schema, build, smoke, and package gates | Implementation success run completed every named step |
-| Immutable Actions and timeout | Full-SHA contract and 15-minute job limit |
+| Immutable Actions and timeout | Full-SHA contract and current 30-minute job limit; initial 15-minute evidence retained above |
 | Superseded pull-request cancellation without lost pushes | PR-number groups; unique run IDs for non-PR events |
 | Useful short-lived diagnostics | Four successful failure uploads with three-day expiry |
 | Lint, type, test, and package failures block | Four deliberate failing runs above |

--- a/tests/ci-workflow-contract.test.ts
+++ b/tests/ci-workflow-contract.test.ts
@@ -75,7 +75,7 @@ describe("pull-request CI workflow", () => {
     const quality = object(jobs.quality, "quality");
     expect(quality.name).toBe("Node quality and package");
     expect(quality["runs-on"]).toBe("ubuntu-latest");
-    expect(quality["timeout-minutes"]).toBe(15);
+    expect(quality["timeout-minutes"]).toBe(30);
     expect(quality.env).toEqual({ CI: "true" });
     expect(quality.permissions).toBeUndefined();
     expect(quality["continue-on-error"]).toBeUndefined();


### PR DESCRIPTION
## Outcome

Increase the bounded `Node quality and package` CI window from 15 to 30 minutes after Dependabot PRs #161 and #162 reached the former limit with preceding checks passing.

## Evidence

- TDD RED: CI contract expected 30 and received 15.
- TDD GREEN: focused CI contract passed 6/6.
- `npm run verify`: 150 test files and 4,024 tests passed; coverage, mutation, contracts, build, package verification, and benchmark passed.
- `npm run templates:validate`: 5 forms valid.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`: passed.
- `npm run format:check`, `npm run spellcheck`, and `git diff --check`: passed.

## Scope

Commands, permissions, runner, triggers, and job topology remain unchanged. Repository rulesets and the absent `developer` branch are intentionally out of scope.

Signed-off-by: Thiago Botelho <thiagogcorreabotelho2021@gmail.com>