### PR TITLE
feat(init): write state ignore rules for volatile logs and transient caches (#137)

### DIFF
--- a/docs/architecture/project-initialization.md
+++ b/docs/architecture/project-initialization.md
@@ -11,11 +11,14 @@ either untouched or complete.
 
 ## The generated surface
 
-The `go-v3-v0.6.5` inventory freezes the generated file list. The twenty-seven
-paths that carry no `<feature>` or `<run>` segment are initialization's; the
-rest belong to the commands that own those lifecycles.
+The `go-v3-v0.6.5` inventory freezes the legacy generated file list. The
+twenty-eight paths that carry no `<feature>` or `<run>` segment are
+initialization's (the twenty-seven legacy oracle paths plus
+`.brain/.gitignore`); the rest belong to the commands that own those
+lifecycles.
 
 ```text
+.brain/.gitignore
 .brain/00-business/README.md
 .brain/01-architecture/README.md
 .brain/01-architecture/adr/.gitkeep
@@ -35,9 +38,31 @@ AGENTS.md
 CLAUDE.md
 ```
 
-That list is the allowlist. The test reads it from the inventory rather than
-from a copy, so a path that drifts from the oracle fails there instead of
-shipping.
+That list is the allowlist.
+
+## State ignore rules (`.brain/.gitignore`)
+
+The state directory carries its own `.gitignore` so that append-only logs
+(`03-memory/task_log.jsonl`, `02-features/*/runs/*/events.jsonl`,
+`events.jsonl`), transient caches (`03-memory/.cache/`), and tool traces
+(`*.trace`, `traces/`) stay untracked in Git without polluting the project root
+`.gitignore`.
+
+Curated memory, decisions (`decisions.log`), gotchas (`gotchas.md`), distilled
+task metrics (`task_metrics.md`), project configuration (`config.json`),
+guardrails (`guardrails.json`), and all feature specifications and execution
+states remain under version control.
+
+### Adopting state ignore rules in existing repositories
+
+Repositories initialized before this change can adopt the rules by running
+`kratos init` and removing any previously committed volatile files from the
+Git index without deleting local files:
+
+```bash
+git rm -r --cached .brain/03-memory/task_log.jsonl .brain/03-memory/.cache/
+git commit -m "chore: adopt state ignore rules"
+```
 
 ## Shared phase-agent prompts
 

--- a/packages/runtime/src/domain/init/skeleton.ts
+++ b/packages/runtime/src/domain/init/skeleton.ts
@@ -89,6 +89,7 @@ function stateFiles(
   profile: StackProfile,
 ): readonly FileEntry[] {
   return [
+    [".brain/.gitignore", brainGitignore()],
     [".brain/00-business/README.md", businessReadme()],
     [".brain/01-architecture/README.md", architectureReadme()],
     // An empty keeper is how the directory survives a checkout while it holds
@@ -219,6 +220,18 @@ function stackProfileDocument(profile: StackProfile): string {
     "| Stack | Evidence |",
     "| --- | --- |",
     ...profile.stacks.map(({ id, evidence }) => `| ${id} | \`${evidence}\` |`),
+  );
+}
+
+function brainGitignore(): string {
+  return lines(
+    "# Volatile telemetry and run event streams are not tracked.",
+    "03-memory/task_log.jsonl",
+    "03-memory/.cache/",
+    "02-features/*/runs/*/events.jsonl",
+    "events.jsonl",
+    "*.trace",
+    "traces/",
   );
 }
 

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -159,7 +159,7 @@ describe("the init command", () => {
 
     expect(result).toMatchObject({
       reasonCode: "trail.ok",
-      summary: expect.stringContaining("Created 27") as unknown,
+      summary: expect.stringContaining("Created 28") as unknown,
       stateChanged: true,
     });
     expect(run.output.structured_.join("")).toContain("modelRoles.codex");
@@ -434,7 +434,7 @@ describe("the init command", () => {
 
     const result: unknown = JSON.parse(run.output.structured_.join(""));
     expect(result).toMatchObject({
-      summary: expect.stringContaining("preserved 18") as unknown,
+      summary: expect.stringContaining("preserved 19") as unknown,
     });
     expect(Object.keys(run.storage.snapshot().files)).toContain("CLAUDE.md");
   });

--- a/tests/init-fault-campaign.test.ts
+++ b/tests/init-fault-campaign.test.ts
@@ -116,7 +116,7 @@ describe("init fault campaign", () => {
 
     // The campaign is only worth running if it reaches the operations that
     // publish the surface, so the count is asserted rather than assumed.
-    expect(Object.keys(complete)).toHaveLength(27);
+    expect(Object.keys(complete)).toHaveLength(28);
     expect(boundaries.length).toBeGreaterThan(100);
 
     for (const boundary of boundaries) {

--- a/tests/init-skeleton.test.ts
+++ b/tests/init-skeleton.test.ts
@@ -32,6 +32,7 @@ interface Discovery {
  * A path that drifts from the inventory fails here instead of shipping.
  */
 let frozen: readonly string[];
+let expectedSurface: readonly string[];
 
 beforeAll(async () => {
   const discovery = JSON.parse(
@@ -43,6 +44,7 @@ beforeAll(async () => {
     // owns that lifecycle, not to initialization.
     .filter((name) => !name.includes("<"))
     .sort();
+  expectedSurface = [".brain/.gitignore", ...frozen].sort();
 });
 
 const registry = createSchemaRegistry();
@@ -109,10 +111,75 @@ describe("the generated skeleton", () => {
     >();
   });
 
-  it("generates exactly the frozen initialization surface", () => {
+  it("generates exactly the expected initialization surface", () => {
     expect(destinationsOf(skeletonEffects(answers(), nodeProject))).toEqual(
-      frozen,
+      expectedSurface,
     );
+  });
+
+  it("writes the state ignore rules byte for byte", () => {
+    const generated = skeletonEffects(answers(), nodeProject);
+    const gitignore = contentAt(generated, ".brain/.gitignore");
+
+    expect(gitignore).toBe(
+      [
+        "# Volatile telemetry and run event streams are not tracked.",
+        "03-memory/task_log.jsonl",
+        "03-memory/.cache/",
+        "02-features/*/runs/*/events.jsonl",
+        "events.jsonl",
+        "*.trace",
+        "traces/",
+      ].join("\n") + "\n",
+    );
+  });
+
+  it("classifies every path written by initialization as deliberately committed or ignored", () => {
+    const effects = skeletonEffects(answers(), nodeProject);
+    const paths = destinationsOf(effects);
+
+    const ignoredPaths = [
+      ".brain/03-memory/task_log.jsonl",
+      ".brain/03-memory/.cache/feature-create.json",
+    ];
+
+    const committedPaths = [
+      ".brain/.gitignore",
+      ".brain/00-business/README.md",
+      ".brain/01-architecture/README.md",
+      ".brain/01-architecture/adr/.gitkeep",
+      ".brain/01-architecture/stack-profile.md",
+      ".brain/02-features/README.md",
+      ".brain/02-features/_template/00-prd.md",
+      ".brain/02-features/_template/01-design.md",
+      ".brain/02-features/_template/02-tasks.md",
+      ".brain/02-features/_template/03-summa.md",
+      ".brain/02-features/_template/state.json",
+      ".brain/02-features/active",
+      ".brain/03-memory/decisions.log",
+      ".brain/03-memory/gotchas.md",
+      ".brain/03-memory/task_metrics.md",
+      ".brain/config.json",
+      ".brain/guardrails.json",
+      ".claude/settings.json",
+      ".codex/agents/code-implementer.toml",
+      ".codex/agents/implementation-evaluator.toml",
+      ".codex/agents/prd-researcher.toml",
+      ".codex/agents/spec-planner.toml",
+      ".codex/agents/spec-reviewer.toml",
+      ".codex/config.toml",
+      "AGENTS.md",
+      "CLAUDE.md",
+    ];
+
+    expect([...paths].sort()).toEqual(
+      [...committedPaths, ...ignoredPaths].sort(),
+    );
+    for (const path of paths) {
+      const isIgnored = ignoredPaths.includes(path);
+      const isCommitted = committedPaths.includes(path);
+      expect(isIgnored !== isCommitted).toBe(true);
+    }
   });
 
   it("writes files and creates no directory of its own", () => {
@@ -166,7 +233,7 @@ describe("the generated skeleton", () => {
       uuid.mockRestore();
     }
 
-    expect(destinationsOf(generated)).toEqual(frozen);
+    expect(destinationsOf(generated)).toEqual(expectedSurface);
   });
 
   it("generates only the surface of the hosts the answers enabled", () => {
@@ -178,12 +245,12 @@ describe("the generated skeleton", () => {
     );
 
     expect(claudeOnly).toEqual(
-      frozen.filter(
+      expectedSurface.filter(
         (path) => !path.startsWith(".codex/") && path !== "AGENTS.md",
       ),
     );
     expect(codexOnly).toEqual(
-      frozen.filter(
+      expectedSurface.filter(
         (path) => !path.startsWith(".claude/") && path !== "CLAUDE.md",
       ),
     );

--- a/tests/state-ignore-rules.test.ts
+++ b/tests/state-ignore-rules.test.ts
@@ -1,0 +1,344 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { skeletonEffects } from "@kratos/runtime/domain/init";
+import { profileStack } from "@kratos/runtime/domain/init";
+import { describe, expect, it } from "vitest";
+
+const IDENTITY = [
+  "-c",
+  "user.email=test@example.com",
+  "-c",
+  "user.name=Test",
+  "-c",
+  "commit.gpgsign=false",
+] as const;
+
+function git(root: string, args: readonly string[]): string {
+  return execFileSync("git", [...IDENTITY, ...args], {
+    cwd: root,
+    env: {
+      ...process.env,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: join(root, ".absent-global-config"),
+      GIT_TERMINAL_PROMPT: "0",
+      LC_ALL: "C",
+    },
+    encoding: "utf8",
+  });
+}
+
+function tryGit(
+  root: string,
+  args: readonly string[],
+): { status: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync("git", [...IDENTITY, ...args], {
+      cwd: root,
+      env: {
+        ...process.env,
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_CONFIG_GLOBAL: join(root, ".absent-global-config"),
+        GIT_TERMINAL_PROMPT: "0",
+        LC_ALL: "C",
+      },
+      encoding: "utf8",
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (error: unknown) {
+    const err = error as {
+      status?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  }
+}
+
+async function createGitRepo(): Promise<{
+  root: string;
+  dispose(): Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "kratos-state-ignore-"));
+  git(root, ["init", "-b", "main"]);
+  return {
+    root,
+    dispose: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+async function writeSkeleton(root: string): Promise<void> {
+  const effects = skeletonEffects(
+    {
+      contractVersion: "1.1.0",
+      hostContract: "1.1.0",
+      hosts: ["claude", "codex"],
+      language: "en",
+      policyMode: "standard",
+      snapshots: true,
+      modelRoles: {
+        claude: {
+          planner: { model: "claude-planner", effort: "medium" },
+          implementer: { model: "claude-implementer", effort: "medium" },
+          judge: { model: "claude-judge", effort: "medium" },
+        },
+        codex: {
+          planner: { model: "codex-planner", effort: "medium" },
+          implementer: { model: "codex-implementer", effort: "high" },
+          judge: { model: "codex-judge", effort: "medium" },
+        },
+      },
+    },
+    profileStack({ rootEntries: ["package.json"] }),
+  );
+
+  for (const effect of effects) {
+    if (effect.kind === "write_file") {
+      const fullPath = join(root, effect.path);
+      const parentDir = join(fullPath, "..");
+      await mkdir(parentDir, { recursive: true });
+      await writeFile(fullPath, effect.content, "utf8");
+    }
+  }
+}
+
+describe("state directory ignore rules in Git", () => {
+  it("ignores all volatile and transient paths while tracking durable knowledge", async () => {
+    const repo = await createGitRepo();
+    try {
+      await writeSkeleton(repo.root);
+
+      // Create additional simulated paths
+      const volatilePaths = [
+        ".brain/03-memory/task_log.jsonl",
+        ".brain/03-memory/.cache/feature-create.json",
+        ".brain/02-features/auth/runs/run-1/events.jsonl",
+        ".brain/events.jsonl",
+        ".brain/agent.trace",
+        ".brain/traces/step-1.log",
+      ];
+
+      for (const relPath of volatilePaths) {
+        const fullPath = join(repo.root, relPath);
+        await mkdir(join(fullPath, ".."), { recursive: true });
+        await writeFile(fullPath, "temporary volatile data\n", "utf8");
+      }
+
+      const durablePaths = [
+        ".brain/.gitignore",
+        ".brain/00-business/README.md",
+        ".brain/01-architecture/README.md",
+        ".brain/01-architecture/adr/.gitkeep",
+        ".brain/01-architecture/stack-profile.md",
+        ".brain/02-features/README.md",
+        ".brain/02-features/_template/00-prd.md",
+        ".brain/02-features/_template/01-design.md",
+        ".brain/02-features/_template/02-tasks.md",
+        ".brain/02-features/_template/03-summa.md",
+        ".brain/02-features/_template/state.json",
+        ".brain/02-features/active",
+        ".brain/03-memory/decisions.log",
+        ".brain/03-memory/gotchas.md",
+        ".brain/03-memory/task_metrics.md",
+        ".brain/config.json",
+        ".brain/guardrails.json",
+      ];
+
+      // Verify each volatile path is ignored by git
+      for (const relPath of volatilePaths) {
+        const result = tryGit(repo.root, ["check-ignore", "-q", relPath]);
+        expect(result.status, `Expected ${relPath} to be ignored by git`).toBe(
+          0,
+        );
+      }
+
+      // Verify each durable path is NOT ignored by git
+      for (const relPath of durablePaths) {
+        const result = tryGit(repo.root, ["check-ignore", "-q", relPath]);
+        expect(
+          result.status,
+          `Expected ${relPath} NOT to be ignored by git`,
+        ).toBe(1);
+      }
+    } finally {
+      await repo.dispose();
+    }
+  });
+
+  it("eliminates merge conflicts between parallel branches writing to volatile logs", async () => {
+    const repo = await createGitRepo();
+    try {
+      await writeSkeleton(repo.root);
+
+      // Stage and commit initial skeleton (including .brain/.gitignore)
+      git(repo.root, ["add", "."]);
+      git(repo.root, [
+        "commit",
+        "-m",
+        "Initial commit with state ignore rules",
+      ]);
+
+      // Create branch A
+      git(repo.root, ["checkout", "-b", "feature-a"]);
+      // Branch A writes to volatile task_log and run events
+      const taskLogA = join(repo.root, ".brain/03-memory/task_log.jsonl");
+      const eventsA = join(
+        repo.root,
+        ".brain/02-features/auth/runs/run-1/events.jsonl",
+      );
+      await mkdir(join(eventsA, ".."), { recursive: true });
+      await writeFile(taskLogA, '{"task":"A1"}\n{"task":"A2"}\n', "utf8");
+      await writeFile(eventsA, '{"event":"A1"}\n', "utf8");
+
+      // Branch A makes a durable commit (e.g. decision log)
+      const decisionLog = join(repo.root, ".brain/03-memory/decisions.log");
+      await writeFile(
+        decisionLog,
+        "2026-08-29: Branch A made decision 1\n",
+        "utf8",
+      );
+      git(repo.root, ["add", ".brain/03-memory/decisions.log"]);
+      git(repo.root, ["commit", "-m", "Branch A decision"]);
+
+      // Switch back to main and create branch B
+      git(repo.root, ["checkout", "main"]);
+      git(repo.root, ["checkout", "-b", "feature-b"]);
+
+      // Branch B writes different volatile logs
+      await writeFile(taskLogA, '{"task":"B1"}\n{"task":"B2"}\n', "utf8");
+      await writeFile(eventsA, '{"event":"B1"}\n', "utf8");
+
+      // Branch B makes another durable commit (e.g. gotchas)
+      const gotchas = join(repo.root, ".brain/03-memory/gotchas.md");
+      await writeFile(gotchas, "Gotcha recorded on branch B\n", "utf8");
+      git(repo.root, ["add", ".brain/03-memory/gotchas.md"]);
+      git(repo.root, ["commit", "-m", "Branch B gotcha"]);
+
+      // Merge feature-a into main
+      git(repo.root, ["checkout", "main"]);
+      git(repo.root, [
+        "merge",
+        "--no-ff",
+        "feature-a",
+        "-m",
+        "Merge feature-a",
+      ]);
+
+      // Merge feature-b into main - should merge cleanly with ZERO conflict!
+      const mergeResult = tryGit(repo.root, [
+        "merge",
+        "--no-ff",
+        "feature-b",
+        "-m",
+        "Merge feature-b",
+      ]);
+      expect(
+        mergeResult.status,
+        `Expected merge to succeed without conflict, but got stderr: ${mergeResult.stderr}`,
+      ).toBe(0);
+
+      // Verify durable content from both branches is preserved
+      expect(await readFile(decisionLog, "utf8")).toContain(
+        "Branch A made decision 1",
+      );
+      expect(await readFile(gotchas, "utf8")).toContain(
+        "Gotcha recorded on branch B",
+      );
+    } finally {
+      await repo.dispose();
+    }
+  });
+
+  it("reproduces the merge conflict when volatile logs are tracked without ignore rules", async () => {
+    const repo = await createGitRepo();
+    try {
+      // Setup repo without .brain/.gitignore and with tracked task_log.jsonl
+      const taskLog = join(repo.root, ".brain/03-memory/task_log.jsonl");
+      await mkdir(join(taskLog, ".."), { recursive: true });
+      await writeFile(taskLog, '{"seed":"initial"}\n', "utf8");
+      git(repo.root, ["add", "."]);
+      git(repo.root, ["commit", "-m", "Initial commit tracking task_log"]);
+
+      // Branch A appends to task_log.jsonl
+      git(repo.root, ["checkout", "-b", "branch-a"]);
+      await writeFile(taskLog, '{"seed":"initial"}\n{"branch":"A"}\n', "utf8");
+      git(repo.root, ["add", "."]);
+      git(repo.root, ["commit", "-m", "Branch A log append"]);
+
+      // Branch B appends different content to task_log.jsonl
+      git(repo.root, ["checkout", "main"]);
+      git(repo.root, ["checkout", "-b", "branch-b"]);
+      await writeFile(taskLog, '{"seed":"initial"}\n{"branch":"B"}\n', "utf8");
+      git(repo.root, ["add", "."]);
+      git(repo.root, ["commit", "-m", "Branch B log append"]);
+
+      // Merge branch-a into main
+      git(repo.root, ["checkout", "main"]);
+      git(repo.root, ["merge", "--no-ff", "branch-a", "-m", "Merge branch-a"]);
+
+      // Merge branch-b into main - MUST conflict on the append-only log!
+      const mergeResult = tryGit(repo.root, [
+        "merge",
+        "--no-ff",
+        "branch-b",
+        "-m",
+        "Merge branch-b",
+      ]);
+      expect(mergeResult.status).not.toBe(0);
+      expect(mergeResult.stdout + mergeResult.stderr).toContain("CONFLICT");
+    } finally {
+      await repo.dispose();
+    }
+  });
+
+  it("allows legacy repositories to adopt ignore rules without losing working copies", async () => {
+    const repo = await createGitRepo();
+    try {
+      // Simulate legacy repo where task_log was tracked in git
+      const taskLog = join(repo.root, ".brain/03-memory/task_log.jsonl");
+      await mkdir(join(taskLog, ".."), { recursive: true });
+      await writeFile(
+        taskLog,
+        '{"legacy":"log-entry-1"}\n{"legacy":"log-entry-2"}\n',
+        "utf8",
+      );
+      git(repo.root, ["add", "."]);
+      git(repo.root, ["commit", "-m", "Legacy commit with tracked log"]);
+
+      // Adoption: write .brain/.gitignore and untrack the file from Git index
+      const gitignore = join(repo.root, ".brain/.gitignore");
+      await writeFile(
+        gitignore,
+        "# Managed by Kratos.\n03-memory/task_log.jsonl\n03-memory/.cache/\n",
+        "utf8",
+      );
+
+      // Run git rm --cached to untrack while preserving working copy
+      git(repo.root, ["rm", "--cached", ".brain/03-memory/task_log.jsonl"]);
+      git(repo.root, ["add", ".brain/.gitignore"]);
+      git(repo.root, ["commit", "-m", "Adopt state ignore rules"]);
+
+      // Prove the file still exists on disk with intact content
+      const fileOnDisk = await readFile(taskLog, "utf8");
+      expect(fileOnDisk).toBe(
+        '{"legacy":"log-entry-1"}\n{"legacy":"log-entry-2"}\n',
+      );
+
+      // Prove the file is now ignored and no longer tracked in git
+      const statusResult = git(repo.root, ["status", "--porcelain"]);
+      expect(statusResult).toBe("");
+
+      // Appending to the local log leaves working tree clean in git
+      await writeFile(taskLog, fileOnDisk + '{"new":"local-entry"}\n', "utf8");
+      expect(git(repo.root, ["status", "--porcelain"])).toBe("");
+    } finally {
+      await repo.dispose();
+    }
+  });
+});


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #137

Work ID: `FND-09`

## Outcome and design

The `.brain` state directory now carries its own `.gitignore` rules generated during `kratos init`, ensuring volatile append-only telemetry logs (`03-memory/task_log.jsonl`, `02-features/*/runs/*/events.jsonl`, `events.jsonl`), transient caches (`03-memory/.cache/`), and internal tool traces (`*.trace`, `traces/`) remain untracked by Git.

This eliminates recurring merge conflicts on parallel pull requests while preserving all durable curated memory, architecture records, feature specifications, and run states under version control.

## Compatibility and public contracts

- **Initialization Surface**: `skeletonEffects` now generates 28 managed destinations (the 27 legacy oracle destinations plus `.brain/.gitignore`).
- **Host neutrality**: The state ignore rules apply identically whether the active host is Claude Code, Codex, or CLI.
- **Documentation**: Updated `docs/architecture/project-initialization.md` to document state ignore rules and migration.

## State, migration, security, and rollback

- **State impact**: Adds `.brain/.gitignore` scoped to the `.brain/` state root. The project root `.gitignore` remains untouched.
- **Migration**: Existing repositories initialized prior to this change can adopt the rules by running `kratos init` and untracking volatile files from Git:
  ```bash
  git rm -r --cached .brain/03-memory/task_log.jsonl .brain/03-memory/.cache/
  git commit -m "chore: adopt state ignore rules"
  ```
  Local working copies remain preserved on disk.
- **Security & Privacy**: High-volume telemetry and local transient caches remain isolated to the host/machine that produced them.
- **Rollback**: Safe. Reverting the commit restores previous state files generation without altering existing project assets.

## Deterministic test evidence

- **Focused verification**:
  ```text
  npx vitest run tests/init-skeleton.test.ts tests/init-command.test.ts tests/state-ignore-rules.test.ts
  Test Files  3 passed (3)
  Tests  43 passed (43)
  ```
- **Full repository verification (`npm run verify`)**:
  - `npm run format:check` (Passed - Prettier code style verified)
  - `npm run spellcheck` (Passed - 0 issues)
  - `npm run english:check` (Passed - English-only source check passed)
  - `npm run lint` (Passed - ESLint 0 warnings/errors)
  - `npm run typecheck` (Passed - TypeScript type check clean)
  - `npm run oracle:verify` & `npm run parity:check` (Passed - Oracle catalog verified)
  - `npm run result:check` & `npm run contracts:check` (Passed - Result & Contract families verified)
  - `npm run differential:check` (Passed - Differential scenarios clean)
  - `npm run build` & `npm run package:verify` (Passed - Builds for Claude Code & Codex verified)
  - `npm run performance:check` & `npm run gaps:calibrate` (Passed - Performance budget and gap recall 1.00)
- **Diff hygiene (`git diff --check`)**: Clean.

## Prompt and model evaluations

Not applicable.

## Failure evidence

Initial behavior allowed two branches writing to `.brain/03-memory/task_log.jsonl` to generate Git merge conflicts on merge. `tests/state-ignore-rules.test.ts` reproduces this exact failure when volatile logs are tracked without ignore rules and proves that with `.brain/.gitignore`, the conflict is completely eliminated.

## Provenance

- Sources used: Kratos Harness public codebase
- Contribution method: `original`
- Publication authority and required notices: Not applicable
- Confirmation: Confirmed that no secret, credential, customer/personal data, private infrastructure, or confidential business information is included.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.