### PR TITLE
fix: respect project root in worktree gate

### DIFF
--- a/docs/specs/2026-08-30-project-relative-worktree-gate-spec.md
+++ b/docs/specs/2026-08-30-project-relative-worktree-gate-spec.md
@@ -1,0 +1,56 @@
+# Objective Spec: Project-Relative Worktree Gate
+
+Date: 2026-08-30
+Status: DONE
+
+## Problem and desired outcome
+
+When the selected project root is below the Git worktree root, porcelain-v2
+paths include the project prefix. The workflow gate currently recognizes only
+the root-relative `.brain` spelling, so Kratos refuses to start a run even when
+all changes belong to the selected project's managed state.
+
+The Git observation must expose the selected project's prefix within the
+worktree, and the workflow gate must use it when recognizing managed paths.
+
+## Scope
+
+In scope:
+
+- Observe the project prefix through the existing `rev-parse` invocation.
+- Treat only `<project-prefix>/.brain/**` as managed.
+- Preserve repository-relative Git change paths and linked-worktree behavior.
+- Cover root and nested project layouts with automated regression tests.
+
+Out of scope:
+
+- Rewriting Git change paths as project-relative paths.
+- Changing the policy for changes outside the selected project's `.brain`.
+- Adding Git commands or external dependencies.
+
+## Acceptance criteria
+
+- [x] A project at the worktree root continues to treat `.brain/**` as managed.
+- [x] A nested project treats only `<project-prefix>/.brain/**` as managed.
+- [x] A nested project with only managed state changes records `run.started`.
+- [x] A change outside the selected project's managed state still returns
+      `trail.worktree_dirty`.
+- [x] Linked-worktree classification and existing Git observation behavior stay
+      intact.
+- [x] Relevant tests, lint, type checking, and the full test suite pass.
+
+## Test strategy and failure modes
+
+- Unit-test `rev-parse` parsing for empty and nested prefixes.
+- Use a real repository fixture whose project root is a child directory.
+- Exercise `start` through runtime composition and assert the emitted result.
+- Add a negative case for a repository-root or sibling change.
+- Verify malformed `rev-parse` output remains `unreadable` and undecodable paths
+  remain conservatively unmanaged.
+
+## Compatibility and risk
+
+The Git observation model gains one additive field. Existing change paths keep
+their repository-relative spelling. The principal risk is accidentally
+classifying a different `.brain` directory as managed; exact prefix matching
+and the negative regression prevent that.

--- a/packages/runtime/src/composition/git.ts
+++ b/packages/runtime/src/composition/git.ts
@@ -17,6 +17,7 @@ const REV_PARSE = [
   "--is-inside-work-tree",
   "--git-dir",
   "--git-common-dir",
+  "--show-prefix",
 ] as const;
 
 const STATUS = [
@@ -93,6 +94,7 @@ export function composeGit(runner: GitRunner, digests: Digests): Git {
           repository: {
             head: parsed.head,
             worktree: classifyWorktree(facts),
+            worktreePrefix: facts.worktreePrefix,
             operation: classifyOperation(markers),
             changes: parsed.changes,
           },

--- a/packages/runtime/src/composition/workflow.ts
+++ b/packages/runtime/src/composition/workflow.ts
@@ -2128,10 +2128,11 @@ function corruptRun(): {
   };
 }
 
-function managed(path: GitPath): boolean {
+function managed(path: GitPath, worktreePrefix: string): boolean {
+  const managedRoot = `${worktreePrefix}.brain`;
   return (
     path.kind === "text" &&
-    (path.value === ".brain" || path.value.startsWith(".brain/"))
+    (path.value === managedRoot || path.value.startsWith(`${managedRoot}/`))
   );
 }
 
@@ -2150,7 +2151,9 @@ async function observeGitContext(
   return {
     clean: observation.repository.changes.every(
       ({ path, renamedFrom }) =>
-        managed(path) && (renamedFrom === null || managed(renamedFrom)),
+        managed(path, observation.repository.worktreePrefix) &&
+        (renamedFrom === null ||
+          managed(renamedFrom, observation.repository.worktreePrefix)),
     ),
     commit: head.kind === "unborn" ? null : head.commit,
   };

--- a/packages/runtime/src/domain/git/model.ts
+++ b/packages/runtime/src/domain/git/model.ts
@@ -53,6 +53,7 @@ export type GitOperation =
 export interface GitRepository {
   readonly head: GitHead;
   readonly worktree: "principal" | "linked";
+  readonly worktreePrefix: string;
   readonly operation: GitOperation;
   readonly changes: readonly GitChange[];
 }

--- a/packages/runtime/src/domain/git/refs.ts
+++ b/packages/runtime/src/domain/git/refs.ts
@@ -4,21 +4,28 @@ export interface RevParseFacts {
   readonly insideWorkTree: boolean;
   readonly gitDir: string;
   readonly gitCommonDir: string;
+  readonly worktreePrefix: string;
 }
 
-function isTriple(
+function isQuadruple(
   lines: readonly string[],
-): lines is readonly [string, string, string] {
-  return lines.length === 3;
+): lines is readonly [string, string, string, string] {
+  return lines.length === 4;
 }
 
-/** Read the three fields `rev-parse` emits, one per line, in argument order. */
+/** Read the four fields `rev-parse` emits, one per line, in argument order. */
 export function parseRevParse(stdout: string): RevParseFacts | null {
-  const lines = stdout.split("\n").filter((line) => line.length > 0);
-  if (!isTriple(lines)) return null;
-  const [worktree, gitDir, gitCommonDir] = lines;
+  const lines = stdout.split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  if (!isQuadruple(lines)) return null;
+  const [worktree, gitDir, gitCommonDir, worktreePrefix] = lines;
   if (worktree !== "true" && worktree !== "false") return null;
-  return { insideWorkTree: worktree === "true", gitDir, gitCommonDir };
+  return {
+    insideWorkTree: worktree === "true",
+    gitDir,
+    gitCommonDir,
+    worktreePrefix,
+  };
 }
 
 /** A linked worktree is exactly a git dir that differs from the common dir. */

--- a/packages/runtime/src/infra/fake/git.ts
+++ b/packages/runtime/src/infra/fake/git.ts
@@ -12,6 +12,7 @@ const CLEAN_PRINCIPAL: GitObservation = {
       upstream: null,
     },
     worktree: "principal",
+    worktreePrefix: "",
     operation: "none",
     changes: [],
   },

--- a/tests/git-observation.test.ts
+++ b/tests/git-observation.test.ts
@@ -20,7 +20,7 @@ const ok = (stdout: string): RawCommandResult => ({
   bufferExceeded: false,
 });
 
-const REFS_OK = "true\n/p/.git\n/p/.git\n";
+const REFS_OK = "true\n/p/.git\n/p/.git\n\n";
 const STATUS_OK = "# branch.oid " + "a".repeat(40) + "\0# branch.head main\0";
 
 /** Drive the sequence by position: first call is rev-parse, second is status. */
@@ -58,6 +58,7 @@ describe("successful observation", () => {
           upstream: null,
         },
         worktree: "principal",
+        worktreePrefix: "",
         operation: "none",
         changes: [],
       },
@@ -69,6 +70,7 @@ describe("successful observation", () => {
             "--is-inside-work-tree",
             "--git-dir",
             "--git-common-dir",
+            "--show-prefix",
           ],
           exitCode: 0,
           stdoutSha256: digests.sha256Bytes(utf8(REFS_OK)),
@@ -99,7 +101,7 @@ describe("successful observation", () => {
 
   it("reports a linked worktree when the git dirs differ", async () => {
     const result = await observe([
-      ok("true\n/p/.git/worktrees/f\n/p/.git\n"),
+      ok("true\n/p/.git/worktrees/f\n/p/.git\n\n"),
       ok(STATUS_OK),
     ]);
 
@@ -175,7 +177,7 @@ describe("failure classification", () => {
 
   it("reports not_a_repository for a bare repository", async () => {
     // Exit 0 with a false work-tree report: bare repo, or inside .git.
-    const result = await observe([ok("false\n/p.git\n/p.git\n")]);
+    const result = await observe([ok("false\n/p.git\n/p.git\n\n")]);
 
     expect(result.kind).toBe("not_a_repository");
   });

--- a/tests/git-refs.test.ts
+++ b/tests/git-refs.test.ts
@@ -7,26 +7,38 @@ import {
 } from "../packages/runtime/src/domain/git/refs.js";
 
 describe("parseRevParse", () => {
-  it("reads the three fields in argument order", () => {
-    expect(parseRevParse("true\n/tmp/p/.git\n/tmp/p/.git\n")).toEqual({
+  it("reads a root project prefix in argument order", () => {
+    expect(parseRevParse("true\n/tmp/p/.git\n/tmp/p/.git\n\n")).toEqual({
       insideWorkTree: true,
       gitDir: "/tmp/p/.git",
       gitCommonDir: "/tmp/p/.git",
+      worktreePrefix: "",
+    });
+  });
+
+  it("reads a nested project prefix", () => {
+    expect(
+      parseRevParse("true\n/tmp/p/.git\n/tmp/p/.git\napp/packages/\n"),
+    ).toEqual({
+      insideWorkTree: true,
+      gitDir: "/tmp/p/.git",
+      gitCommonDir: "/tmp/p/.git",
+      worktreePrefix: "app/packages/",
     });
   });
 
   it("reads a false work-tree report", () => {
     expect(
-      parseRevParse("false\n/tmp/p.git\n/tmp/p.git\n")?.insideWorkTree,
+      parseRevParse("false\n/tmp/p.git\n/tmp/p.git\n\n")?.insideWorkTree,
     ).toBe(false);
   });
 
   it("returns null when a field is missing", () => {
-    expect(parseRevParse("true\n/tmp/p/.git\n")).toBeNull();
+    expect(parseRevParse("true\n/tmp/p/.git\n/tmp/p/.git\n")).toBeNull();
   });
 
   it("returns null on a non-boolean work-tree field", () => {
-    expect(parseRevParse("maybe\n/tmp/p/.git\n/tmp/p/.git\n")).toBeNull();
+    expect(parseRevParse("maybe\n/tmp/p/.git\n/tmp/p/.git\n\n")).toBeNull();
   });
 
   it("returns null on empty output", () => {
@@ -35,11 +47,14 @@ describe("parseRevParse", () => {
 
   it("does not transpose gitDir and gitCommonDir", () => {
     expect(
-      parseRevParse("true\n/repo/.git/worktrees/feature\n/repo/.git\n"),
+      parseRevParse(
+        "true\n/repo/.git/worktrees/feature\n/repo/.git\npackages/app/\n",
+      ),
     ).toEqual({
       insideWorkTree: true,
       gitDir: "/repo/.git/worktrees/feature",
       gitCommonDir: "/repo/.git",
+      worktreePrefix: "packages/app/",
     });
   });
 });
@@ -51,6 +66,7 @@ describe("classifyWorktree", () => {
         insideWorkTree: true,
         gitDir: "/p/.git",
         gitCommonDir: "/p/.git",
+        worktreePrefix: "",
       }),
     ).toBe("principal");
   });
@@ -61,13 +77,14 @@ describe("classifyWorktree", () => {
         insideWorkTree: true,
         gitDir: "/p/.git/worktrees/feature",
         gitCommonDir: "/p/.git",
+        worktreePrefix: "app/",
       }),
     ).toBe("linked");
   });
 
   it("derives a linked worktree from parsed rev-parse output", () => {
     const facts = parseRevParse(
-      "true\n/repo/.git/worktrees/feature\n/repo/.git\n",
+      "true\n/repo/.git/worktrees/feature\n/repo/.git\napp/\n",
     );
     if (facts === null) throw new Error("expected parseRevParse to succeed");
     expect(classifyWorktree(facts)).toBe("linked");

--- a/tests/git-scenarios.test.ts
+++ b/tests/git-scenarios.test.ts
@@ -56,6 +56,7 @@ function repository(
   head: GitHead,
   options: {
     readonly worktree?: GitRepository["worktree"];
+    readonly worktreePrefix?: string;
     readonly operation?: GitRepository["operation"];
     readonly changes?: readonly GitChange[];
   } = {},
@@ -63,6 +64,7 @@ function repository(
   return {
     head,
     worktree: options.worktree ?? "principal",
+    worktreePrefix: options.worktreePrefix ?? "",
     operation: options.operation ?? "none",
     changes: options.changes ?? [],
   };
@@ -579,6 +581,7 @@ describe("real-repository scenario corpus", () => {
           "--is-inside-work-tree",
           "--git-dir",
           "--git-common-dir",
+          "--show-prefix",
           "status",
           "--porcelain=v2",
           "-z",

--- a/tests/ports-contract.test.ts
+++ b/tests/ports-contract.test.ts
@@ -318,6 +318,7 @@ describe("deterministic fakes", () => {
           upstream: null,
         },
         worktree: "principal",
+        worktreePrefix: "",
         operation: "none",
         changes: [],
       },

--- a/tests/support/git-repositories.ts
+++ b/tests/support/git-repositories.ts
@@ -66,6 +66,15 @@ export interface Scenario {
   dispose(): Promise<void>;
 }
 
+export interface NestedProjectRepository {
+  readonly repositoryRoot: string;
+  readonly projectRoot: string;
+  commitAll(message?: string): void;
+  dispose(): Promise<void>;
+}
+
+export type RootProjectRepository = NestedProjectRepository;
+
 // ---------------------------------------------------------------------------
 // Process-level git helpers
 // ---------------------------------------------------------------------------
@@ -730,6 +739,44 @@ export function createScenarioRepository(
   name: ScenarioName,
 ): Promise<Scenario> {
   return BUILDERS[name]();
+}
+
+/** Build a real repository whose selected project is the `app` child. */
+export async function createNestedProjectRepository(): Promise<NestedProjectRepository> {
+  const repositoryRoot = await scratchDir("kratos-git-nested-project-");
+  return withCleanup(repositoryRoot, async () => {
+    await initRepositoryAt(repositoryRoot);
+    const projectRoot = join(repositoryRoot, "app");
+    await mkdir(projectRoot);
+    commitEmpty(repositoryRoot, "initial");
+    return {
+      repositoryRoot,
+      projectRoot,
+      commitAll: (message = "project state") => {
+        git(repositoryRoot, ["add", "-A"]);
+        commit(repositoryRoot, message);
+      },
+      dispose: disposer(repositoryRoot),
+    };
+  });
+}
+
+/** Build a real repository whose selected project is the worktree root. */
+export async function createRootProjectRepository(): Promise<RootProjectRepository> {
+  const repositoryRoot = await scratchDir("kratos-git-root-project-");
+  return withCleanup(repositoryRoot, async () => {
+    await initRepositoryAt(repositoryRoot);
+    commitEmpty(repositoryRoot, "initial");
+    return {
+      repositoryRoot,
+      projectRoot: repositoryRoot,
+      commitAll: (message = "project state") => {
+        git(repositoryRoot, ["add", "-A"]);
+        commit(repositoryRoot, message);
+      },
+      dispose: disposer(repositoryRoot),
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/worktree-gate.test.ts
+++ b/tests/worktree-gate.test.ts
@@ -1,0 +1,262 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, sep } from "node:path";
+
+import { createRuntime } from "@kratos/runtime/composition";
+import { runCommandLine } from "@kratos/runtime/composition/cli";
+import {
+  fixedEnvironment,
+  pipedInput,
+  recordingOutput,
+} from "@kratos/runtime/infra/fake";
+import { describe, expect, it } from "vitest";
+
+import {
+  createNestedProjectRepository,
+  createRootProjectRepository,
+  UNDECODABLE_NAME_BYTES,
+} from "./support/git-repositories.js";
+
+const ANSWERS = JSON.stringify({
+  contractVersion: "1.3.0",
+  hostContract: "1.3.0",
+  hosts: ["claude"],
+});
+
+const REAL_REPOSITORY_TIMEOUT = 15_000;
+
+function runtime(root: string, input: string | null = null) {
+  const output = recordingOutput();
+  return {
+    output,
+    ports: createRuntime({
+      environment: fixedEnvironment({}, root),
+      output,
+      standardInput: pipedInput(input),
+    }),
+  };
+}
+
+describe("the workflow worktree gate", () => {
+  it(
+    "starts a root project when only its managed state is dirty",
+    async () => {
+      const repository = await createRootProjectRepository();
+      try {
+        expect(
+          await runCommandLine(
+            ["init", "--root", repository.projectRoot],
+            runtime(repository.projectRoot, ANSWERS).ports,
+          ),
+        ).toBe(0);
+        repository.commitAll("initialize project");
+
+        expect(
+          await runCommandLine(
+            [
+              "objective",
+              "Ship the root project",
+              "--root",
+              repository.projectRoot,
+            ],
+            runtime(repository.projectRoot).ports,
+          ),
+        ).toBe(0);
+
+        const started = runtime(repository.projectRoot);
+        const exitCode = await runCommandLine(
+          [
+            "--json",
+            "start",
+            "--root",
+            repository.projectRoot,
+            "--host",
+            "claude-code",
+          ],
+          started.ports,
+        );
+        expect(exitCode, started.output.structured_.join("")).toBe(0);
+        const featureRoot = join(
+          repository.projectRoot,
+          ".brain/02-features/ship-the-root-project",
+        );
+        const runId = (
+          await readFile(join(featureRoot, "active-run"), "utf8")
+        ).trim();
+        const events = await readFile(
+          join(featureRoot, "runs", runId, "events.jsonl"),
+          "utf8",
+        );
+        expect(events).toContain('"reasonCode":"run.started"');
+      } finally {
+        await repository.dispose();
+      }
+    },
+    REAL_REPOSITORY_TIMEOUT,
+  );
+
+  it(
+    "starts a nested project when only its managed state is dirty",
+    async () => {
+      const repository = await createNestedProjectRepository();
+      try {
+        expect(
+          await runCommandLine(
+            ["init", "--root", repository.projectRoot],
+            runtime(repository.projectRoot, ANSWERS).ports,
+          ),
+        ).toBe(0);
+        repository.commitAll("initialize project");
+
+        expect(
+          await runCommandLine(
+            [
+              "objective",
+              "Ship the nested project",
+              "--root",
+              repository.projectRoot,
+            ],
+            runtime(repository.projectRoot).ports,
+          ),
+        ).toBe(0);
+
+        const started = runtime(repository.projectRoot);
+        const exitCode = await runCommandLine(
+          [
+            "--json",
+            "start",
+            "--root",
+            repository.projectRoot,
+            "--host",
+            "claude-code",
+          ],
+          started.ports,
+        );
+        expect(exitCode, started.output.structured_.join("")).toBe(0);
+        const featureRoot = join(
+          repository.projectRoot,
+          ".brain/02-features/ship-the-nested-project",
+        );
+        const runId = (
+          await readFile(join(featureRoot, "active-run"), "utf8")
+        ).trim();
+        const events = await readFile(
+          join(featureRoot, "runs", runId, "events.jsonl"),
+          "utf8",
+        );
+        expect(events).toContain('"reasonCode":"run.started"');
+      } finally {
+        await repository.dispose();
+      }
+    },
+    REAL_REPOSITORY_TIMEOUT,
+  );
+
+  it(
+    "refuses a nested project when a repository-root path is dirty",
+    async () => {
+      const repository = await createNestedProjectRepository();
+      try {
+        expect(
+          await runCommandLine(
+            ["init", "--root", repository.projectRoot],
+            runtime(repository.projectRoot, ANSWERS).ports,
+          ),
+        ).toBe(0);
+        repository.commitAll("initialize project");
+
+        expect(
+          await runCommandLine(
+            [
+              "objective",
+              "Ship the nested project",
+              "--root",
+              repository.projectRoot,
+            ],
+            runtime(repository.projectRoot).ports,
+          ),
+        ).toBe(0);
+        await mkdir(join(repository.repositoryRoot, ".brain"));
+        await writeFile(
+          join(repository.repositoryRoot, ".brain/foreign.txt"),
+          "x\n",
+        );
+
+        const started = runtime(repository.projectRoot);
+        const exitCode = await runCommandLine(
+          [
+            "--json",
+            "start",
+            "--root",
+            repository.projectRoot,
+            "--host",
+            "claude-code",
+          ],
+          started.ports,
+        );
+        expect(exitCode, started.output.structured_.join("")).toBe(2);
+        expect(JSON.parse(started.output.structured_.join(""))).toMatchObject({
+          reasonCode: "trail.worktree_dirty",
+        });
+      } finally {
+        await repository.dispose();
+      }
+    },
+    REAL_REPOSITORY_TIMEOUT,
+  );
+
+  it(
+    "refuses an undecodable path inside managed state",
+    async () => {
+      const repository = await createNestedProjectRepository();
+      try {
+        expect(
+          await runCommandLine(
+            ["init", "--root", repository.projectRoot],
+            runtime(repository.projectRoot, ANSWERS).ports,
+          ),
+        ).toBe(0);
+        repository.commitAll("initialize project");
+
+        expect(
+          await runCommandLine(
+            [
+              "objective",
+              "Ship the nested project",
+              "--root",
+              repository.projectRoot,
+            ],
+            runtime(repository.projectRoot).ports,
+          ),
+        ).toBe(0);
+        const managedRoot = Buffer.from(
+          `${join(repository.projectRoot, ".brain")}${sep}`,
+          "utf8",
+        );
+        await writeFile(
+          Buffer.concat([managedRoot, Buffer.from(UNDECODABLE_NAME_BYTES)]),
+          "x\n",
+        );
+
+        const started = runtime(repository.projectRoot);
+        const exitCode = await runCommandLine(
+          [
+            "--json",
+            "start",
+            "--root",
+            repository.projectRoot,
+            "--host",
+            "claude-code",
+          ],
+          started.ports,
+        );
+        expect(exitCode, started.output.structured_.join("")).toBe(2);
+        expect(JSON.parse(started.output.structured_.join(""))).toMatchObject({
+          reasonCode: "trail.worktree_dirty",
+        });
+      } finally {
+        await repository.dispose();
+      }
+    },
+    REAL_REPOSITORY_TIMEOUT,
+  );
+});


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #151

Work ID: Not assigned; issue #151 is the tracking work item.

## Outcome and design

The worktree gate now observes Git's project-to-worktree prefix through the existing git rev-parse call and uses that prefix when recognizing managed .brain paths. This lets a project nested under a repository root start a run when only its own managed state is dirty, while retaining refusal for repository-root and sibling paths.

The selected design preserves Git's repository-relative porcelain paths and matches only <prefix>/.brain and its descendants. It avoids rewriting paths, adding another Git command, or broadening the managed-path policy.

Out of scope: project-relative path rewriting, policy changes for foreign changes, and new Git dependencies.

Approved design: docs/specs/2026-08-30-project-relative-worktree-gate-spec.md.

## Compatibility and public contracts

Runtime Git observation adds the additive worktreePrefix field. Git change paths remain repository-relative. Existing principal/linked-worktree classification, reason codes, exit codes, commands, schemas, fixtures, host contracts, and Go-v3 parity behavior are unchanged. The observable behavior change is limited to accepting a nested project's own managed .brain changes at the worktree gate.

## State, migration, security, and rollback

No migration is required. Existing project state and event formats are unchanged. The change does not add permissions, secrets, network access, dependencies, concurrency behavior, or new trust boundaries. Conservatively, undecodable Git paths remain unmanaged and block the gate. Rollback is a normal code revert.

## Deterministic test evidence

- Acceptance evidence record: docs/specs/2026-08-30-project-relative-worktree-gate-spec.md.
- Focused verification: passed.
- Full repository verification: npm run verify was not run as an aggregate; its relevant constituent checks are reported below.
- Diff hygiene: git diff --check passed.

~~~text
npx vitest run tests/git-refs.test.ts tests/git-observation.test.ts tests/worktree-gate.test.ts --testTimeout=15000
3 files / 41 tests passed in 3.60s

npm test -- --testTimeout=15000
193 files / 4808 tests passed in 592.37s

npm run format:check
passed

npm run lint
passed

npm run typecheck
passed

git diff --check
passed
~~~

## Prompt and model evaluations

Not applicable. Deterministic tests cover the behavior.

## Failure evidence

Issue #151 records the minimal nested-project reproduction: Git porcelain reports the selected project's managed paths as app/.brain/..., while the former gate only allowed .brain/..., producing trail.worktree_dirty. The regression suite now verifies nested and root project starts, foreign root-path refusal, and conservative refusal of an invalid-UTF-8 path under managed state.

## Provenance

- Sources used: this repository and Git's existing rev-parse --show-prefix behavior (public; repository owner: thiagocorreanet).
- Contribution method: original.
- Publication authority and required notices: no adapted or verbatim third-party content.
- Confirmation: no secret, credential, customer/personal data, private infrastructure, or confidential business information is included.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, dependencies, design, and specification are linked; no separate epic, ADR, or work ID was assigned.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete npm test suite pass; npm run verify was not run as an aggregate.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation guidance is updated where required through the approved objective spec; no migration or recovery guidance is required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid Signed-off-by DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.
