### PR TITLE
Prepare the Experimental v0.2.0 release

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -25,6 +25,7 @@
     "covermode",
     "coverprofile",
     "CSpell",
+    "cyclonedx",
     "divergente",
     "EEXIST",
     "EINVAL",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,20 @@ jobs:
       - name: Prepare diagnostics
         run: mkdir -p .ci-diagnostics
 
+      # `actions/setup-node` installs whatever npm the Node.js distribution
+      # happens to bundle, and that pairing drifts as the runner image is
+      # rebuilt. Asserting the version without installing it turned a runner
+      # image update into a red build nobody asked for; installing the exact
+      # pin first is what makes the assertion below a check rather than a bet.
+      - name: Pin the exact npm release
+        run: |
+          set -euo pipefail
+          {
+            pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+            test "$pinned" = "11.16.0"
+            npm install --global --no-audit --no-fund "npm@$pinned"
+          } 2>&1 | tee .ci-diagnostics/npm.log
+
       - name: Verify exact toolchain
         run: |
           set -euo pipefail

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -29,6 +29,17 @@ jobs:
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
+      # `actions/setup-node` installs whatever npm the chosen Node.js
+      # distribution bundles, and that pairing drifts as the runner image is
+      # rebuilt. The lockfile is resolved by the npm `package.json` pins, not
+      # by whichever one the image shipped with.
+      - name: Pin the exact npm release
+        shell: bash
+        run: |
+          set -euo pipefail
+          pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          npm install --global --no-audit --no-fund "npm@$pinned"
+          test "$(npm --version)" = "$pinned"
       - run: npm ci
       - run: npm run oracle:verify
       - run: npm run parity:check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           package-manager-cache: false
+      # `actions/setup-node` installs whatever npm the chosen Node.js
+      # distribution bundles, and that pairing drifts as the runner image is
+      # rebuilt. The lockfile is resolved by the npm `package.json` pins, not
+      # by whichever one the image shipped with.
+      - name: Pin the exact npm release
+        shell: bash
+        run: |
+          set -euo pipefail
+          pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          npm install --global --no-audit --no-fund "npm@$pinned"
+          test "$(npm --version)" = "$pinned"
       - run: npm ci
       - run: npm run typecheck
       - run: npm test
@@ -49,6 +60,17 @@ jobs:
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
+      # `actions/setup-node` installs whatever npm the chosen Node.js
+      # distribution bundles, and that pairing drifts as the runner image is
+      # rebuilt. The lockfile is resolved by the npm `package.json` pins, not
+      # by whichever one the image shipped with.
+      - name: Pin the exact npm release
+        shell: bash
+        run: |
+          set -euo pipefail
+          pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          npm install --global --no-audit --no-fund "npm@$pinned"
+          test "$(npm --version)" = "$pinned"
       - run: npm ci
       - run: npm test -- --run tests/transaction-fault-campaign.test.ts tests/event-store-fault-campaign.test.ts tests/lock-fault-campaign.test.ts tests/lock-process-contention.test.ts
 
@@ -64,6 +86,17 @@ jobs:
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
+      # `actions/setup-node` installs whatever npm the chosen Node.js
+      # distribution bundles, and that pairing drifts as the runner image is
+      # rebuilt. The lockfile is resolved by the npm `package.json` pins, not
+      # by whichever one the image shipped with.
+      - name: Pin the exact npm release
+        shell: bash
+        run: |
+          set -euo pipefail
+          pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          npm install --global --no-audit --no-fund "npm@$pinned"
+          test "$(npm --version)" = "$pinned"
       - run: npm ci
       - run: npm run mutation:check
       - run: npm run performance:check

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -38,6 +38,17 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           package-manager-cache: false
+      # `actions/setup-node` installs whatever npm the chosen Node.js
+      # distribution bundles, and that pairing drifts as the runner image is
+      # rebuilt. The lockfile is resolved by the npm `package.json` pins, not
+      # by whichever one the image shipped with.
+      - name: Pin the exact npm release
+        shell: bash
+        run: |
+          set -euo pipefail
+          pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          npm install --global --no-audit --no-fund "npm@$pinned"
+          test "$(npm --version)" = "$pinned"
       - run: npm ci
       - run: npm run typecheck
       - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,13 @@ permissions:
 jobs:
   package:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # `npm run verify` alone now costs more than the 25 minutes this job used
+    # to allow: the CI quality job runs a strict subset of it and takes 26,
+    # and this job then rebuilds the whole distribution a second time to prove
+    # the archives are reproducible. 25 was set when v0.1.0 published in 11
+    # minutes against a suite of 30 tests; there are 5,545 now, and the next
+    # tag would have been killed mid-verify.
+    timeout-minutes: 60
     environment: release
     permissions:
       contents: write
@@ -48,7 +54,6 @@ jobs:
           test "$(npm --version)" = "$pinned"
       - run: npm ci
       - run: npm run verify
-      - run: npm run benchmark
       - name: Stage release, checksums, and SBOM
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,18 @@ jobs:
         run: |
           set -euo pipefail
           printf 'KRATOS_BUILD_OUTPUT=%s\n' "$RUNNER_TEMP/kratos-plugin-build" >> "$GITHUB_ENV"
+      # `actions/setup-node` installs whatever npm the Node.js distribution
+      # happens to bundle, which drifts as the runner image is rebuilt. The
+      # release is reproducible only if the package manager that resolves the
+      # lockfile is the exact one `package.json` pins, so it is installed here
+      # rather than assumed.
+      - name: Pin the exact npm release
+        run: |
+          set -euo pipefail
+          pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          test "$pinned" = "11.16.0"
+          npm install --global --no-audit --no-fund "npm@$pinned"
+          test "$(npm --version)" = "$pinned"
       - run: npm ci
       - run: npm run verify
       - run: npm run benchmark
@@ -41,25 +53,43 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release
-          tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -czf release/kratos-marketplace.tgz -C "$KRATOS_BUILD_OUTPUT" .
-          tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -czf release/kratos-claude-code.tgz -C "$KRATOS_BUILD_OUTPUT/claude-code" .
-          tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -czf release/kratos-codex.tgz -C "$KRATOS_BUILD_OUTPUT/codex" .
-          sha256sum release/*.tgz > release/SHA256SUMS
+          # One archive carries the whole marketplace tree, and one carries each
+          # host package on its own so a host that installs from a plain
+          # directory does not have to download the other two.
+          archive() {
+            tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 \
+              --numeric-owner -czf "$1" -C "$2" .
+          }
+          archive release/kratos-marketplace.tgz "$KRATOS_BUILD_OUTPUT"
+          archive release/kratos-claude-code.tgz "$KRATOS_BUILD_OUTPUT/claude-code"
+          archive release/kratos-codex.tgz "$KRATOS_BUILD_OUTPUT/codex"
+          archive release/kratos-antigravity.tgz "$KRATOS_BUILD_OUTPUT/antigravity"
+          # Written from inside `release/` so a downloader who put the assets in
+          # one directory can run `sha256sum -c SHA256SUMS` unchanged.
+          ( cd release && sha256sum ./*.tgz > SHA256SUMS )
           npm sbom --sbom-format cyclonedx > release/sbom.cdx.json
       - name: Rebuild and prove archive reproducibility
         run: |
           set -euo pipefail
           mkdir -p .reproducibility
-          cp release/kratos-marketplace.tgz .reproducibility/kratos-marketplace.first.tgz
-          cp release/kratos-claude-code.tgz .reproducibility/kratos-claude-code.first.tgz
-          cp release/kratos-codex.tgz .reproducibility/kratos-codex.first.tgz
+          archives="kratos-marketplace kratos-claude-code kratos-codex kratos-antigravity"
+          for name in $archives; do
+            cp "release/$name.tgz" ".reproducibility/$name.first.tgz"
+          done
           npm run build
-          tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -czf .reproducibility/kratos-marketplace.second.tgz -C "$KRATOS_BUILD_OUTPUT" .
-          tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -czf .reproducibility/kratos-claude-code.second.tgz -C "$KRATOS_BUILD_OUTPUT/claude-code" .
-          tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner -czf .reproducibility/kratos-codex.second.tgz -C "$KRATOS_BUILD_OUTPUT/codex" .
-          cmp .reproducibility/kratos-marketplace.first.tgz .reproducibility/kratos-marketplace.second.tgz
-          cmp .reproducibility/kratos-claude-code.first.tgz .reproducibility/kratos-claude-code.second.tgz
-          cmp .reproducibility/kratos-codex.first.tgz .reproducibility/kratos-codex.second.tgz
+          archive() {
+            tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 \
+              --numeric-owner -czf "$1" -C "$2" .
+          }
+          archive .reproducibility/kratos-marketplace.second.tgz "$KRATOS_BUILD_OUTPUT"
+          archive .reproducibility/kratos-claude-code.second.tgz "$KRATOS_BUILD_OUTPUT/claude-code"
+          archive .reproducibility/kratos-codex.second.tgz "$KRATOS_BUILD_OUTPUT/codex"
+          archive .reproducibility/kratos-antigravity.second.tgz "$KRATOS_BUILD_OUTPUT/antigravity"
+          # Byte-for-byte on every published archive, not only the ones that
+          # happened to be compared when the workflow was written.
+          for name in $archives; do
+            cmp ".reproducibility/$name.first.tgz" ".reproducibility/$name.second.tgz"
+          done
       - name: Attest plugin archive
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,17 @@ jobs:
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
+      # `actions/setup-node` installs whatever npm the chosen Node.js
+      # distribution bundles, and that pairing drifts as the runner image is
+      # rebuilt. The lockfile is resolved by the npm `package.json` pins, not
+      # by whichever one the image shipped with.
+      - name: Pin the exact npm release
+        shell: bash
+        run: |
+          set -euo pipefail
+          pinned="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          npm install --global --no-audit --no-fund "npm@$pinned"
+          test "$(npm --version)" = "$pinned"
       - run: npm ci
       - name: Audit production dependency resolution
         run: npm audit --omit=dev --audit-level=high

--- a/distribution/antigravity/plugin.json
+++ b/distribution/antigravity/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "kratos",
+  "description": "Deterministic SDD workflow backed by the embedded Kratos runtime."
+}

--- a/distribution/claude-code/.claude-plugin/plugin.json
+++ b/distribution/claude-code/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kratos",
   "displayName": "Kratos",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "description": "Deterministic SDD workflow backed by the embedded Kratos runtime.",
   "license": "MIT",
   "keywords": ["sdd", "workflow", "evidence", "development"]

--- a/distribution/claude-code/.claude-plugin/plugin.json
+++ b/distribution/claude-code/.claude-plugin/plugin.json
@@ -4,6 +4,12 @@
   "displayName": "Kratos",
   "version": "0.2.0",
   "description": "Deterministic SDD workflow backed by the embedded Kratos runtime.",
+  "author": {
+    "name": "Kratos contributors",
+    "url": "https://github.com/thiagocorreanet/kratos-harness"
+  },
+  "homepage": "https://github.com/thiagocorreanet/kratos-harness",
+  "repository": "https://github.com/thiagocorreanet/kratos-harness",
   "license": "MIT",
   "keywords": ["sdd", "workflow", "evidence", "development"]
 }

--- a/distribution/codex/.codex-plugin/plugin.json
+++ b/distribution/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "description": "Run a deterministic SDD workflow backed by the embedded Kratos runtime.",
   "license": "MIT",
   "keywords": ["sdd", "workflow", "evidence", "development"],

--- a/distribution/codex/.codex-plugin/plugin.json
+++ b/distribution/codex/.codex-plugin/plugin.json
@@ -2,6 +2,12 @@
   "name": "kratos",
   "version": "0.2.0",
   "description": "Run a deterministic SDD workflow backed by the embedded Kratos runtime.",
+  "author": {
+    "name": "Kratos contributors",
+    "url": "https://github.com/thiagocorreanet/kratos-harness"
+  },
+  "homepage": "https://github.com/thiagocorreanet/kratos-harness",
+  "repository": "https://github.com/thiagocorreanet/kratos-harness",
   "license": "MIT",
   "keywords": ["sdd", "workflow", "evidence", "development"],
   "skills": "./skills/",

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -189,8 +189,25 @@ agy plugin install "$KRATOS_HOME/antigravity"
 agy plugin list
 ```
 
-Antigravity stages the package under its own plugin directory and reads the
-`plugin.json` marker at the package root for the plugin name, `kratos`.
+Antigravity stages the package under its own CLI plugin directory
+(`~/.gemini/antigravity-cli/plugins/kratos/`) and reads the `plugin.json`
+marker at the package root for the plugin name, `kratos`.
+
+The Antigravity IDE discovers plugins by scanning directories rather than
+through a command, so a workspace or global installation is a copy:
+
+```bash
+# One workspace only
+mkdir -p /path/to/workspace/.agents/plugins
+cp -R "$KRATOS_HOME/antigravity" /path/to/workspace/.agents/plugins/kratos
+
+# Every workspace
+mkdir -p ~/.gemini/config/plugins
+cp -R "$KRATOS_HOME/antigravity" ~/.gemini/config/plugins/kratos
+```
+
+Uninstalling such a copy means deleting that directory. `agy plugin uninstall`
+manages only what `agy plugin install` staged.
 
 ### Update
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,25 +1,239 @@
 # Installing Kratos
 
-Kratos is source-first and does not keep a generated `dist` directory in its
-repository. A build creates three temporary, installable packages: one for Codex,
-one for Claude Code, and one for Google Antigravity. The plugin runtime stays outside the project that uses
-Kratos.
+Kratos ships as three independent host packages built from one embedded
+runtime: one for OpenAI Codex, one for Claude Code, and one for Google
+Antigravity. The runtime lives inside the host-managed plugin directory and is
+never copied into the project that uses Kratos.
+
+There are two ways to obtain those packages:
+
+- install the published archives from a GitHub release, which is what a user
+  does;
+- build them from a checkout, which is what a contributor does.
+
+Both are documented below. Every host command on this page comes from that
+host's own documentation; where a host publishes no command for an operation,
+this page says so instead of inventing one.
 
 ## Prerequisites
 
-- Git;
 - Node.js 24.18 or later within major version 24;
-- npm 11.16.0 for repository development and the full verification suite.
+- `tar` and a SHA-256 checksum tool (`sha256sum`, or `shasum -a 256` on macOS);
+- the [GitHub CLI](https://cli.github.com/) to download and verify release
+  assets;
+- Git and npm 11.16.0 only for the from-source path.
 
-The plugin runtime itself carries no `node_modules` and does not require a
-global Kratos binary.
+The plugin package carries no `node_modules` and needs no global Kratos binary.
 
-## Build and verify
+## Release assets
 
-Choose an absolute output directory outside the checkout:
+A tagged release publishes six assets:
+
+| Asset | Contents |
+| --- | --- |
+| `kratos-marketplace.tgz` | The whole build: `codex/`, `claude-code/`, `antigravity/`, and both local marketplace manifests |
+| `kratos-codex.tgz` | The Codex package alone |
+| `kratos-claude-code.tgz` | The Claude Code package alone |
+| `kratos-antigravity.tgz` | The Antigravity package alone |
+| `SHA256SUMS` | SHA-256 of each archive |
+| `sbom.cdx.json` | CycloneDX software bill of materials |
+
+Every archive is built twice inside the release job and compared byte for byte
+before publication, and each one carries a GitHub build-provenance attestation.
+
+## Download and verify
+
+The commands below use the release tag and repository as variables so the same
+block works for any version.
 
 ```bash
-git clone <your-kratos-repository-url> kratos
+KRATOS_VERSION=v0.2.0
+KRATOS_REPO=thiagocorreanet/kratos-harness
+KRATOS_HOME=~/.kratos/releases/$KRATOS_VERSION
+mkdir -p "$KRATOS_HOME/download"
+cd "$KRATOS_HOME/download"
+
+gh release download "$KRATOS_VERSION" --repo "$KRATOS_REPO" \
+  --pattern 'kratos-*.tgz' --pattern 'SHA256SUMS'
+sha256sum --check --ignore-missing SHA256SUMS
+gh attestation verify kratos-marketplace.tgz --repo "$KRATOS_REPO"
+```
+
+`sha256sum --check` proves the bytes match what the release job measured;
+`gh attestation verify` proves those bytes were produced by this repository's
+release workflow. Run the attestation check against each archive you intend to
+install. On macOS, replace the checksum line with
+`shasum -a 256 --check --ignore-missing SHA256SUMS`.
+
+Extract the marketplace archive once; it contains all three host packages:
+
+```bash
+mkdir -p "$KRATOS_HOME/marketplace"
+tar -xzf "$KRATOS_HOME/download/kratos-marketplace.tgz" \
+  -C "$KRATOS_HOME/marketplace"
+```
+
+The extracted tree is a local marketplace root for both Codex and Claude Code:
+
+```text
+marketplace/
+  .agents/plugins/marketplace.json
+  .claude-plugin/marketplace.json
+  claude-code/
+  codex/
+  antigravity/
+```
+
+Before handing a package to a host, confirm the runtime inside it answers:
+
+```bash
+"$KRATOS_HOME/marketplace/claude-code/runtime/kratos.mjs" version
+"$KRATOS_HOME/marketplace/claude-code/runtime/kratos.mjs" handshake --json
+```
+
+`version` prints the plugin version; `handshake --json` prints the contract
+versions the package carries. Repeat for `codex/` and `antigravity/`.
+
+## Install in Claude Code
+
+Claude Code installs a plugin from a marketplace, and accepts a local directory
+as a marketplace source.
+
+```bash
+claude plugin marketplace add "$KRATOS_HOME/marketplace"
+claude plugin install kratos@kratos-open-source
+```
+
+Confirm the result with `claude plugin marketplace list` and the `/plugin`
+picker inside a session. `/reload-plugins` reloads without restarting.
+
+### Update
+
+Download and verify the new release into its own `KRATOS_HOME`, then repoint
+the marketplace. The marketplace name is the same in both releases, so the old
+entry is removed first:
+
+```bash
+claude plugin uninstall kratos@kratos-open-source
+claude plugin marketplace remove kratos-open-source
+claude plugin marketplace add "$KRATOS_HOME/marketplace"
+claude plugin install kratos@kratos-open-source
+```
+
+### Roll back
+
+Rolling back is the same sequence pointed at the previous release directory,
+which is why each release is extracted under its own version. Keep the previous
+`~/.kratos/releases/<version>` tree until the new one is accepted.
+
+### Uninstall
+
+```bash
+claude plugin uninstall kratos@kratos-open-source
+claude plugin marketplace remove kratos-open-source
+```
+
+## Install in Codex
+
+Codex adds a marketplace from a local directory:
+
+```bash
+codex plugin marketplace add "$KRATOS_HOME/marketplace"
+codex plugin marketplace list
+```
+
+Codex publishes no CLI command for installing an individual plugin. Open the
+plugin browser and install Kratos there:
+
+```bash
+codex /plugins
+```
+
+Select the `Kratos Open Source` marketplace, open `kratos`, install it, and
+press Space to enable it. Start a new session afterwards.
+
+### Update
+
+```bash
+codex plugin marketplace remove kratos-open-source
+codex plugin marketplace add "$KRATOS_HOME/marketplace"
+```
+
+Then reinstall Kratos in `codex /plugins`. Codex also documents
+`codex plugin marketplace upgrade kratos-open-source`, which refreshes a
+marketplace in place.
+
+### Roll back
+
+Remove the marketplace, add the previous release's `marketplace` directory, and
+reinstall from `codex /plugins`.
+
+### Uninstall
+
+Uninstall Kratos from `codex /plugins`, then drop the marketplace:
+
+```bash
+codex plugin marketplace remove kratos-open-source
+```
+
+## Install in Antigravity
+
+Antigravity installs a plugin from a local directory rather than from a
+marketplace, so use the host-specific archive:
+
+```bash
+mkdir -p "$KRATOS_HOME/antigravity"
+tar -xzf "$KRATOS_HOME/download/kratos-antigravity.tgz" \
+  -C "$KRATOS_HOME/antigravity"
+agy plugin install "$KRATOS_HOME/antigravity"
+agy plugin list
+```
+
+Antigravity stages the package under its own plugin directory and reads the
+`plugin.json` marker at the package root for the plugin name, `kratos`.
+
+### Update
+
+```bash
+agy plugin uninstall kratos
+agy plugin install "$KRATOS_HOME/antigravity"
+```
+
+### Roll back
+
+```bash
+agy plugin uninstall kratos
+agy plugin install ~/.kratos/releases/<previous-version>/antigravity
+```
+
+`agy plugin disable kratos` suspends the plugin without removing it, and
+`agy plugin enable kratos` restores it. Prefer disabling while diagnosing a
+problem, and roll back only when the previous release is the answer.
+
+### Uninstall
+
+```bash
+agy plugin uninstall kratos
+```
+
+### What is not claimed for Antigravity
+
+Antigravity's documented plugin manifest carries `name`, `description`, and
+`$schema` and no version field, so the Antigravity package records its version
+in `runtime/manifest.json` rather than in `plugin.json`. Antigravity's hook
+configuration is also read from a `hooks.json` at the package root, and the
+events it documents are `PreToolUse`, `PostToolUse`, `PreInvocation`,
+`PostInvocation`, and `Stop`. The Kratos hook definition does not match that
+shape yet, so this release does not claim working Antigravity hooks; the skill
+and the runtime are what the Antigravity package delivers.
+
+## Build from a checkout
+
+Contributors build the same packages locally. The build refuses to write inside
+the source repository, so choose an absolute output directory outside it:
+
+```bash
+git clone https://github.com/thiagocorreanet/kratos-harness.git kratos
 cd kratos
 npm ci
 export KRATOS_BUILD_OUTPUT=/absolute/temporary/path/kratos-plugin-build
@@ -27,27 +241,13 @@ npm run build
 npm run package:verify
 ```
 
-If `KRATOS_BUILD_OUTPUT` is not set, Kratos uses
-`<operating-system-temp>/kratos-plugin-build`. The build refuses to write
-inside the source repository.
+If `KRATOS_BUILD_OUTPUT` is not set, the build writes to
+`<operating-system-temp>/kratos-plugin-build`. The output has the same layout
+as the extracted `kratos-marketplace.tgz`, so every install command above works
+against it by substituting `"$KRATOS_BUILD_OUTPUT"` for
+`"$KRATOS_HOME/marketplace"`.
 
-The output contains three independent packages and local marketplace manifests:
-
-```text
-kratos-plugin-build/
-  .agents/plugins/marketplace.json
-  .claude-plugin/marketplace.json
-  codex/
-  claude-code/
-  antigravity/
-```
-
-Each package contains its thin host adapter and a private `runtime/` directory.
-Neither package is copied into an application repository.
-
-## Run the temporary build
-
-The repository helper defaults to the Codex package:
+Run the temporary build directly, which defaults to the Codex package:
 
 ```bash
 npm run kratos -- help
@@ -55,52 +255,15 @@ npm run kratos -- version
 npm run kratos -- handshake --json
 ```
 
-Select the Claude Code package with `KRATOS_HOST=claude-code` or Antigravity with `KRATOS_HOST=antigravity`.
-
-## Install in Codex
-
-Add the temporary build as a local marketplace:
-
-```bash
-codex plugin marketplace add "$KRATOS_BUILD_OUTPUT"
-```
-
-Open `/plugins` in Codex, select the `Kratos Open Source` marketplace, install
-Kratos, and start a new session. The package follows the official
-`.codex-plugin/plugin.json` and `skills/<name>/SKILL.md` layout.
-
-## Install in Claude Code
-
-Add the same temporary build as a Claude Code marketplace and install Kratos:
-
-```bash
-claude plugin marketplace add "$KRATOS_BUILD_OUTPUT"
-claude plugin install kratos@kratos-open-source
-```
-
-Alternatively, validate a development package directly with
-`claude --plugin-dir "$KRATOS_BUILD_OUTPUT/claude-code"`.
-
-The host-managed installation receives the motor, contracts, schemas, and thin
-adapter. The application project does not.
-
-## Install in Antigravity
-
-Add the Antigravity package or reference the temporary build in your Antigravity
-configuration or CLI:
-
-```bash
-agy plugin install "$KRATOS_BUILD_OUTPUT/antigravity"
-```
-
-The Antigravity package provides the Kratos skill, workflow hooks, and thin
-pre-tool-use write guards for Google Antigravity.
+Select another package with `KRATOS_HOST=claude-code` or
+`KRATOS_HOST=antigravity`. Claude Code also loads a development package
+directly with `claude --plugin-dir "$KRATOS_BUILD_OUTPUT/claude-code"`.
 
 ## Direct atomic staging
 
-`scripts/install-plugin.mjs` is available for release assembly and controlled
-deployments that need verified atomic activation at an explicit directory. It
-does not register that directory with a host marketplace:
+`scripts/install-plugin.mjs` performs verified atomic activation at an explicit
+directory. It is for release assembly and controlled deployments; it does not
+register anything with a host:
 
 ```bash
 node scripts/install-plugin.mjs install \
@@ -108,6 +271,12 @@ node scripts/install-plugin.mjs install \
   --source "$KRATOS_BUILD_OUTPUT" \
   --target /absolute/plugin/staging/directory/kratos
 ```
+
+The same script supports `update`, `rollback`, `commit`, and `uninstall` with
+the same `--host` and `--target` arguments. It refuses a downgrade, keeps the
+replaced version as a rollback copy until `commit`, and `uninstall` quarantines
+the installation instead of deleting it. None of these operations touches
+project-owned state.
 
 ## Initialize a project
 
@@ -122,9 +291,9 @@ project and pass its project-relative path:
 ```
 
 Initialization creates or reconciles only project-facing material such as
-`.brain/`, `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`, and the selected bounded host surfaces.
-It never copies runtime code, package sources, internal engine skills,
-`node_modules`, TypeScript, or source maps into the project.
+`.brain/`, `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`, and the selected bounded
+host surfaces. It never copies runtime code, package sources, internal engine
+skills, `node_modules`, TypeScript, or source maps into the project.
 
 Record an objective and start a run:
 
@@ -141,12 +310,12 @@ The normal trail continues through artifact and evidence recording, phase
 gates, content-bound approval, and `done`. Run `kratos help` through the same
 installed runtime for the exact command contract.
 
-## Update, rollback, and uninstall
+## Removing project state
 
-The installer supports `update`, `rollback`, `commit`, and `uninstall` with the
-same `--host` and `--target` arguments. `uninstall` quarantines the plugin
-installation instead of deleting it immediately. None of these operations
-touches project-owned state.
+Uninstalling a host package and deleting project state are separate decisions.
+Every command above removes only the plugin. See
+[Uninstall and state preservation](user/uninstall.md) for what to do with
+`.brain/` and the managed host sections.
 
 See [Atomic plugin installation](distribution/atomic-installation.md) and
 [Installation boundary](architecture/installation-boundary.md) for the exact

--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -27,7 +27,7 @@ the metadata-only Go v3 migration profiles.
 | Identity | Current | Owner |
 | --- | --- | --- |
 | Contract-manifest schema | `v1.9` | Contract-family manifest format |
-| `pluginVersion` | `0.0.0-development` | One coherent installed plugin bundle |
+| `pluginVersion` | `0.2.0` | One coherent installed plugin bundle |
 | `stateContract` | `1.4.0` | Persisted `.brain/` configuration and history |
 | `hostContract` | `1.4.0` | Cross-process adapter request and response messages |
 

--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -20,9 +20,12 @@ the published predecessors
 [`contract-manifest.v1.3.schema.json`](../../schemas/contracts/contract-manifest.v1.3.schema.json),
 [`contract-manifest.v1.2.schema.json`](../../schemas/contracts/contract-manifest.v1.2.schema.json),
 [`contract-manifest.v1.1.schema.json`](../../schemas/contracts/contract-manifest.v1.1.schema.json),
-and the v1 schema remain byte-preserved.
-The manifest registers every current payload schema, its generated type, and
-the metadata-only Go v3 migration profiles.
+and the v1 schema keep their shape.
+Their bytes move only when `pluginVersion` does, because that constant is the
+identity of one installed bundle rather than a per-schema historical record;
+the v0.2.0 release is the first time that has happened. The manifest registers
+every current payload schema, its generated type, and the metadata-only Go v3
+migration profiles.
 
 | Identity | Current | Owner |
 | --- | --- | --- |

--- a/docs/distribution/release-gates.md
+++ b/docs/distribution/release-gates.md
@@ -6,10 +6,16 @@ reviewers before a release is considered protected; naming an environment in
 workflow source does not activate those settings.
 
 The workflow verifies the complete repository, benchmarks the built runtime,
-creates the shared plugin and both host-specific archives, rebuilds them, and
-requires byte-for-byte equality. It then emits SHA-256 checksums, a CycloneDX
-SBOM, and GitHub build-provenance attestations. Only a verified `v*` tag is
-published as a GitHub release.
+creates the shared marketplace archive and all three host-specific archives —
+Codex, Claude Code, and Antigravity — rebuilds every one of them, and requires
+byte-for-byte equality across all four. It then emits SHA-256 checksums written
+from inside the release directory, a CycloneDX SBOM, and GitHub
+build-provenance attestations covering every archive. Only a verified `v*` tag
+is published as a GitHub release.
+
+The npm release that resolves the lockfile is installed from the pin in
+`package.json` before it is used, in every workflow that runs npm. The version
+the runner image bundles with Node.js decides nothing.
 
 The `developer` branch is the integration line and `main` is the release line.
 Repository rulesets must require pull requests, CI, DCO, dependency review,

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -63,13 +63,23 @@ three supported hosts.
 `pluginVersion` identifies one coherent installed bundle. The runtime accepts
 exactly one value, so moving it to `0.2.0` moves it in every schema at once.
 
-**A project initialized with the v0.1.0 package is not readable by v0.2.0.**
-Its `.brain/config.json` records `pluginVersion: "0.0.0-development"`, which the
-v0.2.0 runtime classifies as `contract.plugin_version_unsupported`. There is no
-migration for this, and none is offered: at Experimental maturity the supported
-path is to re-initialize the project with the v0.2.0 package. The event log,
-evidence, and approvals of such a project were produced by a version whose
-behavior this release does not promise to reproduce.
+**A project initialized with the v0.1.0 package needs to be re-initialized.**
+Its `.brain/config.json` records `pluginVersion: "0.0.0-development"`. Measured
+against the v0.2.0 package, that configuration is rejected: `kratos doctor`
+returns `runtime.state_corrupt` with exit code 4 and reports "The authoritative
+project configuration is invalid."
+
+The failure is partial rather than clean. Commands that do not read the
+configuration — `status`, `objective`, `audit` — still answer, so a stale
+project looks usable until `doctor` is run. Treat `doctor` as the check that
+decides, not the first command that succeeds.
+
+No automatic migration is offered. At Experimental maturity the supported path
+is to re-initialize the project with the v0.2.0 package. A v0.1.0 project also
+predates the current state contract, so its configuration would need the
+documented `kratos migrate config` preview and apply in addition to the version
+field, and its event log, evidence, and approvals were produced by a version
+whose behavior this release does not promise to reproduce.
 
 Contract families are otherwise unchanged. The state contract stays at `1.4.0`,
 the host contract at `1.4.0`, the result contract at `1.0.0`, and the reason

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,199 @@
+# Proposed release notes — Kratos v0.2.0 (Experimental)
+
+These notes are a proposal. No tag has been created, nothing has been pushed,
+and no GitHub release has been published. Publishing is a separate, explicitly
+authorized step.
+
+## Classification
+
+**Experimental.** This is a development snapshot published as a GitHub
+pre-release, not a production release. The maturity gates in
+[ROADMAP.md](../../ROADMAP.md) decide promotion, and every criterion for
+Preview is still open. Nothing in this release changes that classification.
+
+## What this release is
+
+v0.2.0 is the first release whose version is coherent end to end. The tag, the
+npm workspace versions, `KRATOS_VERSION`, the contract-family manifest, the
+host plugin manifests, the schemas, and the version the installed runtime
+prints are all `0.2.0`. In v0.1.0 the tag said `0.1.0` while every package
+still reported `0.0.0-development`.
+
+It is also the first release that publishes an installable package for all
+three supported hosts.
+
+## Changes
+
+### Distribution
+
+- The release workflow now publishes four archives instead of three:
+  `kratos-marketplace.tgz`, `kratos-codex.tgz`, `kratos-claude-code.tgz`, and
+  `kratos-antigravity.tgz`. The Antigravity package previously existed in the
+  build but was never published on its own.
+- All four archives are rebuilt inside the release job and compared byte for
+  byte against the first build. Previously only three were compared.
+- `SHA256SUMS` is written from inside the release directory, so a downloader
+  who places the assets in one directory can run `sha256sum --check SHA256SUMS`
+  unchanged.
+- A CycloneDX SBOM (`sbom.cdx.json`) and GitHub build-provenance attestations
+  cover every published archive.
+
+### Hosts
+
+- The Antigravity package now carries the `plugin.json` marker file at the
+  package root that Antigravity requires to recognize a directory as a plugin.
+  Without it, `agy plugin install` had nothing to identify.
+- Package verification now checks each host's manifest at the location that
+  host documents, for all three hosts rather than two.
+
+### Toolchain
+
+- Every workflow that runs `npm` now installs the exact npm release pinned in
+  `package.json` before using it, instead of trusting whichever npm the runner
+  image happened to bundle with Node.js.
+
+### Documentation
+
+- [Installing Kratos](../INSTALLATION.md) documents install, update, roll back,
+  and uninstall for each host using that host's own commands, starting from the
+  published release assets.
+
+## Compatibility and migration
+
+`pluginVersion` identifies one coherent installed bundle. The runtime accepts
+exactly one value, so moving it to `0.2.0` moves it in every schema at once.
+
+**A project initialized with the v0.1.0 package is not readable by v0.2.0.**
+Its `.brain/config.json` records `pluginVersion: "0.0.0-development"`, which the
+v0.2.0 runtime classifies as `contract.plugin_version_unsupported`. There is no
+migration for this, and none is offered: at Experimental maturity the supported
+path is to re-initialize the project with the v0.2.0 package. The event log,
+evidence, and approvals of such a project were produced by a version whose
+behavior this release does not promise to reproduce.
+
+Contract families are otherwise unchanged. The state contract stays at `1.4.0`,
+the host contract at `1.4.0`, the result contract at `1.0.0`, and the reason
+catalog at `1.11.0`. No schema shape changed; only the `pluginVersion` constant
+moved.
+
+## What is validated, and what is not
+
+### Behavioral parity: 0 / 400
+
+Behavioral parity with the Go v3 predecessor remains **0 / 400** (P0 0 / 211,
+P1 0 / 174). The differential harness runs and its self-test passes, but both
+of its sides run the same executable, so it proves the harness rather than
+parity. The authorized comparison needs the private frozen oracle, which is not
+part of this repository. Nothing in this release moves that number.
+
+### Signed-in host E2E: still pending
+
+Real signed-in end-to-end runs in Codex, Claude Code, and Antigravity are
+**still pending**. They require authenticated host sessions and cannot be
+performed by automation in this repository. What is proven instead is that each
+package installs atomically into a clean directory, reports the correct version,
+answers `handshake --json`, initializes a project, records an objective, and
+starts a run — all through the built runtime, in `npm run package:verify`.
+
+That is a package contract, not a host integration. No claim is made that a
+signed-in host loads, enables, and drives the plugin end to end.
+
+### Platforms and hosts effectively validated
+
+| Surface | Status | Evidence |
+| --- | --- | --- |
+| Linux (`ubuntu-latest`), Node 24.18.0 | Validated | CI, platform, compatibility, security, and nightly jobs pass |
+| macOS (`macos-latest`), Node 24.18.0 | Not validated | The nightly matrix fails at `npm test` |
+| Windows (`windows-latest`), Node 24.18.0 | Not validated | The nightly matrix fails at `npm test` |
+| Codex package | Builds, verifies, installs, initializes a project | `npm run package:verify` |
+| Claude Code package | Builds, verifies, installs, initializes a project | `npm run package:verify` |
+| Antigravity package | Builds, verifies, installs, initializes a project | `npm run package:verify` |
+| Codex hooks | Not validated in a signed-in host | — |
+| Claude Code hooks | Not validated in a signed-in host | — |
+| Antigravity hooks | **Not claimed** | The Kratos hook definition does not match Antigravity's documented `hooks.json` location or event set |
+
+The Antigravity package delivers the Kratos skill and the embedded runtime.
+Antigravity reads plugin hooks from a `hooks.json` at the package root and
+documents the events `PreToolUse`, `PostToolUse`, `PreInvocation`,
+`PostInvocation`, and `Stop`. Kratos writes its hook configuration to
+`hooks/hooks.json` and declares `PostToolUseFailure` and `SessionEnd`, so those
+hooks do not load in Antigravity. This release states that rather than shipping
+a claim it cannot support.
+
+### Other open items
+
+- In-process coverage of the runtime decision surface is below the 100% this
+  project intends.
+- Public-beta pilots and human graduation approval are not available.
+- Protected release configuration is not active on the repository. The
+  `release` environment exists with no protection rules, no rulesets are
+  defined, and `main` is unprotected. A release published in this state is not
+  a protected release, and this document does not claim it is.
+
+## Rollback by host
+
+Each release is downloaded and extracted under its own
+`~/.kratos/releases/<version>` directory, so rolling back means pointing the
+host at the previous directory. Keep the previous release until the new one is
+accepted.
+
+### Claude Code
+
+```bash
+claude plugin uninstall kratos@kratos-open-source
+claude plugin marketplace remove kratos-open-source
+claude plugin marketplace add ~/.kratos/releases/v0.1.0/marketplace
+claude plugin install kratos@kratos-open-source
+```
+
+### Codex
+
+```bash
+codex plugin marketplace remove kratos-open-source
+codex plugin marketplace add ~/.kratos/releases/v0.1.0/marketplace
+```
+
+Then reinstall Kratos from `codex /plugins`. Codex publishes no CLI command for
+installing an individual plugin.
+
+### Antigravity
+
+```bash
+agy plugin uninstall kratos
+agy plugin install ~/.kratos/releases/v0.1.0/antigravity
+```
+
+`agy plugin disable kratos` suspends the plugin without removing it, which is
+the right first move while diagnosing a problem.
+
+### A note on rolling back to v0.1.0
+
+v0.1.0 published no `kratos-antigravity.tgz`, and its packages report
+`0.0.0-development`. A project initialized under v0.2.0 is not readable by the
+v0.1.0 runtime for the same reason the reverse is true. Roll back the plugin
+only together with the project state it wrote.
+
+### Staged installations
+
+For an installation managed by `scripts/install-plugin.mjs`, roll back with the
+retained verified copy instead:
+
+```bash
+node scripts/install-plugin.mjs rollback \
+  --host claude-code --target /absolute/plugin/directory/kratos
+```
+
+The installer keeps the replaced version until `commit` removes it, refuses a
+downgrade that would bypass this path, and quarantines rather than deletes on
+`uninstall`.
+
+## Verification performed
+
+- `npm ci` and `npm run verify` in a clean checkout, with the build written
+  outside the source tree.
+- Four archives built, rebuilt, and compared byte for byte.
+- `version` and `handshake --json` executed from each of the three installed
+  packages.
+
+Exact commands, outputs, and the GO/NO-GO decision are recorded in
+[the v0.2.0 release readiness report](../verification/v0.2.0-release-readiness.md).

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -163,9 +163,10 @@ refuses to review one as routine.
 
 Stated here rather than left for someone to discover:
 
-**SBOM, checksums, and build provenance.** `release.yml` creates a deterministic
-plugin archive, `SHA256SUMS`, a CycloneDX SBOM, and a GitHub build-provenance
-attestation. The workflow is executable, but a protected release environment
+**SBOM, checksums, and build provenance.** `release.yml` creates four
+deterministic plugin archives — the marketplace tree and one per host —
+`SHA256SUMS`, a CycloneDX SBOM, and a GitHub build-provenance attestation over
+every archive. The workflow is executable, but a protected release environment
 and published immutable release are external repository controls and therefore
 must still be evidenced before promotion. The exact source-side gates are
 documented in [release gates](../distribution/release-gates.md).

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -5,7 +5,12 @@
 - Node.js 24.18.0
 - npm 11.16.0
 - Git
-- Claude Code, Codex, or direct runtime use
+- Claude Code, Codex, Google Antigravity, or direct runtime use
+
+This page builds the packages from a checkout. To install the published
+packages from a GitHub release instead — with checksum and provenance
+verification, and the update, rollback, and uninstall commands for each host —
+see [Installing Kratos](../INSTALLATION.md).
 
 Build a clean checkout:
 
@@ -24,7 +29,9 @@ codex plugin marketplace add "$KRATOS_BUILD_OUTPUT"
 
 Install Kratos from `/plugins`, then start a new session. For Claude Code, use
 `claude plugin marketplace add "$KRATOS_BUILD_OUTPUT"` followed by
-`claude plugin install kratos@kratos-open-source`.
+`claude plugin install kratos@kratos-open-source`. Antigravity installs a
+plugin directory rather than a marketplace, so use
+`agy plugin install "$KRATOS_BUILD_OUTPUT/antigravity"`.
 
 Inside a Git project, initialize the managed surfaces and start a trail:
 

--- a/docs/verification/v0.2.0-release-readiness.md
+++ b/docs/verification/v0.2.0-release-readiness.md
@@ -49,6 +49,11 @@ Findings that shaped the work:
   project invented, so the package records its version in
   `runtime/manifest.json` instead, and package verification asserts the absence
   of the invented field rather than its presence.
+- **The Codex manifest carried no `author`.** The `plugin.json` specification
+  Codex's own plugin-creator ships lists `author` among the required top-level
+  fields, while the public builder documentation lists it as optional. Added,
+  along with `homepage` and `repository`, to both the Codex and the Claude Code
+  manifests; every one of those fields is documented by both hosts.
 - **No host documents installing a plugin from a GitHub release asset.** Claude
   Code has an `archive` source, but it accepts a zip over HTTPS referenced from
   a marketplace entry, not a release tarball. The documented path for all three

--- a/docs/verification/v0.2.0-release-readiness.md
+++ b/docs/verification/v0.2.0-release-readiness.md
@@ -1,0 +1,176 @@
+# v0.2.0 release readiness — GO/NO-GO
+
+- Verification date: 2026-09-01 (America/Sao_Paulo)
+- Branch: `release/v0.2.0-preparation`
+- Base commit: `ce924ec` (`main`)
+- Preparation commit: `ad06313`
+- Status: **NO-GO for publishing today.** GO for the source-side preparation.
+
+Nothing was tagged, pushed, or published, and no GitHub setting was changed.
+The blocking items below are repository configuration and human-driven tests
+that this branch cannot perform.
+
+## Decision
+
+| Gate | Verdict | Basis |
+| --- | --- | --- |
+| Version coherence across the distribution | GO | Every surface reports `0.2.0` |
+| Four archives, checksums, SBOM, attestations | GO | `release.yml` builds and attests all four |
+| Deterministic rebuild, byte-for-byte | GO | All four archives compared, locally and in the workflow |
+| Exact npm in CI | GO | Installed from the `package.json` pin in every npm workflow |
+| Installable in Codex | GO, unproven signed in | Documented local-marketplace path; no signed-in run |
+| Installable in Claude Code | GO, unproven signed in | Documented local-marketplace path; no signed-in run |
+| Installable in Antigravity | GO for the skill and runtime; NO-GO for hooks | `plugin.json` added; hook contract does not match the host |
+| Protected release configuration | **NO-GO** | No rulesets, no environment protection, `main` unprotected |
+| Behavioral parity | Disclosed at `0 / 400` | Unchanged by this release |
+| Signed-in host E2E | **Pending** | Requires authenticated sessions |
+| macOS and Windows | **Not validated** | The nightly matrix fails at `npm test` on both |
+
+Publishing is defensible only as an Experimental pre-release that states each
+of the open items. The proposed notes in
+[the v0.2.0 release notes](../releases/v0.2.0.md) state all of them.
+
+## Host distribution, checked against each host's own documentation
+
+| Host | Manifest the host requires | Present | Install source the host documents |
+| --- | --- | --- | --- |
+| Claude Code | `.claude-plugin/plugin.json`; marketplace at `.claude-plugin/marketplace.json` | Yes, version `0.2.0` | `claude plugin marketplace add <path or repo>`, then `claude plugin install <plugin>@<marketplace>` |
+| Codex | `.codex-plugin/plugin.json`; marketplace at `.agents/plugins/marketplace.json` | Yes, version `0.2.0` | `codex plugin marketplace add <path, owner/repo, or git URL>`, then install from `codex /plugins` |
+| Antigravity | `plugin.json` at the package root | Yes, added in this branch | `agy plugin install /path/to/local/plugin` |
+
+Findings that shaped the work:
+
+- **Antigravity had no manifest at all.** Antigravity requires `plugin.json` at
+  the package root as the marker that a directory is a plugin. The build
+  produced an Antigravity package without one, so the host had nothing to
+  identify. Added.
+- **Antigravity documents no version field.** Its manifest carries `name`,
+  `description`, and `$schema`. Adding a `version` would be a field this
+  project invented, so the package records its version in
+  `runtime/manifest.json` instead, and package verification asserts the absence
+  of the invented field rather than its presence.
+- **No host documents installing a plugin from a GitHub release asset.** Claude
+  Code has an `archive` source, but it accepts a zip over HTTPS referenced from
+  a marketplace entry, not a release tarball. The documented path for all three
+  hosts is therefore: download the release asset, verify it, extract it, and
+  point the host at the extracted directory. That is what
+  [Installing Kratos](../INSTALLATION.md) documents.
+- **Codex publishes no CLI command for installing an individual plugin.** It
+  documents `codex plugin marketplace add|list|upgrade|remove`, and the plugin
+  browser `codex /plugins` for install and enable. The documentation says so
+  rather than inventing a command.
+
+### Antigravity hooks: NO-GO, disclosed
+
+Antigravity reads plugin hooks from `hooks.json` **at the package root** and
+documents the events `PreToolUse`, `PostToolUse`, `PreInvocation`,
+`PostInvocation`, and `Stop`. The Kratos distribution writes `hooks/hooks.json`
+and declares `PostToolUseFailure` and `SessionEnd`, and every rendered hook
+command interpolates `${CLAUDE_PLUGIN_ROOT}`, which Antigravity does not
+document. The Antigravity adapter also normalizes `tool_name` / `tool_input`,
+while Antigravity's documented `PreToolUse` payload is `toolCall.name` /
+`toolCall.args`.
+
+Making those agree is a behavioral change to the hook contract with its own
+tests and its own evidence, not a release chore. This branch does not attempt
+it, and the release notes state that Antigravity hooks are not claimed. The
+Antigravity package ships the Kratos skill and the embedded runtime, which are
+what `npm run package:verify` exercises.
+
+## Version coherence
+
+| Surface | Value |
+| --- | --- |
+| `package.json` and all four workspaces | `0.2.0` |
+| `package-lock.json` | `0.2.0` |
+| `KRATOS_VERSION` (`packages/contracts/src/version.ts`) | `0.2.0` |
+| `packages/runtime/src/domain/prompt-ceilings/discovery.ts` | `0.2.0` |
+| `contract-families.v1.json` `pluginVersion` | `0.2.0` |
+| `schemas/**` `pluginVersion` constants | `0.2.0` |
+| `fixtures/contracts/**` | `0.2.0` |
+| Codex `plugin.json` | `0.2.0` |
+| Claude Code `plugin.json` | `0.2.0` |
+| Antigravity `plugin.json` | no version field by design |
+| Built `runtime/manifest.json` (all three hosts) | `0.2.0` |
+| `kratos version` from each installed package | `0.2.0` |
+
+Other contract families are unchanged: contract `1.0.0`, result `1.0.0`, reason
+catalog `1.11.0`, state `1.4.0`, host `1.4.0`, 68 registered schemas.
+
+### The one contract-visible consequence
+
+`pluginVersion` is the identity of one coherent installed bundle, not a
+per-schema historical record: `classifyContractVersion("plugin", …)` accepts
+exactly the current value, and every configuration upgrade carries the field
+forward unchanged. Moving it therefore moves it in every schema at once,
+including superseded schema versions whose bytes are frozen by
+`tests/contract-schemas.test.ts`. Seven frozen digests and one more in
+`tests/acceptance-criterion-contracts.test.ts` were updated, and the test now
+carries a comment explaining why they move together. Nothing else in those
+files changed.
+
+Measured effect on a project written by the v0.1.0 package, whose
+`.brain/config.json` records `pluginVersion: "0.0.0-development"`:
+
+```text
+$ kratos doctor --json --root <legacy project>
+{"status":"blocked","exitCode":4,"reasonCode":"runtime.state_corrupt",
+ "why":[… "The authoritative project configuration is invalid." …]}
+```
+
+`status`, `objective`, and `audit` still answer on the same project, so the
+failure is partial and only `doctor` reports it. The release notes say so, and
+the supported path is re-initialization.
+
+## Release workflow
+
+`.github/workflows/release.yml` now:
+
+- installs the exact npm release pinned in `package.json` before `npm ci`;
+- builds `kratos-marketplace.tgz`, `kratos-codex.tgz`, `kratos-claude-code.tgz`,
+  and `kratos-antigravity.tgz`;
+- writes `SHA256SUMS` from inside `release/`, so `sha256sum --check SHA256SUMS`
+  works unchanged after download;
+- emits `sbom.cdx.json` with `npm sbom --sbom-format cyclonedx`;
+- rebuilds and `cmp`s **all four** archives, not three;
+- attests every archive with `actions/attest-build-provenance`;
+- publishes as a pre-release on a verified `v*` tag.
+
+## Clean-checkout verification
+
+See [the recorded run](#recorded-run) below.
+
+## What must happen outside this repository
+
+These are repository settings. They cannot be changed from a branch, and this
+work did not change them.
+
+1. **`release` environment protection.** The environment exists and has zero
+   protection rules. Add required reviewers, and restrict deployment branches
+   and tags to the release line. Until then, naming the environment in the
+   workflow protects nothing.
+2. **Repository rulesets.** `GET /repos/thiagocorreanet/kratos-harness/rulesets`
+   returns `[]`. `docs/distribution/release-gates.md` requires rules for pull
+   requests, CI, DCO, dependency review, CodeQL, up-to-date review, and blocked
+   force pushes and deletions.
+3. **Branch protection on `main`.** `GET …/branches/main/protection` returns
+   `404 Branch not protected`.
+4. **Attestation readability.** Confirm that `gh attestation verify` succeeds
+   against a published asset once a release exists; it cannot be exercised
+   before publication.
+
+## What needs a human
+
+1. **Signed-in E2E in Codex.** Add the marketplace, install from `/plugins`,
+   run the documented trail in a real project, confirm the hooks fire.
+2. **Signed-in E2E in Claude Code.** Same, through
+   `claude plugin marketplace add` and `claude plugin install`.
+3. **Signed-in E2E in Antigravity.** `agy plugin install`, confirm the skill
+   loads. Hooks are expected not to fire; record what actually happens.
+4. **macOS and Windows.** The nightly matrix fails at `npm test` on both. Either
+   fix the fixtures or state the supported platform as Linux only.
+5. **Authorization to tag and publish.** No tag exists, nothing was pushed.
+
+## Recorded run
+
+Recorded below after execution.

--- a/docs/verification/v0.2.0-release-readiness.md
+++ b/docs/verification/v0.2.0-release-readiness.md
@@ -3,7 +3,7 @@
 - Verification date: 2026-09-01 (America/Sao_Paulo)
 - Branch: `release/v0.2.0-preparation`
 - Base commit: `ce924ec` (`main`)
-- Preparation commit: `ad06313`
+- Verified commit: `35513ff`
 - Status: **NO-GO for publishing today.** GO for the source-side preparation.
 
 Nothing was tagged, pushed, or published, and no GitHub setting was changed.
@@ -141,10 +141,6 @@ the supported path is re-initialization.
 - attests every archive with `actions/attest-build-provenance`;
 - publishes as a pre-release on a verified `v*` tag.
 
-## Clean-checkout verification
-
-See [the recorded run](#recorded-run) below.
-
 ## What must happen outside this repository
 
 These are repository settings. They cannot be changed from a branch, and this
@@ -178,4 +174,53 @@ work did not change them.
 
 ## Recorded run
 
-Recorded below after execution.
+A fresh clone of `release/v0.2.0-preparation` at `35513ff`, with the build
+written outside the source tree and npm installed from the `package.json` pin.
+
+| Step | Result |
+| --- | --- |
+| `npm ci` | PASS, 270 packages from the lockfile |
+| `npm run verify` | PASS, every gate |
+| Four archives built, rebuilt, `cmp` | PASS, all four byte-identical |
+| `sha256sum --check SHA256SUMS` | PASS, four archives |
+| `version` and `handshake --json` per package | PASS, all three report `0.2.0` |
+
+Gate detail from that run:
+
+| Gate | Result |
+| --- | --- |
+| Format, spelling, English-only, lint, type-check | Pass |
+| Unit tests | 5,545 passed, 233 files |
+| Coverage | 91.97% statements, 87.17% branches, 95.95% functions, 93.11% lines |
+| Mutation sentinels | 4 / 4 (100%) |
+| Gap calibration | 10 planted found, 0 missed, 0 false positives |
+| Go v3 oracle | Public catalog verified: 12 surfaces, 4 PRD anchors, 3 binaries |
+| Parity inventory | **0 / 400** (P0 0 / 211, P1 0 / 174) |
+| Result contract | v1.0.0 verified: 76 reasons, exits 0-5, 6 examples |
+| Contract schemas | 329,513 / 330,000 bytes |
+| Differential self-test | Equal on 12 planned scenarios |
+| Prompt ceilings | All pass |
+| Build and package verification | Pass for Codex, Claude Code, and Antigravity |
+| Benchmarks | help p95 141ms, version p95 137ms, handshake p95 133ms, bundle 2,072,666 bytes |
+
+Archive digests from that build:
+
+```text
+2914c6d0a6581428f804c7eabbcffc9d7c5e05091a602432f7ca319e367ab9b3  kratos-antigravity.tgz
+e2dd3deb29df64dafbb365a895509e8755b5ac547a9ad342cd7f5211b592201b  kratos-claude-code.tgz
+02c109aff1fb8be11efa165c5038b8f0502abac22709386639231fa1ccd85b97  kratos-codex.tgz
+23745a8c6035b0c54aec8dc4f44433fb73a924c99770aad31152d929e7e15ba2  kratos-marketplace.tgz
+```
+
+Those digests are from this machine's build, not from a release. The release
+job produces its own, and only the digests it publishes alongside the archives
+are authoritative.
+
+Two deviations from the CI toolchain, both recorded rather than hidden: the run
+used Node.js `v24.19.0` rather than the `v24.18.0` that `.nvmrc` pins and CI
+asserts, and the local test count is 5,545 rather than 5,547 because two tests
+in an uncommitted working-tree file are absent from the clone.
+
+Everything the release workflow does that this run cannot reproduce — the
+provenance attestations, the GitHub release, and the `release` environment —
+remains unexercised until a tag is pushed.

--- a/fixtures/contracts/v1.1/project-config.json
+++ b/fixtures/contracts/v1.1/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.1.0",
   "stateContract": "1.1.0",
-  "pluginVersion": "0.0.0-development",
+  "pluginVersion": "0.2.0",
   "hostContract": "1.1.0",
   "language": "en",
   "policyMode": "strict",

--- a/fixtures/contracts/v1.2/project-config.json
+++ b/fixtures/contracts/v1.2/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.2.0",
   "stateContract": "1.2.0",
-  "pluginVersion": "0.0.0-development",
+  "pluginVersion": "0.2.0",
   "hostContract": "1.2.0",
   "language": {
     "conversation": "pt-BR",

--- a/fixtures/contracts/v1.3/compatibility-window.json
+++ b/fixtures/contracts/v1.3/compatibility-window.json
@@ -1,5 +1,5 @@
 {
-  "pluginVersion": "0.0.0-development",
+  "pluginVersion": "0.2.0",
   "stateContract": {
     "readable": ["1.0.0", "1.1.0", "1.2.0", "1.3.0"],
     "migrationOnly": ["0.9.0", "go-v3@0.6.5"]

--- a/fixtures/contracts/v1.3/project-config.json
+++ b/fixtures/contracts/v1.3/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.3.0",
   "stateContract": "1.3.0",
-  "pluginVersion": "0.0.0-development",
+  "pluginVersion": "0.2.0",
   "hostContract": "1.3.0",
   "language": {
     "conversation": "en",

--- a/fixtures/contracts/v1.4/project-config.json
+++ b/fixtures/contracts/v1.4/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.4.0",
   "stateContract": "1.4.0",
-  "pluginVersion": "0.0.0-development",
+  "pluginVersion": "0.2.0",
   "hostContract": "1.4.0",
   "language": {
     "conversation": "en",

--- a/fixtures/contracts/v1/project-config.json
+++ b/fixtures/contracts/v1/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.0.0",
   "stateContract": "1.0.0",
-  "pluginVersion": "0.0.0-development",
+  "pluginVersion": "0.2.0",
   "hostContract": "1.0.0",
   "language": "en",
   "policyMode": "strict",

--- a/fixtures/contracts/v1/version-cases.json
+++ b/fixtures/contracts/v1/version-cases.json
@@ -2,7 +2,7 @@
   {
     "name": "plugin current",
     "family": "plugin",
-    "value": "0.0.0-development",
+    "value": "0.2.0",
     "classification": "current",
     "reasonCode": null
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kratos-harness",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kratos-harness",
-      "version": "0.0.0-development",
+      "version": "0.2.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4383,28 +4383,28 @@
     },
     "packages/adapters": {
       "name": "@kratos/adapters",
-      "version": "0.0.0-development",
+      "version": "0.2.0",
       "dependencies": {
-        "@kratos/contracts": "0.0.0-development"
+        "@kratos/contracts": "0.2.0"
       }
     },
     "packages/contracts": {
       "name": "@kratos/contracts",
-      "version": "0.0.0-development"
+      "version": "0.2.0"
     },
     "packages/differential": {
       "name": "@kratos/differential",
-      "version": "0.0.0-development",
+      "version": "0.2.0",
       "dependencies": {
         "ajv": "8.20.0"
       }
     },
     "packages/runtime": {
       "name": "@kratos/runtime",
-      "version": "0.0.0-development",
+      "version": "0.2.0",
       "dependencies": {
-        "@kratos/adapters": "0.0.0-development",
-        "@kratos/contracts": "0.0.0-development",
+        "@kratos/adapters": "0.2.0",
+        "@kratos/contracts": "0.2.0",
         "ajv": "8.20.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos-harness",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "packageManager": "npm@11.16.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@kratos/adapters",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",
   "dependencies": {
-    "@kratos/contracts": "0.0.0-development"
+    "@kratos/contracts": "0.2.0"
   }
 }

--- a/packages/contracts/catalogs/contract-families.v1.json
+++ b/packages/contracts/catalogs/contract-families.v1.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1.0.0",
-  "pluginVersion": "0.0.0-development",
+  "pluginVersion": "0.2.0",
   "resultContract": "1.0.0",
   "reasonCatalog": "1.11.0",
   "stateContract": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kratos/contracts",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts"

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -53,11 +53,11 @@
 // source: https://kratos.dev/schemas/state/migration/v1.1 sha256:4223e8c4d4f69d60453edc2aaa880f0b0d04fdfea435ea45e378abff0d6aea38
 // source: https://kratos.dev/schemas/state/narration/v1 sha256:b3d99195b1792dbfb6d0d693f24fcfc546f0993c9fafcce4d873218aa7058e5f
 // source: https://kratos.dev/schemas/state/phase-measurement/v1 sha256:c783ccba225a9cd283460d11f9f1b590195c70ddcc8af28bf2bd891014888548
-// source: https://kratos.dev/schemas/state/project-config/v1 sha256:0471230187a6ee726fdd26c68f524c9649730765b9962b3668c0eeccd3580fbf
-// source: https://kratos.dev/schemas/state/project-config/v1.1 sha256:ce578e418cb03d4c25219f5d81de7fec81c19f03c8bc961d1cfe9cbb1778d4a4
-// source: https://kratos.dev/schemas/state/project-config/v1.2 sha256:27a694a7e337aab5f9e0811f47af7876a24519599278ba11e991f246bc9d3495
-// source: https://kratos.dev/schemas/state/project-config/v1.3 sha256:7c895a22950cc7f7b02f2fdac57d7553bf08138e65ef1510307073b3f92e3c3b
-// source: https://kratos.dev/schemas/state/project-config/v1.4 sha256:2a1681a6231b74735ad73f8f8dab4d29869c3c4b5c89577945d5aa47637eeeb9
+// source: https://kratos.dev/schemas/state/project-config/v1 sha256:989427d7680941436b09a8ce7786f43a55131498bec82e74b171a44d5a16056d
+// source: https://kratos.dev/schemas/state/project-config/v1.1 sha256:246c84c839d0cf4c5b5b5eca10eb900e3d468feb38633850bf8cab406292b297
+// source: https://kratos.dev/schemas/state/project-config/v1.2 sha256:3f3f7f0fd5a2be574fcb8a15096ebaf75b515a1283df4e848cf41fb9098b43f9
+// source: https://kratos.dev/schemas/state/project-config/v1.3 sha256:4dd74aff09e68f1c3d121e535cae355c3bcca408c998b9fa4296aef3c70534b6
+// source: https://kratos.dev/schemas/state/project-config/v1.4 sha256:c112c4bbec84b108cbae589a8ad2dd097cbb1c23773046fbc4fe136a246cc134
 // source: https://kratos.dev/schemas/state/requirement-discovery/v1 sha256:7974861ace6571c08cc3cee2921715f06800e48fb5ee9767cdcf45c0dc4354b4
 // source: https://kratos.dev/schemas/state/repair-loop-stop/v1 sha256:bf18ca66a29e1615e4714bcc081b8d41257cd553d9e3466d26846ce7d441d21b
 // source: https://kratos.dev/schemas/state/repair-loop-stop/v1.1 sha256:8dde526faeb7bc240f31e6edef90f6c2670e166dad0b75cda25ab58734386124
@@ -4456,7 +4456,7 @@ export namespace ProjectConfigV1Contract {
   export interface ProjectConfigV1 {
     contractVersion: "1.0.0";
     stateContract: "1.0.0";
-    pluginVersion: "0.0.0-development";
+    pluginVersion: "0.2.0";
     hostContract: "1.0.0";
     language: "en" | "pt-BR";
     policyMode: "standard" | "strict";
@@ -4480,7 +4480,7 @@ export namespace ProjectConfigV1_1Contract {
   export interface ProjectConfigV1_1 {
     contractVersion: "1.1.0";
     stateContract: "1.1.0";
-    pluginVersion: "0.0.0-development";
+    pluginVersion: "0.2.0";
     hostContract: "1.1.0";
     language: "en" | "pt-BR";
     policyMode: "standard" | "strict";
@@ -4515,7 +4515,7 @@ export namespace ProjectConfigV1_2Contract {
   export interface ProjectConfigV1_2 {
     contractVersion: "1.2.0";
     stateContract: "1.2.0";
-    pluginVersion: "0.0.0-development";
+    pluginVersion: "0.2.0";
     hostContract: "1.2.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4570,7 +4570,7 @@ export namespace ProjectConfigV1_3Contract {
   export interface ProjectConfigV1_3 {
     contractVersion: "1.3.0";
     stateContract: "1.3.0";
-    pluginVersion: "0.0.0-development";
+    pluginVersion: "0.2.0";
     hostContract: "1.3.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4677,7 +4677,7 @@ export namespace ProjectConfigV1_4Contract {
   export interface ProjectConfigV1_4 {
     contractVersion: "1.4.0";
     stateContract: "1.4.0";
-    pluginVersion: "0.0.0-development";
+    pluginVersion: "0.2.0";
     hostContract: "1.4.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";

--- a/packages/contracts/src/version.ts
+++ b/packages/contracts/src/version.ts
@@ -1,1 +1,1 @@
-export const KRATOS_VERSION = "0.0.0-development";
+export const KRATOS_VERSION = "0.2.0";

--- a/packages/differential/package.json
+++ b/packages/differential/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kratos/differential",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kratos/runtime",
-  "version": "0.0.0-development",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -60,8 +60,8 @@
     "./ports": "./src/ports/index.ts"
   },
   "dependencies": {
-    "@kratos/adapters": "0.0.0-development",
-    "@kratos/contracts": "0.0.0-development",
+    "@kratos/adapters": "0.2.0",
+    "@kratos/contracts": "0.2.0",
     "ajv": "8.20.0"
   }
 }

--- a/packages/runtime/src/domain/prompt-ceilings/discovery.ts
+++ b/packages/runtime/src/domain/prompt-ceilings/discovery.ts
@@ -7,7 +7,7 @@ import {
 } from "../init/managed-section.ts";
 import type { PromptCategory } from "./model.ts";
 
-const KRATOS_VERSION = "0.0.0-development";
+const KRATOS_VERSION = "0.2.0";
 
 export interface ShippedPromptSurface {
   readonly id: string;

--- a/schemas/contracts/contract-manifest.v1.1.schema.json
+++ b/schemas/contracts/contract-manifest.v1.1.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.0.0-development"
+      "const": "0.2.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.2.schema.json
+++ b/schemas/contracts/contract-manifest.v1.2.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.0.0-development"
+      "const": "0.2.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.3.schema.json
+++ b/schemas/contracts/contract-manifest.v1.3.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.8.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.4.schema.json
+++ b/schemas/contracts/contract-manifest.v1.4.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.0.0-development"
+      "const": "0.2.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.5.schema.json
+++ b/schemas/contracts/contract-manifest.v1.5.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.0.0-development"
+      "const": "0.2.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.6.schema.json
+++ b/schemas/contracts/contract-manifest.v1.6.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.0.0-development"
+      "const": "0.2.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.7.schema.json
+++ b/schemas/contracts/contract-manifest.v1.7.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.11.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.8.schema.json
+++ b/schemas/contracts/contract-manifest.v1.8.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.11.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.9.schema.json
+++ b/schemas/contracts/contract-manifest.v1.9.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.11.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.schema.json
+++ b/schemas/contracts/contract-manifest.v1.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.0.0-development"
+      "const": "0.2.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/state/project-config.v1.1.schema.json
+++ b/schemas/state/project-config.v1.1.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "contractVersion": { "const": "1.1.0" },
     "stateContract": { "const": "1.1.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "hostContract": { "const": "1.1.0" },
     "language": { "enum": ["en", "pt-BR"] },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.2.schema.json
+++ b/schemas/state/project-config.v1.2.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "contractVersion": { "const": "1.2.0" },
     "stateContract": { "const": "1.2.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "hostContract": { "const": "1.2.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.3.schema.json
+++ b/schemas/state/project-config.v1.3.schema.json
@@ -18,7 +18,7 @@
   "properties": {
     "contractVersion": { "const": "1.3.0" },
     "stateContract": { "const": "1.3.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "hostContract": { "const": "1.3.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.4.schema.json
+++ b/schemas/state/project-config.v1.4.schema.json
@@ -19,7 +19,7 @@
   "properties": {
     "contractVersion": { "const": "1.4.0" },
     "stateContract": { "const": "1.4.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "hostContract": { "const": "1.4.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.schema.json
+++ b/schemas/state/project-config.v1.schema.json
@@ -16,7 +16,7 @@
   "properties": {
     "contractVersion": { "const": "1.0.0" },
     "stateContract": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.0.0-development" },
+    "pluginVersion": { "const": "0.2.0" },
     "hostContract": { "const": "1.0.0" },
     "language": { "enum": ["en", "pt-BR"] },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -224,23 +224,35 @@ async function verifyArtifact(root, host) {
     fail(`${host} host assets digest is wrong`);
   }
 
+  // Every host requires its own manifest at the location its documentation
+  // names: `.codex-plugin/plugin.json` for Codex, `.claude-plugin/plugin.json`
+  // for Claude Code, and `plugin.json` at the plugin root for Antigravity.
+  // Without it the host does not recognize the directory as a plugin at all.
   const hostManifestPath =
     host === "codex"
       ? join(root, ".codex-plugin/plugin.json")
       : host === "claude-code"
         ? join(root, ".claude-plugin/plugin.json")
-        : null;
-  if (hostManifestPath !== null) {
-    const hostManifest = JSON.parse(await readFile(hostManifestPath, "utf8"));
-    if (
-      hostManifest.name !== "kratos" ||
-      hostManifest.version !== manifest.pluginVersion
-    ) {
-      fail(`${host} host manifest is not version coherent`);
-    }
-    if (host === "codex" && hostManifest.skills !== "./skills/") {
-      fail("Codex manifest does not expose the Kratos skill");
-    }
+        : join(root, "plugin.json");
+  const hostManifest = JSON.parse(await readFile(hostManifestPath, "utf8"));
+  if (hostManifest.name !== "kratos") {
+    fail(`${host} host manifest does not identify the Kratos plugin`);
+  }
+  // Antigravity's documented manifest carries `name`, `description`, and
+  // `$schema` and no version field, so the installed version is read from
+  // `runtime/manifest.json` there. Inventing a field the host does not
+  // document would be a manifest this project made up.
+  if (
+    host !== "antigravity" &&
+    hostManifest.version !== manifest.pluginVersion
+  ) {
+    fail(`${host} host manifest is not version coherent`);
+  }
+  if (host === "antigravity" && hostManifest.version !== undefined) {
+    fail("Antigravity manifest declares an undocumented version field");
+  }
+  if (host === "codex" && hostManifest.skills !== "./skills/") {
+    fail("Codex manifest does not expose the Kratos skill");
   }
   const skillBridge = join(root, "skills/kratos/scripts/kratos.mjs");
   const bridge = await readFile(skillBridge, "utf8");

--- a/tests/acceptance-criterion-contracts.test.ts
+++ b/tests/acceptance-criterion-contracts.test.ts
@@ -77,10 +77,10 @@ describe("acceptance criterion contracts", () => {
       "7d95ea2c2541c12b8e960094bb3bd197b35f5f55ffd6412581449efacde54d3a",
     );
     expect(createHash("sha256").update(manifestV1).digest("hex")).toBe(
-      "0de8cb9096adbe984b729cb511d57f8c9aa0e3f50f6ec09b9bc39cf5b022cff6",
+      "a87dd52092ee34eb3d0a1e182f10481c87a83111f104607c2a5df378a431e629",
     );
     expect(createHash("sha256").update(manifestV11).digest("hex")).toBe(
-      "7693411838fa4629ca524fd0053de08372201d2d3ffd44e9e2e3c69f5d91d9bf",
+      "ec050850bcf9cb584bee1f27a047891d3ed60236a36be3c7bb586fad7cea281e",
     );
   });
 

--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -62,7 +62,7 @@ describe("standalone runtime package", () => {
       const result = execute(host, "--version");
 
       expect(result.status).toBe(0);
-      expect(result.stdout).toBe("0.0.0-development\n");
+      expect(result.stdout).toBe("0.2.0\n");
       expect(result.stderr).toBe("");
     },
   );

--- a/tests/ci-workflow-contract.test.ts
+++ b/tests/ci-workflow-contract.test.ts
@@ -88,6 +88,7 @@ describe("pull-request CI workflow", () => {
       "Checkout",
       "Set up exact Node.js",
       "Prepare diagnostics",
+      "Pin the exact npm release",
       "Verify exact toolchain",
       "Install locked dependencies",
       "Check formatting",
@@ -162,8 +163,9 @@ describe("pull-request CI workflow", () => {
     const jobs = object(workflow.jobs, "jobs");
     const quality = object(jobs.quality, "quality");
     const steps = quality.steps as JsonObject[];
-    const commandSteps = steps.slice(3, 18);
+    const commandSteps = steps.slice(3, 19);
     const expectedCommands = [
+      'npm install --global --no-audit --no-fund "npm@$pinned"',
       "node --version",
       "npm ci",
       "npm run format:check",
@@ -190,7 +192,16 @@ describe("pull-request CI workflow", () => {
       );
     }
 
-    const toolchain = String(commandSteps[0]?.run);
+    // The pin installs the npm `package.json` names; the check that follows
+    // then observes what is actually on PATH. Asserting only the second one is
+    // what let a runner image decide the package manager version.
+    const pin = String(commandSteps[0]?.run);
+    expect(pin).toContain(
+      'require("./package.json").packageManager.split("@")[1]',
+    );
+    expect(pin).toContain('test "$pinned" = "11.16.0"');
+
+    const toolchain = String(commandSteps[1]?.run);
     expect(toolchain).toContain('test "$node_version" = "v24.18.0"');
     expect(toolchain).toContain('test "$npm_version" = "11.16.0"');
   });

--- a/tests/cli-retired.test.ts
+++ b/tests/cli-retired.test.ts
@@ -62,8 +62,8 @@ describe("retired phase commands", () => {
     for (const argv of [
       ["--json", name],
       [name, "--json"],
-      ["--expect", "0.0.0-development", name],
-      [name, "--expect", "0.0.0-development"],
+      ["--expect", "0.2.0", name],
+      [name, "--expect", "0.2.0"],
     ]) {
       const { decision, failure } = invoke(argv);
       expect(failure, argv.join(" ")).toBeNull();

--- a/tests/config-migration.test.ts
+++ b/tests/config-migration.test.ts
@@ -49,7 +49,7 @@ const SNAPSHOT_REF = ".brain/02-features/sample-feature/runs/run-01/state.json";
 const LEGACY_CONFIG: ProjectConfigV1 = {
   contractVersion: "1.0.0",
   stateContract: "1.0.0",
-  pluginVersion: "0.0.0-development",
+  pluginVersion: "0.2.0",
   hostContract: "1.0.0",
   language: "pt-BR",
   policyMode: "strict",
@@ -278,7 +278,7 @@ describe("configuration migration", () => {
     const source: ProjectConfigV1_3 = {
       contractVersion: "1.3.0",
       stateContract: "1.3.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.3.0",
       language: {
         conversation: "en",
@@ -340,7 +340,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -382,7 +382,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -456,7 +456,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -516,7 +516,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -588,7 +588,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.1.0",
       language: "en",
       policyMode: "standard",
@@ -633,7 +633,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.1.0",
       language: "en",
       policyMode: "standard",
@@ -692,7 +692,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -778,7 +778,7 @@ describe("configuration migration", () => {
     const legacy: ProjectConfigV1_1 = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.1.0",
       language: "pt-BR",
       policyMode: "standard",
@@ -807,7 +807,7 @@ describe("configuration migration", () => {
     const legacy: ProjectConfigV1_1 = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.1.0",
       language: "en",
       policyMode: "standard",
@@ -865,7 +865,7 @@ describe("configuration migration", () => {
     const legacy1_1: ProjectConfigV1_1 = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.1.0",
       language: "pt-BR",
       policyMode: "standard",
@@ -893,7 +893,7 @@ describe("configuration migration", () => {
     expect(JSON.parse(after[CONFIG_REF] ?? "null")).toEqual({
       contractVersion: "1.4.0",
       stateContract: "1.4.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.4.0",
       gateModes: {},
       language: {

--- a/tests/contract-manifest.test.ts
+++ b/tests/contract-manifest.test.ts
@@ -106,7 +106,7 @@ describe("contract family manifest", () => {
   it("publishes exact independent compatibility windows", () => {
     expect(manifest).toMatchObject({
       contractVersion: "1.0.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       resultContract: "1.0.0",
       reasonCatalog: "1.11.0",
       stateContract: {

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -235,7 +235,7 @@ describe("versioned state and host schemas", () => {
     const project = {
       contractVersion: "1.4.0",
       stateContract: "1.4.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.4.0",
       language: {
         conversation: "en",
@@ -336,7 +336,7 @@ describe("versioned state and host schemas", () => {
     const project = {
       contractVersion: "1.3.0",
       stateContract: "1.3.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.3.0",
       language: {
         conversation: "en",
@@ -472,7 +472,7 @@ describe("versioned state and host schemas", () => {
     const baseProject12 = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -664,10 +664,18 @@ describe("versioned state and host schemas", () => {
     }
   });
 
+  // These digests freeze a superseded schema so an edit to it has to be
+  // deliberate. `pluginVersion` is the one field they all pin to a single
+  // value, because the contract model treats it as the identity of one
+  // coherent installed bundle rather than a per-schema historical record:
+  // `classifyContractVersion("plugin", ...)` accepts exactly the current
+  // value and every configuration upgrade carries the field forward
+  // unchanged. Releasing 0.2.0 therefore moves it in every schema at once,
+  // and these digests move with it. Nothing else about these files changed.
   it.each([
     [
       "state/project-config.v1.schema.json",
-      "0471230187a6ee726fdd26c68f524c9649730765b9962b3668c0eeccd3580fbf",
+      "989427d7680941436b09a8ce7786f43a55131498bec82e74b171a44d5a16056d",
     ],
     [
       "state/event.v1.schema.json",
@@ -683,15 +691,15 @@ describe("versioned state and host schemas", () => {
     ],
     [
       "contracts/contract-manifest.v1.1.schema.json",
-      "7693411838fa4629ca524fd0053de08372201d2d3ffd44e9e2e3c69f5d91d9bf",
+      "ec050850bcf9cb584bee1f27a047891d3ed60236a36be3c7bb586fad7cea281e",
     ],
     [
       "contracts/contract-manifest.v1.2.schema.json",
-      "cc681c74f36da960791a0e5a79d8f5eca96a246dc59da244fc91992620ec8f78",
+      "4fd2411deadcda1d1012eacbd6036a3b950b58256df0ded745bd84497e4458b3",
     ],
     [
       "contracts/contract-manifest.v1.8.schema.json",
-      "e4333d7f6d0a5378dd4fdb0d79f9b42c14c05a87f017bab451560c393560e7bd",
+      "8b1783ad5fbeff14a41240273327d5f45821af68f5785104b3f17e7513506e9f",
     ],
     [
       "host/adapter-message.v1.1.schema.json",
@@ -723,15 +731,15 @@ describe("versioned state and host schemas", () => {
     ],
     [
       "state/project-config.v1.1.schema.json",
-      "ce578e418cb03d4c25219f5d81de7fec81c19f03c8bc961d1cfe9cbb1778d4a4",
+      "246c84c839d0cf4c5b5b5eca10eb900e3d468feb38633850bf8cab406292b297",
     ],
     [
       "state/project-config.v1.2.schema.json",
-      "27a694a7e337aab5f9e0811f47af7876a24519599278ba11e991f246bc9d3495",
+      "3f3f7f0fd5a2be574fcb8a15096ebaf75b515a1283df4e848cf41fb9098b43f9",
     ],
     [
       "state/project-config.v1.3.schema.json",
-      "7c895a22950cc7f7b02f2fdac57d7553bf08138e65ef1510307073b3f92e3c3b",
+      "4dd74aff09e68f1c3d121e535cae355c3bcca408c998b9fa4296aef3c70534b6",
     ],
   ])("keeps the published %s schema byte-identical", async (path, digest) => {
     const bytes = await readFile(join(schemaRoot, path));
@@ -1023,7 +1031,7 @@ describe("versioned state and host schemas", () => {
       ({ fixtureName }) => fixtureName === "project-config.json",
     )?.fixture;
     expect(projectConfig).toMatchObject({
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       stateContract: "1.0.0",
       hostContract: "1.0.0",
     });

--- a/tests/migration-observability.test.ts
+++ b/tests/migration-observability.test.ts
@@ -95,7 +95,7 @@ describe("transactional migration lifecycle", () => {
       {
         contractVersion: "1.0.0",
         stateContract: "1.0.0",
-        pluginVersion: "0.0.0-development",
+        pluginVersion: "0.2.0",
         hostContract: "1.0.0",
         language: "pt-BR",
         policyMode: "strict",
@@ -117,7 +117,7 @@ describe("transactional migration lifecycle", () => {
     expect(upgraded).toEqual({
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.0.0-development",
+      pluginVersion: "0.2.0",
       hostContract: "1.2.0",
       language: {
         conversation: "pt-BR",

--- a/tests/package-boundaries.test.ts
+++ b/tests/package-boundaries.test.ts
@@ -39,7 +39,7 @@ describe("distribution boundaries", () => {
         encoding: "utf8",
       });
 
-    expect(run(first)).toBe("0.0.0-development\n");
+    expect(run(first)).toBe("0.2.0\n");
     expect(run(second)).toBe(run(first));
     expect(await readdir(first)).toEqual([]);
     expect(await readdir(second)).toEqual([]);
@@ -57,6 +57,6 @@ describe("distribution boundaries", () => {
         [join(installed, "runtime/kratos.mjs"), "--version"],
         { cwd: await project(), encoding: "utf8" },
       ),
-    ).toBe("0.0.0-development\n");
+    ).toBe("0.2.0\n");
   });
 });

--- a/tests/project-configuration.test.ts
+++ b/tests/project-configuration.test.ts
@@ -18,7 +18,7 @@ import { createSchemaRegistry } from "@kratos/runtime/composition/schema";
 const validConfiguration: ProjectConfigV1_4 = {
   contractVersion: "1.4.0",
   stateContract: "1.4.0",
-  pluginVersion: "0.0.0-development",
+  pluginVersion: "0.2.0",
   hostContract: "1.4.0",
   language: {
     conversation: "en",

--- a/tests/project-discovery-composition.test.ts
+++ b/tests/project-discovery-composition.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from "vitest";
 const configuration: ProjectConfigV1_4 = {
   contractVersion: "1.4.0",
   stateContract: "1.4.0",
-  pluginVersion: "0.0.0-development",
+  pluginVersion: "0.2.0",
   hostContract: "1.4.0",
   language: {
     conversation: "en",

--- a/tests/result-envelope.test.ts
+++ b/tests/result-envelope.test.ts
@@ -29,10 +29,10 @@ describe("result envelope", () => {
 
   it("carries a caller summary without changing catalog policy", () => {
     const result = resultFor("runtime.orientation_ok", {
-      summary: "Runtime version 0.0.0-development.",
+      summary: "Runtime version 0.2.0.",
     });
 
-    expect(result.summary).toBe("Runtime version 0.0.0-development.");
+    expect(result.summary).toBe("Runtime version 0.2.0.");
     expect(result.exitCode).toBe(0);
     expect(result.recovery).toBeNull();
     expect(result.stateChanged).toBe(false);

--- a/tests/result-rendering.test.ts
+++ b/tests/result-rendering.test.ts
@@ -11,7 +11,7 @@ import {
 describe("result rendering", () => {
   it("emits one compact newline-terminated object in JSON mode", () => {
     const result = resultFor("runtime.orientation_ok", {
-      summary: "Runtime version 0.0.0-development.",
+      summary: "Runtime version 0.2.0.",
     });
     const rendered = renderResultJson(result);
 

--- a/tests/runtime-distribution.test.ts
+++ b/tests/runtime-distribution.test.ts
@@ -56,7 +56,7 @@ describe("runtime distribution", () => {
       const core = await readFile(join(root, manifest.runtime.core));
 
       expect(manifest.contractVersion).toBe("1.0.0");
-      expect(manifest.pluginVersion).toBe("0.0.0-development");
+      expect(manifest.pluginVersion).toBe("0.2.0");
       expect(manifest.host.name).toBe(host);
       expect(manifest.host.assetsSha256).toMatch(/^[a-f0-9]{64}$/u);
       expect(manifest.runtime).toMatchObject({

--- a/tests/support/host-adapter-contract.ts
+++ b/tests/support/host-adapter-contract.ts
@@ -45,7 +45,7 @@ export function conformanceResponse(
     operation: "handshake",
     capabilities: [],
     observedIdentity: {
-      adapterVersion: "0.0.0-development",
+      adapterVersion: "0.2.0",
       model: null,
       effort: null,
     },

--- a/tests/support/model-routing.ts
+++ b/tests/support/model-routing.ts
@@ -56,7 +56,7 @@ export function roleConfig(
   return {
     contractVersion: "1.4.0",
     stateContract: "1.4.0",
-    pluginVersion: "0.0.0-development",
+    pluginVersion: "0.2.0",
     hostContract: "1.4.0",
     language: {
       conversation: "en",


### PR DESCRIPTION
The v0.1.0 tag published packages that reported `0.0.0-development`, so the
release version and the version a user could observe never agreed, and the
Antigravity package existed in the build but was never published at all. This
makes v0.2.0 coherent and installable on all three hosts.

## Version

`0.2.0` across the workspaces, `package-lock.json`, `KRATOS_VERSION`, the
contract-family manifest, every schema that pins `pluginVersion`, the fixtures,
the host manifests, and the `runtime/manifest.json` each build emits.

`pluginVersion` is the identity of one coherent installed bundle rather than a
per-schema historical record — `classifyContractVersion("plugin", …)` accepts
exactly the current value and every configuration upgrade carries the field
forward unchanged — so the constant moves in every schema at once. Seven frozen
schema digests in `tests/contract-schemas.test.ts` and one in
`tests/acceptance-criterion-contracts.test.ts` move with it, and the test now
carries a comment saying why. Nothing else in those schema files changed.

The consequence is measured and documented: a project written by the v0.1.0
package makes `kratos doctor` return `runtime.state_corrupt` with exit code 4
and "The authoritative project configuration is invalid", while `status`,
`objective`, and `audit` still answer. The supported path is re-initialization.

## Hosts

- Antigravity had no `plugin.json`, which is the marker file the host requires
  to recognize a directory as a plugin at all. Added. Its documented manifest
  carries no version field, so package verification now refuses one rather than
  inventing it.
- The Codex manifest carried no `author`, which the `plugin.json` specification
  Codex ships with its plugin-creator lists as required. Added, with `homepage`
  and `repository`, to both the Codex and Claude Code manifests.
- Package verification checks each host's manifest at the location that host
  documents, for all three hosts rather than two.

## Release and CI

- The release job publishes four archives instead of three, and rebuilds and
  byte-compares all four.
- `SHA256SUMS` is written from inside `release/`, so a downloader can run
  `sha256sum --check SHA256SUMS` unchanged.
- The job's timeout was 25 minutes while its own `npm run verify` now costs
  more than that; raised to 60, and the duplicate benchmark step removed.
- Every workflow that runs npm installs the exact npm release pinned in
  `package.json` first, instead of trusting the runner image.

## Documentation

`docs/INSTALLATION.md` documents install, update, roll back, and uninstall for
each host, using only commands that host publishes. Three limits are stated
rather than papered over: no host documents installing a plugin directly from a
GitHub release asset, Codex publishes no CLI command for installing an
individual plugin, and the Kratos hook definition does not match Antigravity's
documented `hooks.json` location or event set, so Antigravity hooks are not
claimed.

`docs/releases/v0.2.0.md` proposes the release notes, keeping the Experimental
classification and disclosing parity at 0/400, signed-in host E2E pending,
macOS and Windows failing the nightly matrix, and no protected release
configuration on the repository.

`docs/verification/v0.2.0-release-readiness.md` records the GO/NO-GO evidence.

## Verification

Fresh clone, npm installed from the `package.json` pin, build written outside
the source tree: `npm ci` and `npm run verify` pass; 5,545 tests across 233
files; coverage 91.97% statements and 87.17% branches; mutation 4/4; all four
archives byte-identical on rebuild; `sha256sum --check` passes; `version` and
`handshake --json` answer `0.2.0` from each of the three packages.

Parity remains 0/400 and is unchanged by this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Tw8jK4HvUDvz8F4tuxXiQ
