### PR TITLE
chore(release): prepare the Experimental v0.3.0 distribution

### DIFF
--- a/distribution/claude-code/.claude-plugin/plugin.json
+++ b/distribution/claude-code/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kratos",
   "displayName": "Kratos",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Deterministic SDD workflow backed by the embedded Kratos runtime.",
   "author": {
     "name": "Kratos contributors",

--- a/distribution/codex/.codex-plugin/plugin.json
+++ b/distribution/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Run a deterministic SDD workflow backed by the embedded Kratos runtime.",
   "author": {
     "name": "Kratos contributors",

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -47,7 +47,7 @@ The commands below use the release tag and repository as variables so the same
 block works for any version.
 
 ```bash
-KRATOS_VERSION=v0.2.0
+KRATOS_VERSION=v0.3.0
 KRATOS_REPO=thiagocorreanet/kratos-harness
 KRATOS_HOME=~/.kratos/releases/$KRATOS_VERSION
 mkdir -p "$KRATOS_HOME/download"

--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -23,14 +23,14 @@ the published predecessors
 and the v1 schema keep their shape.
 Their bytes move only when `pluginVersion` does, because that constant is the
 identity of one installed bundle rather than a per-schema historical record;
-the v0.2.0 release is the first time that has happened. The manifest registers
+the v0.2.0 release was the first time that happened. The manifest registers
 every current payload schema, its generated type, and the metadata-only Go v3
 migration profiles.
 
 | Identity | Current | Owner |
 | --- | --- | --- |
-| Contract-manifest schema | `v1.9` | Contract-family manifest format |
-| `pluginVersion` | `0.2.0` | One coherent installed plugin bundle |
+| Contract-manifest schema | `v1.10` | Contract-family manifest format |
+| `pluginVersion` | `0.3.0` | One coherent installed plugin bundle |
 | `stateContract` | `1.5.0` | Persisted `.brain/` configuration and history |
 | `hostContract` | `1.4.0` | Cross-process adapter request and response messages |
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,227 @@
+# Proposed release notes — Kratos v0.3.0 (Experimental)
+
+These notes are a proposal. Publishing the tag and the GitHub release is a
+separate, explicitly authorized step.
+
+## Classification
+
+**Experimental.** This is a development snapshot published as a GitHub
+pre-release, not a production release. The maturity gates in
+[ROADMAP.md](../../ROADMAP.md) decide promotion, and every criterion for
+Preview is still open. Nothing in this release changes that classification.
+
+## What this release is
+
+v0.3.0 is the release that makes `kratos init` answer the two questions it
+previously left blank: what a project is written in, and how that project is
+built and laid out. Before this release, initializing a repository that was not
+one of thirteen recognized shapes produced empty placeholders, and
+`kratos doctor` reported `stack-profile: fail` on a project that had just been
+initialized successfully.
+
+Version coherence established in v0.2.0 is preserved: the tag, the npm
+workspace versions, `KRATOS_VERSION`, the contract-family manifest, the host
+plugin manifests, the schemas, and the version the installed runtime prints all
+say `0.3.0`.
+
+## Changes
+
+### Project identification (ADP-07)
+
+- Technology detection is now two layers answering two questions. A language
+  census counts source files by extension (~85 extensions) and answers what the
+  project is written in; toolchain markers (37 exact, 8 by suffix, 23
+  identifiers) answer how it is built. `StackProfile` reports `languages` and
+  `stacks` separately, because a project can have either without the other.
+- Elixir, Swift, Dart, Scala, Clojure, Haskell, Zig, Lua, R, Julia, Perl, Deno,
+  and Bun are recognized. A `.NET` solution under `src/Api/` is recognized;
+  detection is no longer limited to a deciding file sitting at the repository
+  root.
+- `observeRepositoryEvidence` walks breadth first within a bounded depth and
+  entry budget, never entering `.git`, `.brain`, `node_modules`, `vendor`,
+  `target`, `dist`, `build`, `bin`, `obj`, `.venv`, or their peers. Breadth
+  first is what makes a spent budget degrade honestly: the shallow part of the
+  tree is complete, and the profile says it is partial.
+- When both layers miss, the profile reports the extensions and root entries the
+  scan observed, bounded in count, rather than reporting nothing.
+- Detection stays offline, deterministic, total, and name-only. No manifest is
+  opened, so no stack is named confidently and wrongly.
+
+### Project profile derivation (ADP-08)
+
+- `kratos init` derives the project profile from declarative manifests
+  (`package.json`, `Makefile`, `pyproject.toml`, `Cargo.toml`, `go.mod`) and
+  directory layout (`src`, `tests`, `config`) instead of writing empty
+  placeholders.
+- Stated or confirmed answers (`resolved`) are distinguished from inferred
+  evidence (`derived`), and every derived leaf carries a required `evidence`
+  string naming what it was read from.
+- `kratos doctor` reports `stack-profile: pass` when every profile leaf is
+  resolved, derived, or not applicable.
+- Derivation is a pure, offline, bounded read of top-level files. It spawns no
+  subprocess, consults no clock, and makes no network call.
+
+### Feature documents (SDD-19)
+
+- The scaffold templates in `.brain/02-features/_template/` are replaced with an
+  authored set carrying blockquote roles, depth-3 section headings, inline
+  placeholders, trade-off examples, and audit contract statements.
+- Templates reference the native Kratos phase agents — `prd-researcher` (prd
+  phase), `spec-planner` (spec phase), `spec-reviewer` (plan phase) — rather
+  than commands this project does not ship.
+- The machine-readable `KRATOS-REQUIREMENT-DISCOVERY-V1` block is preserved in
+  the Action Framing section.
+
+## Compatibility and migration
+
+### Contract families
+
+| Identity | v0.2.0 | v0.3.0 |
+| --- | --- | --- |
+| `pluginVersion` | `0.2.0` | `0.3.0` |
+| `stateContract` current | `1.4.0` | `1.5.0` |
+| `stateContract` readable | `1.0.0`–`1.4.0` | `1.0.0`–`1.5.0` |
+| `hostContract` | `1.4.0` | `1.4.0` (unchanged) |
+| Result contract | `1.0.0` | `1.0.0` (unchanged) |
+| Reason catalog | `1.11.0` | `1.11.0` (unchanged) |
+| Contract-manifest schema | `v1.9` | `v1.10` |
+
+New payload schemas: `host.init-answers@1.6.0` (adds `derivedCommand`,
+`derivedPaths`, `derivedConvention`, and `derivedImplementationLanguages`, each
+with a required `evidence` string) and `state.project-config@1.5.0` (adds
+`derived` profile leaves).
+
+### Upgrading an existing project
+
+**A project initialized under v0.2.0 upgrades in place.** Its `.brain/config.json`
+records `stateContract: "1.4.0"`, which this release still reads, and an
+adjacent configuration migration to `1.5.0` is provided:
+
+```bash
+kratos migrate config --preview
+kratos migrate config --apply
+```
+
+Event logs, transaction journals, approvals, and snapshots are untouched by that
+migration.
+
+`pluginVersion` identifies one coherent installed bundle, so moving it to
+`0.3.0` moves it in every schema at once. Update the plugin and run
+`kratos doctor` before continuing an existing run.
+
+**A project initialized with the v0.1.0 package still needs to be
+re-initialized.** Its configuration records
+`pluginVersion: "0.0.0-development"`, and `kratos doctor` rejects it with
+`runtime.state_corrupt` and exit code 4. Commands that do not read the
+configuration — `status`, `objective`, `audit` — still answer, so a stale
+project looks usable until `doctor` is run. Treat `doctor` as the check that
+decides.
+
+## What is validated, and what is not
+
+### Behavioral parity: 0 / 400
+
+Behavioral parity with the Go v3 predecessor remains **0 / 400** (P0 0 / 211,
+P1 0 / 174). The differential harness runs and its self-test passes, but both of
+its sides run the same executable, so it proves the harness rather than parity.
+The authorized comparison needs the private frozen oracle, which is not part of
+this repository. Nothing in this release moves that number.
+
+### Signed-in host E2E: still pending
+
+Real signed-in end-to-end runs in Codex, Claude Code, and Antigravity are
+**still pending**. What is proven instead is that each package installs
+atomically into a clean directory, reports the correct version, answers
+`handshake --json`, initializes a project, records an objective, and starts a
+run — all through the built runtime, in `npm run package:verify`. That is a
+package contract, not a host integration.
+
+### Platforms and hosts effectively validated
+
+| Surface | Status | Evidence |
+| --- | --- | --- |
+| Linux (`ubuntu-latest`), Node 24.18.0 | Validated | CI, platform, compatibility, security, and nightly jobs pass |
+| macOS (`macos-latest`), Node 24.18.0 | Not validated | The nightly matrix fails at `npm test` |
+| Windows (`windows-latest`), Node 24.18.0 | Not validated | The nightly matrix fails at `npm test` |
+| Codex package | Builds, verifies, installs, initializes a project | `npm run package:verify` |
+| Claude Code package | Builds, verifies, installs, initializes a project | `npm run package:verify` |
+| Antigravity package | Builds, verifies, installs, initializes a project | `npm run package:verify` |
+| Codex hooks | Not validated in a signed-in host | — |
+| Claude Code hooks | Not validated in a signed-in host | — |
+| Antigravity hooks | **Not claimed** | The Kratos hook definition does not match Antigravity's documented `hooks.json` location or event set |
+
+### Other open items
+
+- In-process coverage of the runtime decision surface is below the 100% this
+  project intends.
+- Public-beta pilots and human graduation approval are not available.
+- Protected release configuration is not active on the repository. The `release`
+  environment exists with no protection rules, no rulesets are defined, and
+  `main` is unprotected. A release published in this state is not a protected
+  release, and this document does not claim it is.
+
+## Installing and rolling back
+
+[Installing Kratos](../INSTALLATION.md) documents download, checksum,
+attestation verification, install, update, and uninstall for each host. Set
+`KRATOS_VERSION=v0.3.0` in the blocks there.
+
+Each release is extracted under its own `~/.kratos/releases/<version>`
+directory, so rolling back means pointing the host at the previous directory.
+Keep the v0.2.0 directory until v0.3.0 is accepted.
+
+### Claude Code
+
+```bash
+claude plugin uninstall kratos@kratos-open-source
+claude plugin marketplace remove kratos-open-source
+claude plugin marketplace add ~/.kratos/releases/v0.2.0/marketplace
+claude plugin install kratos@kratos-open-source
+```
+
+### Codex
+
+```bash
+codex plugin marketplace remove kratos-open-source
+codex plugin marketplace add ~/.kratos/releases/v0.2.0/marketplace
+```
+
+Then reinstall Kratos from `codex /plugins`. Codex publishes no CLI command for
+installing an individual plugin.
+
+### Antigravity
+
+```bash
+agy plugin uninstall kratos
+agy plugin install ~/.kratos/releases/v0.2.0/antigravity
+```
+
+`agy plugin disable kratos` suspends the plugin without removing it, which is
+the right first move while diagnosing a problem.
+
+### Rolling back the project state as well
+
+A project migrated to `stateContract: "1.5.0"` is not readable by the v0.2.0
+runtime, whose current contract is `1.4.0`. Roll back the plugin only together
+with the project state it wrote, from a snapshot taken before the migration.
+
+### Staged installations
+
+For an installation managed by `scripts/install-plugin.mjs`, roll back with the
+retained verified copy instead:
+
+```bash
+node scripts/install-plugin.mjs rollback \
+  --host claude-code --target /absolute/plugin/directory/kratos
+```
+
+## Verification performed
+
+- `npm run verify` on the release branch, with the build written outside the
+  source tree.
+- Four archives built, rebuilt, and compared byte for byte in the release job.
+- `version` and `handshake --json` executed from each of the three installed
+  packages.
+
+Exact commands, outputs, and the GO/NO-GO decision are recorded in
+[the v0.3.0 release readiness report](../verification/v0.3.0-release-readiness.md).

--- a/docs/verification/v0.3.0-release-readiness.md
+++ b/docs/verification/v0.3.0-release-readiness.md
@@ -1,0 +1,125 @@
+# v0.3.0 release readiness — GO/NO-GO
+
+- Verification date: 2026-09-03 (America/Sao_Paulo)
+- Branch: `release/v0.3.0`
+- Base commit: `9db8cfc` (`main`)
+- Status: **GO to publish as an Experimental pre-release**, with the open items
+  below disclosed in the release notes.
+
+Nothing has been tagged or published at the time this report was written. The
+items marked NO-GO are repository configuration and human-driven tests that
+this branch cannot perform; they were already open at v0.2.0 and none of them
+regressed.
+
+## Decision
+
+| Gate | Verdict | Basis |
+| --- | --- | --- |
+| Version coherence across the distribution | GO | Every surface reports `0.3.0` |
+| Full verification suite | GO | `npm run verify` passed end to end |
+| Four archives, checksums, SBOM, attestations | GO | `release.yml` builds and attests all four |
+| Deterministic rebuild, byte-for-byte | GO | Proven in the release job; local build reproduced the same tree |
+| Installable in Codex | GO, unproven signed in | `npm run package:verify` passed; no signed-in run |
+| Installable in Claude Code | GO, unproven signed in | `npm run package:verify` passed; no signed-in run |
+| Installable in Antigravity | GO for the skill and runtime; NO-GO for hooks | Hook contract still does not match the host |
+| State migration `1.4.0` → `1.5.0` | GO | Adjacent migration shipped and covered by `tests/config-migration.test.ts` |
+| Protected release configuration | **NO-GO** | No rulesets, no environment protection, `main` unprotected |
+| Behavioral parity | Disclosed at `0 / 400` | Unchanged by this release |
+| Signed-in host E2E | **Pending** | Requires authenticated sessions |
+| macOS and Windows | **Not validated** | The nightly matrix fails at `npm test` on both |
+
+## Version coherence
+
+| Surface | Reports |
+| --- | --- |
+| `package.json` and all four workspaces | `0.3.0` |
+| `package-lock.json` | `0.3.0` |
+| `KRATOS_VERSION` (`packages/contracts/src/version.ts`) | `0.3.0` |
+| `packages/runtime/src/domain/prompt-ceilings/discovery.ts` | `0.3.0` |
+| `contract-families.v1.json` `pluginVersion` | `0.3.0` |
+| `schemas/**` `pluginVersion` constants | `0.3.0` |
+| `fixtures/contracts/**` | `0.3.0` |
+| Codex `plugin.json` | `0.3.0` |
+| Claude Code `plugin.json` | `0.3.0` |
+| Built `runtime/manifest.json` (all three hosts) | `0.3.0` |
+
+`pluginVersion` is the identity of one coherent installed bundle rather than a
+per-schema historical record, so moving it rewrites the bytes of every schema
+that pins it. The frozen schema digests in
+`tests/contract-schemas.test.ts` and `tests/acceptance-criterion-contracts.test.ts`
+were recomputed for the nine schemas affected, and no schema shape changed.
+
+## Contract identities published by this release
+
+| Identity | Value |
+| --- | --- |
+| Contract-manifest schema | `v1.10` |
+| `pluginVersion` | `0.3.0` |
+| `stateContract` current | `1.5.0` |
+| `stateContract` readable | `1.0.0`, `1.1.0`, `1.2.0`, `1.3.0`, `1.4.0`, `1.5.0` |
+| `hostContract` | `1.4.0` |
+| Result contract | `1.0.0` |
+| Reason catalog | `1.11.0` |
+
+A v0.2.0 project records `stateContract: "1.4.0"`, which stays readable, so it
+upgrades in place through `kratos migrate config`. A v0.1.0 project records
+`pluginVersion: "0.0.0-development"` and still has to be re-initialized.
+
+## Recorded run
+
+`npm run verify` on `release/v0.3.0`, with the build written outside the source
+tree.
+
+| Step | Result |
+| --- | --- |
+| `npm run verify` | PASS, every gate, exit 0 |
+| `npm run package:verify` | PASS for Codex, Claude Code, and Antigravity |
+| Built `runtime/manifest.json` per host | `pluginVersion: 0.3.0`, state `1.5.0`, host `1.4.0` |
+
+Gate detail from that run:
+
+| Gate | Result |
+| --- | --- |
+| Format, spelling, English-only, lint, type-check | Pass |
+| Unit tests | 5,640 passed, 236 files |
+| Coverage | 92.15% statements, 87.28% branches, 96.05% functions, 93.26% lines |
+| Mutation sentinels | 4 / 4 (100%) |
+| Gap calibration | 10 planted found, 0 missed |
+| Performance budgets | `runtimeSourceBytes` 1,583,242 / 1,600,000; `contractSchemaBytes` 355,025 / 370,000 |
+| Go v3 oracle | Public catalog verified: 12 surfaces, 4 PRD anchors, 3 binaries |
+| Parity inventory | **0 / 400** (P0 0 / 211, P1 0 / 174) |
+| Result contract | v1.0.0 verified: 76 reasons, exits 0-5, 6 examples |
+| Contract families | v1.0.0 verified: 70 schemas, 14 legacy profiles, generated types current |
+| Differential harness | Self-test equal, 12 scenarios planned |
+| Prompt ceilings | 20 shipped surfaces, all under ceiling |
+| Benchmarks | help p95 115.1 ms, version p95 105.3 ms, handshake p95 105.3 ms, bundle 2,133,681 bytes |
+
+Two deviations from the CI toolchain are stated rather than hidden: this run
+used Node.js 24.19.0 rather than the pinned 24.18.0, and npm 11.17.0 rather
+than the pinned 11.16.0. The release job installs both pins before building, so
+the published archives are produced by the pinned toolchain, not this one.
+
+## Deviation found and corrected during preparation
+
+The performance budget `contractSchemaBytes` was raised from 330,000 to 370,000
+before this branch. The versioned schema directory is append-only, so the three
+contracts added since v0.2.0 — `host.init-answers@1.6.0`,
+`state.project-config@1.5.0`, and `contracts.contract-manifest@1.10.0` — carried
+it past the previous ceiling. `runtimeSourceBytes` is at 99% of its own budget
+and will need the same treatment on the next feature that grows the runtime.
+
+## What still blocks a non-Experimental release
+
+1. **Protected release configuration.** The `release` environment has no
+   protection rules, no rulesets are defined, and `main` is unprotected.
+2. **Signed-in host E2E.** No authenticated run in Codex, Claude Code, or
+   Antigravity has been performed.
+3. **Antigravity hooks.** Kratos writes `hooks/hooks.json` and declares
+   `PostToolUseFailure` and `SessionEnd`; Antigravity reads `hooks.json` at the
+   package root and documents a different event set.
+4. **macOS and Windows.** The nightly matrix fails at `npm test` on both.
+5. **Behavioral parity at 0 / 400.** The authorized comparison needs the private
+   frozen oracle, which is not part of this repository.
+
+The proposed notes in [the v0.3.0 release notes](../releases/v0.3.0.md) state
+all of them.

--- a/fixtures/contracts/v1.1/project-config.json
+++ b/fixtures/contracts/v1.1/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.1.0",
   "stateContract": "1.1.0",
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "hostContract": "1.1.0",
   "language": "en",
   "policyMode": "strict",

--- a/fixtures/contracts/v1.2/project-config.json
+++ b/fixtures/contracts/v1.2/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.2.0",
   "stateContract": "1.2.0",
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "hostContract": "1.2.0",
   "language": {
     "conversation": "pt-BR",

--- a/fixtures/contracts/v1.3/compatibility-window.json
+++ b/fixtures/contracts/v1.3/compatibility-window.json
@@ -1,5 +1,5 @@
 {
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "stateContract": {
     "readable": ["1.0.0", "1.1.0", "1.2.0", "1.3.0"],
     "migrationOnly": ["0.9.0", "go-v3@0.6.5"]

--- a/fixtures/contracts/v1.3/project-config.json
+++ b/fixtures/contracts/v1.3/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.3.0",
   "stateContract": "1.3.0",
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "hostContract": "1.3.0",
   "language": {
     "conversation": "en",

--- a/fixtures/contracts/v1.4/project-config.json
+++ b/fixtures/contracts/v1.4/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.4.0",
   "stateContract": "1.4.0",
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "hostContract": "1.4.0",
   "language": {
     "conversation": "en",

--- a/fixtures/contracts/v1.5/project-config.json
+++ b/fixtures/contracts/v1.5/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.5.0",
   "stateContract": "1.5.0",
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "hostContract": "1.4.0",
   "language": {
     "conversation": "en",

--- a/fixtures/contracts/v1/project-config.json
+++ b/fixtures/contracts/v1/project-config.json
@@ -1,7 +1,7 @@
 {
   "contractVersion": "1.0.0",
   "stateContract": "1.0.0",
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "hostContract": "1.0.0",
   "language": "en",
   "policyMode": "strict",

--- a/fixtures/contracts/v1/version-cases.json
+++ b/fixtures/contracts/v1/version-cases.json
@@ -2,7 +2,7 @@
   {
     "name": "plugin current",
     "family": "plugin",
-    "value": "0.2.0",
+    "value": "0.3.0",
     "classification": "current",
     "reasonCode": null
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kratos-harness",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kratos-harness",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "workspaces": [
         "packages/*"
       ],
@@ -4383,28 +4383,28 @@
     },
     "packages/adapters": {
       "name": "@kratos/adapters",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
-        "@kratos/contracts": "0.2.0"
+        "@kratos/contracts": "0.3.0"
       }
     },
     "packages/contracts": {
       "name": "@kratos/contracts",
-      "version": "0.2.0"
+      "version": "0.3.0"
     },
     "packages/differential": {
       "name": "@kratos/differential",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "ajv": "8.20.0"
       }
     },
     "packages/runtime": {
       "name": "@kratos/runtime",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
-        "@kratos/adapters": "0.2.0",
-        "@kratos/contracts": "0.2.0",
+        "@kratos/adapters": "0.3.0",
+        "@kratos/contracts": "0.3.0",
         "ajv": "8.20.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos-harness",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "packageManager": "npm@11.16.0",

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@kratos/adapters",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",
   "dependencies": {
-    "@kratos/contracts": "0.2.0"
+    "@kratos/contracts": "0.3.0"
   }
 }

--- a/packages/contracts/catalogs/contract-families.v1.json
+++ b/packages/contracts/catalogs/contract-families.v1.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1.0.0",
-  "pluginVersion": "0.2.0",
+  "pluginVersion": "0.3.0",
   "resultContract": "1.0.0",
   "reasonCatalog": "1.11.0",
   "stateContract": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kratos/contracts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts"

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -54,12 +54,12 @@
 // source: https://kratos.dev/schemas/state/migration/v1.1 sha256:4223e8c4d4f69d60453edc2aaa880f0b0d04fdfea435ea45e378abff0d6aea38
 // source: https://kratos.dev/schemas/state/narration/v1 sha256:b3d99195b1792dbfb6d0d693f24fcfc546f0993c9fafcce4d873218aa7058e5f
 // source: https://kratos.dev/schemas/state/phase-measurement/v1 sha256:c783ccba225a9cd283460d11f9f1b590195c70ddcc8af28bf2bd891014888548
-// source: https://kratos.dev/schemas/state/project-config/v1 sha256:989427d7680941436b09a8ce7786f43a55131498bec82e74b171a44d5a16056d
-// source: https://kratos.dev/schemas/state/project-config/v1.1 sha256:246c84c839d0cf4c5b5b5eca10eb900e3d468feb38633850bf8cab406292b297
-// source: https://kratos.dev/schemas/state/project-config/v1.2 sha256:3f3f7f0fd5a2be574fcb8a15096ebaf75b515a1283df4e848cf41fb9098b43f9
-// source: https://kratos.dev/schemas/state/project-config/v1.3 sha256:4dd74aff09e68f1c3d121e535cae355c3bcca408c998b9fa4296aef3c70534b6
-// source: https://kratos.dev/schemas/state/project-config/v1.4 sha256:c112c4bbec84b108cbae589a8ad2dd097cbb1c23773046fbc4fe136a246cc134
-// source: https://kratos.dev/schemas/state/project-config/v1.5 sha256:427f41f3c5d5a12644238c6c67e8c364372e0c7f4496b4dc668681b0f9ee1b57
+// source: https://kratos.dev/schemas/state/project-config/v1 sha256:1dab1c54555c62b2b1fd6bd8d73232d5a363ca33ce1127fd1d2d0f7403b4993c
+// source: https://kratos.dev/schemas/state/project-config/v1.1 sha256:0128b06de2ff573a4b07f2ee867c782e673c15012690591f518e1923a9f9799c
+// source: https://kratos.dev/schemas/state/project-config/v1.2 sha256:e9974da03424b1434214b017e9ed3713336bfc9976dcb221518ac10eb54235f0
+// source: https://kratos.dev/schemas/state/project-config/v1.3 sha256:72709c73c7ed91b5695ee7f640ec4cb49b2c0b9de546448c7e2b516a6bcb2120
+// source: https://kratos.dev/schemas/state/project-config/v1.4 sha256:ef6a7b72d92f7f0b292e582e8dc7ce5dbbfaed5fb54d66c372f5c276befec929
+// source: https://kratos.dev/schemas/state/project-config/v1.5 sha256:a24bdd38c01b74471bf458f6778cad24cd4fcfca72c3c487f6a0fa94d170a6ea
 // source: https://kratos.dev/schemas/state/requirement-discovery/v1 sha256:7974861ace6571c08cc3cee2921715f06800e48fb5ee9767cdcf45c0dc4354b4
 // source: https://kratos.dev/schemas/state/repair-loop-stop/v1 sha256:bf18ca66a29e1615e4714bcc081b8d41257cd553d9e3466d26846ce7d441d21b
 // source: https://kratos.dev/schemas/state/repair-loop-stop/v1.1 sha256:8dde526faeb7bc240f31e6edef90f6c2670e166dad0b75cda25ab58734386124
@@ -4611,7 +4611,7 @@ export namespace ProjectConfigV1Contract {
   export interface ProjectConfigV1 {
     contractVersion: "1.0.0";
     stateContract: "1.0.0";
-    pluginVersion: "0.2.0";
+    pluginVersion: "0.3.0";
     hostContract: "1.0.0";
     language: "en" | "pt-BR";
     policyMode: "standard" | "strict";
@@ -4635,7 +4635,7 @@ export namespace ProjectConfigV1_1Contract {
   export interface ProjectConfigV1_1 {
     contractVersion: "1.1.0";
     stateContract: "1.1.0";
-    pluginVersion: "0.2.0";
+    pluginVersion: "0.3.0";
     hostContract: "1.1.0";
     language: "en" | "pt-BR";
     policyMode: "standard" | "strict";
@@ -4670,7 +4670,7 @@ export namespace ProjectConfigV1_2Contract {
   export interface ProjectConfigV1_2 {
     contractVersion: "1.2.0";
     stateContract: "1.2.0";
-    pluginVersion: "0.2.0";
+    pluginVersion: "0.3.0";
     hostContract: "1.2.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4725,7 +4725,7 @@ export namespace ProjectConfigV1_3Contract {
   export interface ProjectConfigV1_3 {
     contractVersion: "1.3.0";
     stateContract: "1.3.0";
-    pluginVersion: "0.2.0";
+    pluginVersion: "0.3.0";
     hostContract: "1.3.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4832,7 +4832,7 @@ export namespace ProjectConfigV1_4Contract {
   export interface ProjectConfigV1_4 {
     contractVersion: "1.4.0";
     stateContract: "1.4.0";
-    pluginVersion: "0.2.0";
+    pluginVersion: "0.3.0";
     hostContract: "1.4.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4958,7 +4958,7 @@ export namespace ProjectConfigV1_5Contract {
   export interface ProjectConfigV1_5 {
     contractVersion: "1.5.0";
     stateContract: "1.5.0";
-    pluginVersion: "0.2.0";
+    pluginVersion: "0.3.0";
     hostContract: "1.4.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";

--- a/packages/contracts/src/version.ts
+++ b/packages/contracts/src/version.ts
@@ -1,1 +1,1 @@
-export const KRATOS_VERSION = "0.2.0";
+export const KRATOS_VERSION = "0.3.0";

--- a/packages/differential/package.json
+++ b/packages/differential/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kratos/differential",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": "./src/index.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kratos/runtime",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -61,8 +61,8 @@
     "./ports": "./src/ports/index.ts"
   },
   "dependencies": {
-    "@kratos/adapters": "0.2.0",
-    "@kratos/contracts": "0.2.0",
+    "@kratos/adapters": "0.3.0",
+    "@kratos/contracts": "0.3.0",
     "ajv": "8.20.0"
   }
 }

--- a/packages/runtime/src/domain/prompt-ceilings/discovery.ts
+++ b/packages/runtime/src/domain/prompt-ceilings/discovery.ts
@@ -7,7 +7,7 @@ import {
 } from "../init/managed-section.ts";
 import type { PromptCategory } from "./model.ts";
 
-const KRATOS_VERSION = "0.2.0";
+const KRATOS_VERSION = "0.3.0";
 
 export interface ShippedPromptSurface {
   readonly id: string;

--- a/schemas/contracts/contract-manifest.v1.1.schema.json
+++ b/schemas/contracts/contract-manifest.v1.1.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.2.0"
+      "const": "0.3.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.10.schema.json
+++ b/schemas/contracts/contract-manifest.v1.10.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.11.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.2.schema.json
+++ b/schemas/contracts/contract-manifest.v1.2.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.2.0"
+      "const": "0.3.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.3.schema.json
+++ b/schemas/contracts/contract-manifest.v1.3.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.8.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.4.schema.json
+++ b/schemas/contracts/contract-manifest.v1.4.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.2.0"
+      "const": "0.3.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.5.schema.json
+++ b/schemas/contracts/contract-manifest.v1.5.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.2.0"
+      "const": "0.3.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.6.schema.json
+++ b/schemas/contracts/contract-manifest.v1.6.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.2.0"
+      "const": "0.3.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/contracts/contract-manifest.v1.7.schema.json
+++ b/schemas/contracts/contract-manifest.v1.7.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.11.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.8.schema.json
+++ b/schemas/contracts/contract-manifest.v1.8.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.11.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.9.schema.json
+++ b/schemas/contracts/contract-manifest.v1.9.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "contractVersion": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "resultContract": { "const": "1.0.0" },
     "reasonCatalog": { "const": "1.11.0" },
     "stateContract": {

--- a/schemas/contracts/contract-manifest.v1.schema.json
+++ b/schemas/contracts/contract-manifest.v1.schema.json
@@ -19,7 +19,7 @@
       "const": "1.0.0"
     },
     "pluginVersion": {
-      "const": "0.2.0"
+      "const": "0.3.0"
     },
     "resultContract": {
       "const": "1.0.0"

--- a/schemas/state/project-config.v1.1.schema.json
+++ b/schemas/state/project-config.v1.1.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "contractVersion": { "const": "1.1.0" },
     "stateContract": { "const": "1.1.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "hostContract": { "const": "1.1.0" },
     "language": { "enum": ["en", "pt-BR"] },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.2.schema.json
+++ b/schemas/state/project-config.v1.2.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "contractVersion": { "const": "1.2.0" },
     "stateContract": { "const": "1.2.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "hostContract": { "const": "1.2.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.3.schema.json
+++ b/schemas/state/project-config.v1.3.schema.json
@@ -18,7 +18,7 @@
   "properties": {
     "contractVersion": { "const": "1.3.0" },
     "stateContract": { "const": "1.3.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "hostContract": { "const": "1.3.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.4.schema.json
+++ b/schemas/state/project-config.v1.4.schema.json
@@ -19,7 +19,7 @@
   "properties": {
     "contractVersion": { "const": "1.4.0" },
     "stateContract": { "const": "1.4.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "hostContract": { "const": "1.4.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.5.schema.json
+++ b/schemas/state/project-config.v1.5.schema.json
@@ -19,7 +19,7 @@
   "properties": {
     "contractVersion": { "const": "1.5.0" },
     "stateContract": { "const": "1.5.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "hostContract": { "const": "1.4.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/schemas/state/project-config.v1.schema.json
+++ b/schemas/state/project-config.v1.schema.json
@@ -16,7 +16,7 @@
   "properties": {
     "contractVersion": { "const": "1.0.0" },
     "stateContract": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.2.0" },
+    "pluginVersion": { "const": "0.3.0" },
     "hostContract": { "const": "1.0.0" },
     "language": { "enum": ["en", "pt-BR"] },
     "policyMode": { "enum": ["standard", "strict"] },

--- a/tests/acceptance-criterion-contracts.test.ts
+++ b/tests/acceptance-criterion-contracts.test.ts
@@ -77,10 +77,10 @@ describe("acceptance criterion contracts", () => {
       "7d95ea2c2541c12b8e960094bb3bd197b35f5f55ffd6412581449efacde54d3a",
     );
     expect(createHash("sha256").update(manifestV1).digest("hex")).toBe(
-      "a87dd52092ee34eb3d0a1e182f10481c87a83111f104607c2a5df378a431e629",
+      "aa36b05d72b9df368fdbeed693989b44e563bfd67f94e5e8557af11687a3a120",
     );
     expect(createHash("sha256").update(manifestV11).digest("hex")).toBe(
-      "ec050850bcf9cb584bee1f27a047891d3ed60236a36be3c7bb586fad7cea281e",
+      "f4a90cab9c095cbd6ff039c5d1b8b4a726fd76248f5c1316e9d2a5d8552e78bf",
     );
   });
 

--- a/tests/bundle-smoke.test.ts
+++ b/tests/bundle-smoke.test.ts
@@ -62,7 +62,7 @@ describe("standalone runtime package", () => {
       const result = execute(host, "--version");
 
       expect(result.status).toBe(0);
-      expect(result.stdout).toBe("0.2.0\n");
+      expect(result.stdout).toBe("0.3.0\n");
       expect(result.stderr).toBe("");
     },
   );

--- a/tests/cli-retired.test.ts
+++ b/tests/cli-retired.test.ts
@@ -62,8 +62,8 @@ describe("retired phase commands", () => {
     for (const argv of [
       ["--json", name],
       [name, "--json"],
-      ["--expect", "0.2.0", name],
-      [name, "--expect", "0.2.0"],
+      ["--expect", "0.3.0", name],
+      [name, "--expect", "0.3.0"],
     ]) {
       const { decision, failure } = invoke(argv);
       expect(failure, argv.join(" ")).toBeNull();

--- a/tests/config-migration.test.ts
+++ b/tests/config-migration.test.ts
@@ -51,7 +51,7 @@ const SNAPSHOT_REF = ".brain/02-features/sample-feature/runs/run-01/state.json";
 const LEGACY_CONFIG: ProjectConfigV1 = {
   contractVersion: "1.0.0",
   stateContract: "1.0.0",
-  pluginVersion: "0.2.0",
+  pluginVersion: "0.3.0",
   hostContract: "1.0.0",
   language: "pt-BR",
   policyMode: "strict",
@@ -280,7 +280,7 @@ describe("configuration migration", () => {
     const source: ProjectConfigV1_4 = {
       contractVersion: "1.4.0",
       stateContract: "1.4.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.4.0",
       language: {
         conversation: "en",
@@ -334,7 +334,7 @@ describe("configuration migration", () => {
     expect(migrated).toEqual({
       contractVersion: "1.5.0",
       stateContract: "1.5.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.4.0",
       language: source.language,
       policyMode: "strict",
@@ -356,7 +356,7 @@ describe("configuration migration", () => {
     const source: ProjectConfigV1_3 = {
       contractVersion: "1.3.0",
       stateContract: "1.3.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.3.0",
       language: {
         conversation: "en",
@@ -418,7 +418,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -460,7 +460,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -534,7 +534,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -594,7 +594,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -666,7 +666,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.1.0",
       language: "en",
       policyMode: "standard",
@@ -711,7 +711,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.1.0",
       language: "en",
       policyMode: "standard",
@@ -770,7 +770,7 @@ describe("configuration migration", () => {
     const source = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -856,7 +856,7 @@ describe("configuration migration", () => {
     const legacy: ProjectConfigV1_1 = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.1.0",
       language: "pt-BR",
       policyMode: "standard",
@@ -885,7 +885,7 @@ describe("configuration migration", () => {
     const legacy: ProjectConfigV1_1 = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.1.0",
       language: "en",
       policyMode: "standard",
@@ -943,7 +943,7 @@ describe("configuration migration", () => {
     const legacy1_1: ProjectConfigV1_1 = {
       contractVersion: "1.1.0",
       stateContract: "1.1.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.1.0",
       language: "pt-BR",
       policyMode: "standard",
@@ -971,7 +971,7 @@ describe("configuration migration", () => {
     expect(JSON.parse(after[CONFIG_REF] ?? "null")).toEqual({
       contractVersion: "1.5.0",
       stateContract: "1.5.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.4.0",
       gateModes: {},
       language: {
@@ -2021,7 +2021,7 @@ describe("configuration migration", () => {
     const source: ProjectConfigV1_4 = {
       contractVersion: "1.4.0",
       stateContract: "1.4.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.4.0",
       language: {
         conversation: "en",

--- a/tests/contract-manifest.test.ts
+++ b/tests/contract-manifest.test.ts
@@ -106,7 +106,7 @@ describe("contract family manifest", () => {
   it("publishes exact independent compatibility windows", () => {
     expect(manifest).toMatchObject({
       contractVersion: "1.0.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       resultContract: "1.0.0",
       reasonCatalog: "1.11.0",
       stateContract: {

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -235,7 +235,7 @@ describe("versioned state and host schemas", () => {
     const project = {
       contractVersion: "1.4.0",
       stateContract: "1.4.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.4.0",
       language: {
         conversation: "en",
@@ -336,7 +336,7 @@ describe("versioned state and host schemas", () => {
     const project = {
       contractVersion: "1.3.0",
       stateContract: "1.3.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.3.0",
       language: {
         conversation: "en",
@@ -479,7 +479,7 @@ describe("versioned state and host schemas", () => {
     const project = {
       contractVersion: "1.5.0",
       stateContract: "1.5.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.4.0",
       language: {
         conversation: "en",
@@ -620,7 +620,7 @@ describe("versioned state and host schemas", () => {
     const baseProject12 = {
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.2.0",
       language: {
         conversation: "en",
@@ -818,12 +818,12 @@ describe("versioned state and host schemas", () => {
   // coherent installed bundle rather than a per-schema historical record:
   // `classifyContractVersion("plugin", ...)` accepts exactly the current
   // value and every configuration upgrade carries the field forward
-  // unchanged. Releasing 0.2.0 therefore moves it in every schema at once,
+  // unchanged. Releasing 0.3.0 therefore moves it in every schema at once,
   // and these digests move with it. Nothing else about these files changed.
   it.each([
     [
       "state/project-config.v1.schema.json",
-      "989427d7680941436b09a8ce7786f43a55131498bec82e74b171a44d5a16056d",
+      "1dab1c54555c62b2b1fd6bd8d73232d5a363ca33ce1127fd1d2d0f7403b4993c",
     ],
     [
       "state/event.v1.schema.json",
@@ -839,15 +839,15 @@ describe("versioned state and host schemas", () => {
     ],
     [
       "contracts/contract-manifest.v1.1.schema.json",
-      "ec050850bcf9cb584bee1f27a047891d3ed60236a36be3c7bb586fad7cea281e",
+      "f4a90cab9c095cbd6ff039c5d1b8b4a726fd76248f5c1316e9d2a5d8552e78bf",
     ],
     [
       "contracts/contract-manifest.v1.2.schema.json",
-      "4fd2411deadcda1d1012eacbd6036a3b950b58256df0ded745bd84497e4458b3",
+      "991346bf8404b4c55a6bf88fd9ecdce899a6d5f4ea481cec96676a5d1e6a2d00",
     ],
     [
       "contracts/contract-manifest.v1.8.schema.json",
-      "8b1783ad5fbeff14a41240273327d5f45821af68f5785104b3f17e7513506e9f",
+      "ba0d2563ea7dff1a81bea84c10fe2f4875daac9daada8ab5e21f292e04b62703",
     ],
     [
       "host/adapter-message.v1.1.schema.json",
@@ -879,15 +879,15 @@ describe("versioned state and host schemas", () => {
     ],
     [
       "state/project-config.v1.1.schema.json",
-      "246c84c839d0cf4c5b5b5eca10eb900e3d468feb38633850bf8cab406292b297",
+      "0128b06de2ff573a4b07f2ee867c782e673c15012690591f518e1923a9f9799c",
     ],
     [
       "state/project-config.v1.2.schema.json",
-      "3f3f7f0fd5a2be574fcb8a15096ebaf75b515a1283df4e848cf41fb9098b43f9",
+      "e9974da03424b1434214b017e9ed3713336bfc9976dcb221518ac10eb54235f0",
     ],
     [
       "state/project-config.v1.3.schema.json",
-      "4dd74aff09e68f1c3d121e535cae355c3bcca408c998b9fa4296aef3c70534b6",
+      "72709c73c7ed91b5695ee7f640ec4cb49b2c0b9de546448c7e2b516a6bcb2120",
     ],
   ])("keeps the published %s schema byte-identical", async (path, digest) => {
     const bytes = await readFile(join(schemaRoot, path));
@@ -1179,7 +1179,7 @@ describe("versioned state and host schemas", () => {
       ({ fixtureName }) => fixtureName === "project-config.json",
     )?.fixture;
     expect(projectConfig).toMatchObject({
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       stateContract: "1.0.0",
       hostContract: "1.0.0",
     });

--- a/tests/migration-observability.test.ts
+++ b/tests/migration-observability.test.ts
@@ -95,7 +95,7 @@ describe("transactional migration lifecycle", () => {
       {
         contractVersion: "1.0.0",
         stateContract: "1.0.0",
-        pluginVersion: "0.2.0",
+        pluginVersion: "0.3.0",
         hostContract: "1.0.0",
         language: "pt-BR",
         policyMode: "strict",
@@ -117,7 +117,7 @@ describe("transactional migration lifecycle", () => {
     expect(upgraded).toEqual({
       contractVersion: "1.2.0",
       stateContract: "1.2.0",
-      pluginVersion: "0.2.0",
+      pluginVersion: "0.3.0",
       hostContract: "1.2.0",
       language: {
         conversation: "pt-BR",

--- a/tests/package-boundaries.test.ts
+++ b/tests/package-boundaries.test.ts
@@ -39,7 +39,7 @@ describe("distribution boundaries", () => {
         encoding: "utf8",
       });
 
-    expect(run(first)).toBe("0.2.0\n");
+    expect(run(first)).toBe("0.3.0\n");
     expect(run(second)).toBe(run(first));
     expect(await readdir(first)).toEqual([]);
     expect(await readdir(second)).toEqual([]);
@@ -57,6 +57,6 @@ describe("distribution boundaries", () => {
         [join(installed, "runtime/kratos.mjs"), "--version"],
         { cwd: await project(), encoding: "utf8" },
       ),
-    ).toBe("0.2.0\n");
+    ).toBe("0.3.0\n");
   });
 });

--- a/tests/project-configuration.test.ts
+++ b/tests/project-configuration.test.ts
@@ -18,7 +18,7 @@ import { createSchemaRegistry } from "@kratos/runtime/composition/schema";
 const validConfiguration: ProjectConfigV1_4 = {
   contractVersion: "1.4.0",
   stateContract: "1.4.0",
-  pluginVersion: "0.2.0",
+  pluginVersion: "0.3.0",
   hostContract: "1.4.0",
   language: {
     conversation: "en",

--- a/tests/project-discovery-composition.test.ts
+++ b/tests/project-discovery-composition.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from "vitest";
 const configuration: ProjectConfigV1_4 = {
   contractVersion: "1.4.0",
   stateContract: "1.4.0",
-  pluginVersion: "0.2.0",
+  pluginVersion: "0.3.0",
   hostContract: "1.4.0",
   language: {
     conversation: "en",

--- a/tests/result-envelope.test.ts
+++ b/tests/result-envelope.test.ts
@@ -29,10 +29,10 @@ describe("result envelope", () => {
 
   it("carries a caller summary without changing catalog policy", () => {
     const result = resultFor("runtime.orientation_ok", {
-      summary: "Runtime version 0.2.0.",
+      summary: "Runtime version 0.3.0.",
     });
 
-    expect(result.summary).toBe("Runtime version 0.2.0.");
+    expect(result.summary).toBe("Runtime version 0.3.0.");
     expect(result.exitCode).toBe(0);
     expect(result.recovery).toBeNull();
     expect(result.stateChanged).toBe(false);

--- a/tests/result-rendering.test.ts
+++ b/tests/result-rendering.test.ts
@@ -11,7 +11,7 @@ import {
 describe("result rendering", () => {
   it("emits one compact newline-terminated object in JSON mode", () => {
     const result = resultFor("runtime.orientation_ok", {
-      summary: "Runtime version 0.2.0.",
+      summary: "Runtime version 0.3.0.",
     });
     const rendered = renderResultJson(result);
 

--- a/tests/runtime-distribution.test.ts
+++ b/tests/runtime-distribution.test.ts
@@ -56,7 +56,7 @@ describe("runtime distribution", () => {
       const core = await readFile(join(root, manifest.runtime.core));
 
       expect(manifest.contractVersion).toBe("1.0.0");
-      expect(manifest.pluginVersion).toBe("0.2.0");
+      expect(manifest.pluginVersion).toBe("0.3.0");
       expect(manifest.host.name).toBe(host);
       expect(manifest.host.assetsSha256).toMatch(/^[a-f0-9]{64}$/u);
       expect(manifest.runtime).toMatchObject({

--- a/tests/support/host-adapter-contract.ts
+++ b/tests/support/host-adapter-contract.ts
@@ -45,7 +45,7 @@ export function conformanceResponse(
     operation: "handshake",
     capabilities: [],
     observedIdentity: {
-      adapterVersion: "0.2.0",
+      adapterVersion: "0.3.0",
       model: null,
       effort: null,
     },

--- a/tests/support/model-routing.ts
+++ b/tests/support/model-routing.ts
@@ -56,7 +56,7 @@ export function roleConfig(
   return {
     contractVersion: "1.4.0",
     stateContract: "1.4.0",
-    pluginVersion: "0.2.0",
+    pluginVersion: "0.3.0",
     hostContract: "1.4.0",
     language: {
       conversation: "en",


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Release preparation for `v0.3.0`. No issue; this branch carries no behavior change.

## Outcome and design

Makes the whole distribution report `0.3.0` so the tag, the packages, and the
version an installed runtime prints agree, and records what the release contains
and what it does not.

`pluginVersion` is the identity of one coherent installed bundle rather than a
per-schema historical record, so it moves everywhere at once: the workspaces,
the lockfile, `KRATOS_VERSION`, the prompt-ceilings constant, the contract-family
manifest, every schema that pins it, the fixtures, the host manifests, and the
tests that assert an installed package's version.

Release notes: `docs/releases/v0.3.0.md`
Readiness report: `docs/verification/v0.3.0-release-readiness.md`

## Compatibility and public contracts

| Identity | v0.2.0 | v0.3.0 |
| --- | --- | --- |
| `pluginVersion` | `0.2.0` | `0.3.0` |
| `stateContract` current | `1.4.0` | `1.5.0` |
| `stateContract` readable | `1.0.0`-`1.4.0` | `1.0.0`-`1.5.0` |
| `hostContract` | `1.4.0` | unchanged |
| Result contract | `1.0.0` | unchanged |
| Reason catalog | `1.11.0` | unchanged |
| Contract-manifest schema | `v1.9` | `v1.10` |

No schema shape changed in this branch. Moving `pluginVersion` rewrites the
bytes of the schemas that pin it, so the nine frozen digests guarding them are
recomputed in `tests/contract-schemas.test.ts` and
`tests/acceptance-criterion-contracts.test.ts`, and the generated contract types
are regenerated from the schemas.

`docs/compatibility/contract-versioning.md` still named `v1.9` as the current
contract-manifest schema; `v1.10` shipped with ADP-08.

## State, migration, security, and rollback

A project initialized under v0.2.0 upgrades in place: `stateContract` `1.4.0`
stays readable and the adjacent migration to `1.5.0` shipped with ADP-08, so
`kratos migrate config --preview` then `--apply` is the whole path. Event logs,
transaction journals, approvals, and snapshots are untouched.

A project from v0.1.0 still has to be re-initialized; it records
`pluginVersion: "0.0.0-development"`.

Rolling back the plugin to v0.2.0 requires rolling back the project state with
it, because a configuration migrated to `1.5.0` is not readable by a runtime
whose current contract is `1.4.0`. Per-host rollback commands are in the release
notes.

## Deterministic test evidence

- `npm run verify` on this branch: PASS, exit 0, every gate.
- Unit tests: 5,640 passed, 236 files.
- Coverage: 92.15% statements, 87.28% branches, 96.05% functions, 93.26% lines.
- `npm run package:verify`: PASS for Codex, Claude Code, and Antigravity; each
  built `runtime/manifest.json` reports `pluginVersion: 0.3.0`.
- Performance budgets: `contractSchemaBytes` 355,025 / 370,000;
  `runtimeSourceBytes` 1,583,242 / 1,600,000.
- Diff hygiene: `git diff --check` clean.

## Prompt and model evaluations

Not applicable.

## Failure evidence

Before the digests were recomputed, `tests/contract-schemas.test.ts` failed on
seven schemas and `tests/acceptance-criterion-contracts.test.ts` on two, each
with the digest of the file still carrying `pluginVersion: "0.2.0"`.

## Open items disclosed, not fixed here

Behavioral parity is still 0 / 400, no signed-in host E2E has been performed,
macOS and Windows still fail the nightly matrix, Antigravity hooks are not
claimed, and the repository has no protected release configuration. All five are
stated in the release notes and the readiness report rather than implied away.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PoUohNMESehLufG24WD5o
