### PR TITLE
fix(workflow): stop counting git-ignored paths as a dirty worktree

### DIFF
--- a/packages/runtime/src/composition/workflow.ts
+++ b/packages/runtime/src/composition/workflow.ts
@@ -49,7 +49,7 @@ import {
   type WorkflowObservation,
   type WorkflowReducerConfiguration,
 } from "../domain/workflow/index.js";
-import type { GitPath } from "../domain/git/index.js";
+import type { GitChange, GitPath } from "../domain/git/index.js";
 import { verifyEvidence } from "../domain/evidence/index.js";
 import {
   extractAgentBlock,
@@ -2935,6 +2935,24 @@ function managed(path: GitPath, worktreePrefix: string): boolean {
   );
 }
 
+/**
+ * A path the repository has told Git to ignore is not worktree churn a code
+ * step can be held responsible for. Git itself reports such a tree as clean,
+ * and the recovery a refusal offers — commit, stash, or revert — cannot reach
+ * an ignored path at all. Counting one as dirty refuses every start on any
+ * repository that has been built once, because `bin/`, `obj/`, `target/`,
+ * `dist/`, and `node_modules/` are exactly what a build leaves behind.
+ *
+ * `--ignored=matching` stays in the status command. `GitChange` keeps its
+ * tracking state precisely so it is not collapsed into one `dirty` flag —
+ * `complete.ignored_removed` is defined over what was ignored at baseline —
+ * so which classifications a gate acts on is decided here, not by narrowing
+ * what the observation is allowed to see.
+ */
+function ignoredByGit(change: GitChange): boolean {
+  return change.tracking === "ignored";
+}
+
 async function observeGitContext(
   ports: RuntimePorts,
 ): Promise<{ readonly clean: boolean; readonly commit: string | null }> {
@@ -2949,10 +2967,14 @@ async function observeGitContext(
   const head = observation.repository.head;
   return {
     clean: observation.repository.changes.every(
-      ({ path, renamedFrom }) =>
-        managed(path, observation.repository.worktreePrefix) &&
-        (renamedFrom === null ||
-          managed(renamedFrom, observation.repository.worktreePrefix)),
+      (change) =>
+        ignoredByGit(change) ||
+        (managed(change.path, observation.repository.worktreePrefix) &&
+          (change.renamedFrom === null ||
+            managed(
+              change.renamedFrom,
+              observation.repository.worktreePrefix,
+            ))),
     ),
     commit: head.kind === "unborn" ? null : head.commit,
   };

--- a/tests/worktree-gate.test.ts
+++ b/tests/worktree-gate.test.ts
@@ -95,6 +95,67 @@ describe("the workflow worktree gate", () => {
   );
 
   it(
+    "starts when the only unmanaged dirty paths are ignored by Git",
+    async () => {
+      const repository = await createRootProjectRepository();
+      try {
+        expect(
+          await runCommandLine(
+            ["init", "--root", repository.projectRoot],
+            runtime(repository.projectRoot, ANSWERS).ports,
+          ),
+        ).toBe(0);
+        await writeFile(
+          join(repository.projectRoot, ".gitignore"),
+          "build/\n",
+          "utf8",
+        );
+        repository.commitAll("initialize project");
+
+        // A build output, produced after the commit. Git reports it as an
+        // ignored path, so the worktree it belongs to is clean by Git's own
+        // account, and the recovery a refusal would offer — commit, stash, or
+        // revert — cannot act on it.
+        await mkdir(join(repository.projectRoot, "build"));
+        await writeFile(
+          join(repository.projectRoot, "build/output.o"),
+          "artifact\n",
+          "utf8",
+        );
+
+        expect(
+          await runCommandLine(
+            [
+              "objective",
+              "Ship the root project",
+              "--root",
+              repository.projectRoot,
+            ],
+            runtime(repository.projectRoot).ports,
+          ),
+        ).toBe(0);
+
+        const started = runtime(repository.projectRoot);
+        const exitCode = await runCommandLine(
+          [
+            "--json",
+            "start",
+            "--root",
+            repository.projectRoot,
+            "--host",
+            "claude-code",
+          ],
+          started.ports,
+        );
+        expect(exitCode, started.output.structured_.join("")).toBe(0);
+      } finally {
+        await repository.dispose();
+      }
+    },
+    REAL_REPOSITORY_TIMEOUT,
+  );
+
+  it(
     "starts a nested project when only its managed state is dirty",
     async () => {
       const repository = await createNestedProjectRepository();


### PR DESCRIPTION
Closes #199.

## The defect

`start` was refused with `trail.worktree_dirty` when the only unmanaged paths in the worktree were ones the repository had told Git to ignore. Git reports such a tree as clean; Kratos did not.

The status command asks for ignored paths (`--ignored=matching`), `status.ts` files those `!` records into the same `changes` list with `tracking: "ignored"`, and `observeGitContext` required **every** entry to live under `.brain`. Nothing filtered on tracking state, so one ignored build artifact anywhere outside managed state made `clean === false`, which `decideStartWorkflow` turns into a refusal.

This is not an edge case on a built repository. On the .NET project where I hit it, `git status --porcelain=v2 -uall --ignored=matching` lists 90 ignored entries outside `.brain/` — `TestResults/` plus `bin/` and `obj/` for every project in the solution. `start` was refused until all of them were deleted, and the next build brought them straight back. `node_modules/`, `target/`, `dist/`, and `__pycache__` layouts have the same shape.

The offered recovery could not be followed either: "commit, stash, or revert" cannot act on an ignored path.

## The change

`observeGitContext` now skips changes whose `tracking` is `"ignored"` when computing `clean`. The `.brain` exemption is unchanged, and every other classification — tracked, untracked, renamed, undecodable — still counts exactly as before.

`--ignored=matching` stays in the status command deliberately. `GitChange` keeps its tracking state so the observation is not collapsed into one `dirty` flag, and `complete.ignored_removed` is defined over what was ignored at baseline; the policy belongs at the predicate, not in a narrowed observation. This follows the reasoning already recorded in `docs/architecture/git-service.md`.

## Design choice and alternatives

- **Filter at the predicate** (chosen). One boolean, no contract change, the observation stays complete for the reason codes that need ignored facts.
- **Drop `--ignored=matching` from the status command.** Rejected: it would silently remove the baseline `complete.ignored_removed` is specified against, and `git-scenarios.test.ts` pins the collapsed-directory entry that flag produces.
- **Exempt ignored paths only outside the project root.** Rejected: an ignored `bin/` sits *inside* the project root, which is precisely the case that fails.

## Impact

- **Public contract:** none. No reason code, schema, or result shape changes.
- **Behavior:** `start` and rebaseline now succeed in a repository whose only unmanaged churn is ignored. Nothing that previously succeeded now fails — the predicate is strictly more permissive, and only for a classification whose recovery was unreachable.
- **State / migration:** none. No persisted state is read or written differently.
- **Security:** an ignored path was never inspected or acted on by a code step; it is now also not counted against one. Tracked and untracked changes are unaffected.

## Test-first evidence

A failing test was added to `tests/worktree-gate.test.ts` first — a root project, committed, with a `.gitignore` for `build/` and a build output created afterwards:

```
 ❯ tests/worktree-gate.test.ts (5 tests | 1 failed) 3055ms
     × starts when the only unmanaged dirty paths are ignored by Git 631ms

AssertionError: {"reasonCode":"trail.worktree_dirty","summary":"A code step cannot
start or rebaseline with disallowed worktree changes.", ...}
: expected 2 to be +0
```

After the fix:

```
$ npx vitest run tests/worktree-gate.test.ts tests/git-scenarios.test.ts
 Test Files  2 passed (2)
      Tests  145 passed (145)
```

## Verification

| Command | Result |
| --- | --- |
| `npx vitest run tests/worktree-gate.test.ts tests/git-scenarios.test.ts` | 145 passed |
| `npm test` | 236 files, 5641 tests passed (434s) |
| `npm run lint` | passed |
| `npm run typecheck` | passed |
| `npm run format:check` (changed files) | passed |
| `npm run english:check` | passed |
| `npm run spellcheck` | 252 files, 0 issues |
| `npm run oracle:verify` | passed |
| `npm run parity:check` | passed |
| `npm run result:check` | passed |
| `npm run contracts:check` | passed |
| `npm run differential:check` | passed |
| `npm run prompts:ceilings:check` | passed |
| `npm run gaps:calibrate` | passed |
| `npm run performance:check` | passed |
| `npm run build` | passed |
| `npm run package:verify` | passed |

Not run: `npm run test:coverage`, `npm run mutation:check`, and `npm run benchmark`. Say the word if you want those before review.

## Provenance

Original work. No legacy or third-party material was used, so the IP checklist does not apply.

## Note on the environment

`npm ci` fails here on `EBADENGINE` with npm 11.17.0 against the pinned `11.16.0`; installed with `--engine-strict=false`. Not related to this change, and worth knowing if CI ever floats npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dRC4SLNm6Ane6aGokEFZG
