### PR TITLE
feat(cli): expose the derived project profile to the host (ADP-12)

### DIFF
--- a/distribution/antigravity/skills/kratos/SKILL.md
+++ b/distribution/antigravity/skills/kratos/SKILL.md
@@ -20,15 +20,25 @@ stop and relay any refusal unchanged.
 
 ## Initialization interview
 
-Before `kratos init`, load `scripts/project-profile-relay.mjs` from this skill
-directory. Ask every exported `projectProfileQuestions` entry in order,
-presenting candidate suggestions derived from declarative manifests and
-repository evidence for user confirmation. Record confirmed answers as
-`resolved`, unconfirmed derived values with evidence as `derived`, explicitly
-omitted items as `not-applicable` with a reason, or `unresolved` if blank.
-Commands are exact single-line strings run from the project root, paths are
-project-relative lists, and implementation languages are programming languages
-rather than the human-language policy.
+Before `kratos init`, run
+`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>`
+from this skill directory. Its `host.project-profile@1.0.0` payload is the only
+source of interview candidates. Then load `scripts/project-profile-relay.mjs`
+from this skill directory and ask every exported `projectProfileQuestions` entry
+in order.
+
+Present an answer the payload reports as `derived` with its value and its
+evidence string for confirmation, and ask an answer it reports as `unresolved`
+blank. Never present a candidate the payload does not carry, and never add a
+description the payload does not carry. The runtime derives these, and a
+suggestion you author makes one repository answer differently for different
+operators.
+
+Record confirmed answers as `resolved`, unconfirmed derived values with their
+evidence as `derived`, explicitly omitted items as `not-applicable` with a
+reason, or `unresolved` if blank. Commands are exact single-line strings run
+from the project root, paths are project-relative lists, and implementation
+languages are programming languages rather than the human-language policy.
 
 Pass the keyed answers to `relayProjectProfileAnswers`, place its returned
 value in `host.init-answers@1.6.0` as `projectProfile`, and pipe that complete

--- a/distribution/claude-code/skills/kratos/SKILL.md
+++ b/distribution/claude-code/skills/kratos/SKILL.md
@@ -20,15 +20,25 @@ stop and relay any refusal unchanged.
 
 ## Initialization interview
 
-Before `kratos init`, load `scripts/project-profile-relay.mjs` from this skill
-directory. Ask every exported `projectProfileQuestions` entry in order,
-presenting candidate suggestions derived from declarative manifests and
-repository evidence for user confirmation. Record confirmed answers as
-`resolved`, unconfirmed derived values with evidence as `derived`, explicitly
-omitted items as `not-applicable` with a reason, or `unresolved` if blank.
-Commands are exact single-line strings run from the project root, paths are
-project-relative lists, and implementation languages are programming languages
-rather than the human-language policy.
+Before `kratos init`, run
+`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>`
+from this skill directory. Its `host.project-profile@1.0.0` payload is the only
+source of interview candidates. Then load `scripts/project-profile-relay.mjs`
+from this skill directory and ask every exported `projectProfileQuestions` entry
+in order.
+
+Present an answer the payload reports as `derived` with its value and its
+evidence string for confirmation, and ask an answer it reports as `unresolved`
+blank. Never present a candidate the payload does not carry, and never add a
+description the payload does not carry. The runtime derives these, and a
+suggestion you author makes one repository answer differently for different
+operators.
+
+Record confirmed answers as `resolved`, unconfirmed derived values with their
+evidence as `derived`, explicitly omitted items as `not-applicable` with a
+reason, or `unresolved` if blank. Commands are exact single-line strings run
+from the project root, paths are project-relative lists, and implementation
+languages are programming languages rather than the human-language policy.
 
 Pass the keyed answers to `relayProjectProfileAnswers`, place its returned
 value in `host.init-answers@1.6.0` as `projectProfile`, and pipe that complete

--- a/distribution/codex/skills/kratos/SKILL.md
+++ b/distribution/codex/skills/kratos/SKILL.md
@@ -20,15 +20,25 @@ stop and relay any refusal unchanged.
 
 ## Initialization interview
 
-Before `kratos init`, load `scripts/project-profile-relay.mjs` from this skill
-directory. Ask every exported `projectProfileQuestions` entry in order,
-presenting candidate suggestions derived from declarative manifests and
-repository evidence for user confirmation. Record confirmed answers as
-`resolved`, unconfirmed derived values with evidence as `derived`, explicitly
-omitted items as `not-applicable` with a reason, or `unresolved` if blank.
-Commands are exact single-line strings run from the project root, paths are
-project-relative lists, and implementation languages are programming languages
-rather than the human-language policy.
+Before `kratos init`, run
+`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>`
+from this skill directory. Its `host.project-profile@1.0.0` payload is the only
+source of interview candidates. Then load `scripts/project-profile-relay.mjs`
+from this skill directory and ask every exported `projectProfileQuestions` entry
+in order.
+
+Present an answer the payload reports as `derived` with its value and its
+evidence string for confirmation, and ask an answer it reports as `unresolved`
+blank. Never present a candidate the payload does not carry, and never add a
+description the payload does not carry. The runtime derives these, and a
+suggestion you author makes one repository answer differently for different
+operators.
+
+Record confirmed answers as `resolved`, unconfirmed derived values with their
+evidence as `derived`, explicitly omitted items as `not-applicable` with a
+reason, or `unresolved` if blank. Commands are exact single-line strings run
+from the project root, paths are project-relative lists, and implementation
+languages are programming languages rather than the human-language policy.
 
 Pass the keyed answers to `relayProjectProfileAnswers`, place its returned
 value in `host.init-answers@1.6.0` as `projectProfile`, and pipe that complete

--- a/docs/architecture/project-initialization.md
+++ b/docs/architecture/project-initialization.md
@@ -208,6 +208,17 @@ source; a document that is present but blank fails validation with a reason.
 Keeping the interview in the host adapter is what makes initialization testable
 without a terminal and identical under Claude Code, Codex, and a CI job.
 
+The host asks the questions, but it does not answer them. `kratos profile
+derive` publishes the candidates: the same bounded scan, the same declarative
+manifests, and the same pure derivation `init` runs internally, observed before
+any answer exists and mutating nothing. A host presents what that command
+derived, with the evidence it came from, and asks a leaf it left unresolved
+blank. Without it a host has no deterministic source for a candidate and writes
+one itself, which is how two operators initializing one repository are offered
+two different sets. `init` still derives internally for the caller that pipes a
+complete document and never asked anything; the command is an observation of
+that function, not a second copy of it.
+
 Current `host.init-answers@1.6.0` accepts `modelRoles`, keyed by enabled
 configuration host. Every supplied host map is closed to `planner`,
 `implementer`, and `judge`. Each assignment is either a bare model name or

--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -10,8 +10,10 @@ that boundary and implement the behavior described below.
 The closed
 [`contract-families.v1.json`](../../packages/contracts/catalogs/contract-families.v1.json)
 manifest owns compatibility policy. Its current format is checked by
-[`contract-manifest.v1.9.schema.json`](../../schemas/contracts/contract-manifest.v1.9.schema.json);
+[`contract-manifest.v1.11.schema.json`](../../schemas/contracts/contract-manifest.v1.11.schema.json);
 the published predecessors
+[`contract-manifest.v1.10.schema.json`](../../schemas/contracts/contract-manifest.v1.10.schema.json),
+[`contract-manifest.v1.9.schema.json`](../../schemas/contracts/contract-manifest.v1.9.schema.json),
 [`contract-manifest.v1.8.schema.json`](../../schemas/contracts/contract-manifest.v1.8.schema.json),
 [`contract-manifest.v1.7.schema.json`](../../schemas/contracts/contract-manifest.v1.7.schema.json),
 [`contract-manifest.v1.6.schema.json`](../../schemas/contracts/contract-manifest.v1.6.schema.json),
@@ -88,6 +90,10 @@ follow `CONTRACT_VERSIONS`:
   write its registered `1.1.0` revision.
 - `host.doctor-report@1.0.0` is the structured read-only diagnostic payload;
   it carries the recorded gate failures and their effective modes.
+- `host.project-profile@1.0.0` is the structured read-only derived project
+  profile `kratos profile derive` publishes. Every answer is present: a leaf
+  the derivation produced carries its `derived` value and evidence, and a leaf
+  it did not carries `unresolved` and nothing else.
 - The current memory-aware selectors are `host.phase-handoff@1.4.0`,
   `host.agent-output@1.3.0`, `host.memory-capture@1.2.0`,
   `host.memory-change@1.4.0`, `host.memory-curation@1.4.0`, and

--- a/docs/user/commands.md
+++ b/docs/user/commands.md
@@ -7,6 +7,7 @@ also accept `--root PATH` where shown by `kratos help`.
 | --- | --- | --- |
 | `help`, `version`, `handshake` | Usage and contract orientation | No |
 | `adapters` | Report supported host package manifests | No |
+| `profile derive` | Report the project profile the runtime derives from the repository | No |
 | `init` | Create or reconcile managed project surfaces | Yes |
 | `objective TEXT` | Record or replace the active objective | Yes |
 | `start` | Start or idempotently resume a run | Yes |
@@ -79,6 +80,17 @@ resolved, derived with evidence, not applicable with a reason, or unresolved.
 Omitted leaves preserve current `1.5.0` project configuration state during
 reinitialization; explicit unresolved leaves clear it. Initialization never
 infers these values from stack markers and never executes a configured command.
+
+`kratos profile derive [--json]` publishes exactly that derivation before any
+answer is chosen. It mutates nothing, spawns nothing, requires no answers
+document, and reads only what initialization's bounded offline scan already
+reads: the top-level declarative manifests and the directory layout. Its
+`host.project-profile@1.0.0` payload carries all ten profile answers. A leaf the
+derivation produced is `derived` with the evidence string it came from; a leaf
+it did not produce is `unresolved`. A host presents the derived candidates for
+confirmation and asks the unresolved ones blank; it never invents a candidate
+the runtime did not derive. Because the derivation is pure, one repository
+yields the same candidates on every run and on every host.
 
 `kratos init` creates the raw phase log and tracked phase report only when each
 path is absent. Reinitialization preserves the exact existing bytes of both

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -41,6 +41,7 @@ The [`contracts/v1`](contracts/v1) directory contains valid current examples:
 - `operation-error.json`;
 - `agent-output.json`;
 - `doctor-report.json`;
+- `project-profile.json`;
 - `repair-loop-stop.json`;
 - `repair-resolution.json`;
 - `repair-restart.json`.

--- a/fixtures/contracts/v1/project-profile.json
+++ b/fixtures/contracts/v1/project-profile.json
@@ -1,0 +1,46 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.4.0",
+  "profile": {
+    "commands": {
+      "test": {
+        "status": "derived",
+        "value": "npm test",
+        "evidence": "package.json#scripts.test"
+      },
+      "lint": {
+        "status": "derived",
+        "value": "npm run lint",
+        "evidence": "package.json#scripts.lint"
+      },
+      "build": {
+        "status": "derived",
+        "value": "npm run build",
+        "evidence": "package.json#scripts.build"
+      },
+      "run": { "status": "unresolved" }
+    },
+    "paths": {
+      "source": {
+        "status": "derived",
+        "value": ["src"],
+        "evidence": "directory:src"
+      },
+      "tests": {
+        "status": "derived",
+        "value": ["tests"],
+        "evidence": "directory:tests"
+      },
+      "configuration": { "status": "unresolved" }
+    },
+    "conventions": {
+      "directoryLayout": { "status": "unresolved" },
+      "naming": { "status": "unresolved" },
+      "implementationLanguages": {
+        "status": "derived",
+        "value": ["typescript"],
+        "evidence": "census:typescript"
+      }
+    }
+  }
+}

--- a/packages/contracts/catalogs/contract-families.v1.json
+++ b/packages/contracts/catalogs/contract-families.v1.json
@@ -246,6 +246,14 @@
       "typeName": "PreToolUseV1"
     },
     {
+      "id": "host.project-profile",
+      "family": "host",
+      "version": "1.0.0",
+      "path": "schemas/host/project-profile.v1.schema.json",
+      "boundary": "cross-process",
+      "typeName": "ProjectProfileV1"
+    },
+    {
       "id": "state.acceptance-criteria-snapshot",
       "family": "state",
       "version": "1.0.0",

--- a/packages/contracts/src/compatibility.ts
+++ b/packages/contracts/src/compatibility.ts
@@ -31,6 +31,7 @@ export const CONTRACT_VERSIONS = {
   "host.hook-observation": "1.0.0",
   "host.operation-message": "1.0.0",
   "host.pre-tool-use": "1.0.0",
+  "host.project-profile": "1.0.0",
   "state.acceptance-criteria-snapshot": "1.0.0",
   "state.acceptance-verdict": "1.0.0",
   "state.approval": "1.0.0",

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -30,6 +30,7 @@
 // source: https://kratos.dev/schemas/host/phase-handoff/v1.4 sha256:b023bead73d67aeedcf6cc524020ea85412d73e9df6c7cbe1fa564c27db97f79
 // source: https://kratos.dev/schemas/host/phase-lifecycle/v1 sha256:c521ee3ac865f904fae1961d57e3b940df5e8c9988549425ac876631553fd4b2
 // source: https://kratos.dev/schemas/host/pre-tool-use/v1 sha256:f527cf1e975a204f5c3c90a0e8f7a9f5ca875939c751e054d356f3a6e15e9935
+// source: https://kratos.dev/schemas/host/project-profile/v1 sha256:20bf5f6585dd5c6d158fb3d3bc562e157f0796b531269a57e04590567ce2f89e
 // source: https://kratos.dev/schemas/state/acceptance-criteria-snapshot/v1 sha256:6cd6e5c3cbd50a3e79c9b0159f30cb9f4fb83ce8f3422aed5d957d48f5537181
 // source: https://kratos.dev/schemas/state/acceptance-verdict/v1 sha256:a5455afbd293f137f78ba0adfe00f190339a4f79860600a5b563cf20f3114659
 // source: https://kratos.dev/schemas/state/approval/v1 sha256:746f251be3908027032d23be08c4f300cdf63455e6c32cdea73f459b03da07bf
@@ -2985,6 +2986,72 @@ export namespace PreToolUseV1Contract {
   }
 }
 export type PreToolUseV1 = PreToolUseV1Contract.PreToolUseV1;
+export namespace ProjectProfileV1Contract {
+  export type CommandLeaf = DerivedCommand | Unresolved;
+  export type Command = string;
+  export type Evidence = string;
+  export type PathsLeaf = DerivedPaths | Unresolved;
+  export type ProjectPath = string;
+  export type ConventionLeaf = DerivedConvention | Unresolved;
+  export type Convention = string;
+  export type ImplementationLanguagesLeaf =
+    DerivedImplementationLanguages | Unresolved;
+  export type ImplementationLanguage = string;
+
+  export interface ProjectProfileV1 {
+    contractVersion: "1.0.0";
+    hostContract: "1.4.0";
+    profile: DerivedProjectProfile;
+  }
+  export interface DerivedProjectProfile {
+    commands: {
+      test: CommandLeaf;
+      lint: CommandLeaf;
+      build: CommandLeaf;
+      run: CommandLeaf;
+    };
+    paths: {
+      source: PathsLeaf;
+      tests: PathsLeaf;
+      configuration: PathsLeaf;
+    };
+    conventions: {
+      directoryLayout: ConventionLeaf;
+      naming: ConventionLeaf;
+      implementationLanguages: ImplementationLanguagesLeaf;
+    };
+  }
+  export interface DerivedCommand {
+    status: "derived";
+    value: Command;
+    evidence: Evidence;
+  }
+  export interface Unresolved {
+    status: "unresolved";
+  }
+  export interface DerivedPaths {
+    status: "derived";
+    /**
+     * @minItems 1
+     */
+    value: [ProjectPath, ...ProjectPath[]];
+    evidence: Evidence;
+  }
+  export interface DerivedConvention {
+    status: "derived";
+    value: Convention;
+    evidence: Evidence;
+  }
+  export interface DerivedImplementationLanguages {
+    status: "derived";
+    /**
+     * @minItems 1
+     */
+    value: [ImplementationLanguage, ...ImplementationLanguage[]];
+    evidence: Evidence;
+  }
+}
+export type ProjectProfileV1 = ProjectProfileV1Contract.ProjectProfileV1;
 export namespace AcceptanceCriteriaSnapshotV1Contract {
   export type Id = string;
   export type Reference = string;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -102,6 +102,7 @@ export type {
   ProjectConfigV1_4,
   ProjectConfigV1_5,
   PreToolUseV1,
+  ProjectProfileV1,
   RequirementDiscoveryV1,
   RepairLoopStopV1,
   RepairLoopStopV1_1,

--- a/packages/runtime/src/composition/cli.ts
+++ b/packages/runtime/src/composition/cli.ts
@@ -1,4 +1,8 @@
-import { CONTRACT_VERSIONS, type DoctorReportV1 } from "@kratos/contracts";
+import {
+  CONTRACT_VERSIONS,
+  type DoctorReportV1,
+  type ProjectProfileV1,
+} from "@kratos/contracts";
 
 import {
   DEFAULT_REGISTRY,
@@ -29,6 +33,7 @@ import { observeHostOperation } from "./host.js";
 import { observeStopLossUnlock } from "./unlock.js";
 import { observeMigration } from "./migration.js";
 import { observeObjective } from "./objective.js";
+import { observeProjectProfile } from "./profile.js";
 import { observeWorkflow } from "./workflow.js";
 import { observeMetricsRefresh } from "./measurements.js";
 import { renderPhaseHandoffHuman } from "../domain/cli/diagnostics.js";
@@ -146,6 +151,24 @@ function prepareDoctorReportPayload(
   return { canonical: prepared.canonical, value: prepared.value };
 }
 
+function prepareProjectProfilePayload(
+  payload: unknown,
+  registry: SchemaRegistry,
+): { readonly canonical: string; readonly value: ProjectProfileV1 } {
+  const version = declaredContractVersion(payload, "contractVersion", "1.0.0");
+  const prepared = prepareContract(registry, {
+    id: "host.project-profile",
+    version,
+    value: payload,
+    structuralReasonCode: "trail.output_invalido",
+  });
+  if (prepared.kind === "invalid") {
+    throw new Error("Command payload does not satisfy its declared contract");
+  }
+  validatePublicPayload(prepared.value);
+  return { canonical: prepared.canonical, value: prepared.value };
+}
+
 /** Parse, validate, apply, and publish one command line. */
 export async function runCommandLine(
   argv: readonly string[],
@@ -171,41 +194,43 @@ export async function runCommandLine(
           ? await observeInitialization(invocation, ports, schemaRegistry)
           : invocation.command.prerequisite === "objective"
             ? await observeObjective(invocation, ports, schemaRegistry)
-            : invocation.command.prerequisite === "write-guard"
-              ? await observeGuardWrite(invocation, ports, schemaRegistry)
-              : invocation.command.prerequisite === "scope-record"
-                ? await observeScopeRecord(invocation, ports, schemaRegistry)
-                : invocation.command.prerequisite === "memory"
-                  ? await observeMemory(invocation, ports, schemaRegistry)
-                  : invocation.command.prerequisite === "host-operation"
-                    ? await observeHostOperation(
-                        invocation,
-                        ports,
-                        schemaRegistry,
-                      )
-                    : invocation.command.prerequisite === "stop-loss-unlock"
-                      ? await observeStopLossUnlock(
+            : invocation.command.prerequisite === "project-profile"
+              ? await observeProjectProfile(invocation, ports, schemaRegistry)
+              : invocation.command.prerequisite === "write-guard"
+                ? await observeGuardWrite(invocation, ports, schemaRegistry)
+                : invocation.command.prerequisite === "scope-record"
+                  ? await observeScopeRecord(invocation, ports, schemaRegistry)
+                  : invocation.command.prerequisite === "memory"
+                    ? await observeMemory(invocation, ports, schemaRegistry)
+                    : invocation.command.prerequisite === "host-operation"
+                      ? await observeHostOperation(
                           invocation,
                           ports,
                           schemaRegistry,
                         )
-                      : invocation.command.prerequisite === "metrics-refresh"
-                        ? await observeMetricsRefresh(
+                      : invocation.command.prerequisite === "stop-loss-unlock"
+                        ? await observeStopLossUnlock(
                             invocation,
                             ports,
                             schemaRegistry,
                           )
-                        : invocation.command.prerequisite === "migration"
-                          ? await observeMigration(
+                        : invocation.command.prerequisite === "metrics-refresh"
+                          ? await observeMetricsRefresh(
                               invocation,
                               ports,
                               schemaRegistry,
                             )
-                          : await observeWorkflow(
-                              invocation,
-                              ports,
-                              schemaRegistry,
-                            );
+                          : invocation.command.prerequisite === "migration"
+                            ? await observeMigration(
+                                invocation,
+                                ports,
+                                schemaRegistry,
+                              )
+                            : await observeWorkflow(
+                                invocation,
+                                ports,
+                                schemaRegistry,
+                              );
       if (observed.kind === "failure") {
         return publish(observed.result, json, ports);
       }
@@ -246,6 +271,18 @@ export async function runCommandLine(
       );
       preparedOutput = json
         ? `${doctor.canonical}\n`
+        : (decision.humanStdout ?? `${decision.result.summary}\n`);
+      if (!json) validatePublicText(preparedOutput);
+    } else if (invocation.command.jsonContract === "project-profile@1.0.0") {
+      if (decision.payload === undefined) {
+        throw new Error("Command payload is absent");
+      }
+      const profile = prepareProjectProfilePayload(
+        decision.payload,
+        schemaRegistry,
+      );
+      preparedOutput = json
+        ? `${profile.canonical}\n`
         : (decision.humanStdout ?? `${decision.result.summary}\n`);
       if (!json) validatePublicText(preparedOutput);
     } else if (!json) {

--- a/packages/runtime/src/composition/profile.ts
+++ b/packages/runtime/src/composition/profile.ts
@@ -1,0 +1,49 @@
+import type { Invocation } from "../domain/cli/index.js";
+import { deriveProjectProfile } from "../domain/init/index.js";
+import type { SchemaRegistry } from "../domain/schema/index.js";
+import type { RuntimePorts } from "../ports/index.js";
+
+import type { Observed } from "./init.js";
+import { readOnlyPorts } from "./read-only.js";
+import {
+  observeManifestContents,
+  observeRepositoryEvidence,
+} from "./repository.js";
+import { anchorPorts, resolveCommandRoot } from "./root.js";
+import { createSchemaRegistry } from "./schema.js";
+
+/**
+ * Observe the derived project profile without deciding anything from it.
+ *
+ * This is the same composition `init` performs before it resolves answers --
+ * the bounded scan, the declarative manifests, and the pure derivation over
+ * both. It is repeated here rather than shared through `init` because `init`
+ * cannot run until the interview is over, and the interview is exactly when
+ * the candidates are needed.
+ *
+ * The ports are read-only. Publishing what a repository looks like must not be
+ * the thing that creates state in it.
+ */
+export async function observeProjectProfile(
+  invocation: Invocation,
+  ports: RuntimePorts,
+  registry: SchemaRegistry = createSchemaRegistry(),
+): Promise<Observed> {
+  const root = await resolveCommandRoot(invocation, ports, registry);
+  if (root.kind === "failure") return { kind: "failure", result: root.result };
+  const anchored = readOnlyPorts(anchorPorts(root.target, ports));
+
+  const evidence = await observeRepositoryEvidence(anchored.fileSystem);
+  const manifests = await observeManifestContents(
+    anchored.fileSystem,
+    evidence.rootEntries,
+  );
+  return {
+    kind: "observed",
+    observation: {
+      kind: "project-profile",
+      derived: deriveProjectProfile(evidence, manifests),
+    },
+    ports: anchored,
+  };
+}

--- a/packages/runtime/src/domain/cli/commands.ts
+++ b/packages/runtime/src/domain/cli/commands.ts
@@ -16,6 +16,7 @@ import {
   memoryReinforceCommand,
 } from "./memory.js";
 import { objectiveCommand } from "./objective.js";
+import { profileDeriveCommand } from "./profile.js";
 import { continueCommand, doneCommand, startCommand } from "./workflow.js";
 import {
   budgetsCommand,
@@ -151,6 +152,7 @@ export const DEFAULT_REGISTRY: CommandRegistry = [
   memoryArchiveCommand,
   narrateCommand,
   objectiveCommand,
+  profileDeriveCommand,
   repairCommand,
   repairResolveCommand,
   startCommand,

--- a/packages/runtime/src/domain/cli/index.ts
+++ b/packages/runtime/src/domain/cli/index.ts
@@ -14,6 +14,7 @@ export {
 export { hookCommand } from "./hook.js";
 export { guardWriteCommand, scopeRecordCommand } from "./write-guard.js";
 export { objectiveCommand } from "./objective.js";
+export { profileDeriveCommand } from "./profile.js";
 export { adaptersCommand } from "./adapters.js";
 export { agentRecordCommand } from "./agent.js";
 export { approveCommand } from "./approval.js";

--- a/packages/runtime/src/domain/cli/profile.ts
+++ b/packages/runtime/src/domain/cli/profile.ts
@@ -1,0 +1,163 @@
+import { CONTRACT_VERSIONS } from "@kratos/contracts";
+
+import { planOf } from "../effects.js";
+import type {
+  PartialProjectProfile,
+  ProjectProfileLeaf,
+} from "../init/index.js";
+import { resultFor } from "../result/index.js";
+
+import { observingCommand } from "./observed.js";
+import type { CommandObservation, CommandSpec, Decision } from "./spec.js";
+
+type Observation = Extract<
+  CommandObservation,
+  { readonly kind: "project-profile" }
+>;
+
+/** One profile answer, in the document order the packaged interview asks in. */
+interface DerivedEntry {
+  readonly key: string;
+  readonly leaf: ProjectProfileLeaf<string | readonly string[]>;
+}
+
+const UNRESOLVED = { status: "unresolved" } as const;
+
+/**
+ * Publish the profile the runtime derives, and nothing a host inferred.
+ *
+ * The packaged interview presents one candidate per question. Without a
+ * command that answers what those candidates are, every host produced them by
+ * reading the repository itself, and two operators initializing one repository
+ * were offered two different sets. This is that command: the same pure
+ * derivation `init` performs, observed rather than applied.
+ */
+export const profileDeriveCommand: CommandSpec = observingCommand(
+  "project-profile",
+  {
+    path: ["profile", "derive"],
+    summary:
+      "Report the project profile the runtime derives from the repository.",
+    flags: [
+      {
+        name: "--detect-root",
+        kind: "boolean",
+        summary: "Search ancestors for the project root instead of using here.",
+      },
+      {
+        name: "--root",
+        kind: "value",
+        valueLabel: "<path>",
+        summary: "Derive from exactly this directory, searching no ancestor.",
+      },
+      {
+        name: "--worktree-local",
+        kind: "boolean",
+        summary: "In a linked worktree, ignore the principal checkout.",
+      },
+    ],
+    positionals: { min: 0, max: 0 },
+    jsonContract: "project-profile@1.0.0",
+  },
+  (_invocation, observation) => decide(observation),
+);
+
+function decide(observation: Observation): Decision {
+  const entries = entriesOf(observation.derived);
+  const derived = entries.filter(({ leaf }) => leaf.status === "derived");
+  const lines = entries.map(describe);
+  return {
+    result: resultFor("runtime.orientation_ok", {
+      summary: `The runtime derived ${String(derived.length)} of ${String(entries.length)} project profile answers.`,
+      // Every answer is reported, including the ones nothing derived, because
+      // a host that cannot tell "derived nothing" from "was not asked" fills
+      // the silence with a candidate the runtime never produced.
+      why: lines,
+      evidence: [{ kind: "observation", ref: "project-profile" }],
+    }),
+    plan: planOf(),
+    humanStdout: `${lines.join("\n")}\n`,
+    payload: {
+      contractVersion: CONTRACT_VERSIONS["host.project-profile"],
+      hostContract: "1.4.0",
+      profile: {
+        commands: {
+          test: leafOf(observation.derived.commands?.test),
+          lint: leafOf(observation.derived.commands?.lint),
+          build: leafOf(observation.derived.commands?.build),
+          run: leafOf(observation.derived.commands?.run),
+        },
+        paths: {
+          source: leafOf(observation.derived.paths?.source),
+          tests: leafOf(observation.derived.paths?.tests),
+          configuration: leafOf(observation.derived.paths?.configuration),
+        },
+        conventions: {
+          directoryLayout: leafOf(
+            observation.derived.conventions?.directoryLayout,
+          ),
+          naming: leafOf(observation.derived.conventions?.naming),
+          implementationLanguages: leafOf(
+            observation.derived.conventions?.implementationLanguages,
+          ),
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Report an answer nothing derived as unresolved rather than as absent.
+ *
+ * An absent key and an underived one are the same fact, and saying it one way
+ * keeps a reader from inventing a difference between them.
+ */
+function leafOf<T>(
+  leaf: ProjectProfileLeaf<T> | undefined,
+): ProjectProfileLeaf<T> | typeof UNRESOLVED {
+  return leaf ?? UNRESOLVED;
+}
+
+function entriesOf(derived: PartialProjectProfile): readonly DerivedEntry[] {
+  return [
+    {
+      key: "projectProfile.commands.test",
+      leaf: leafOf(derived.commands?.test),
+    },
+    {
+      key: "projectProfile.commands.lint",
+      leaf: leafOf(derived.commands?.lint),
+    },
+    {
+      key: "projectProfile.commands.build",
+      leaf: leafOf(derived.commands?.build),
+    },
+    { key: "projectProfile.commands.run", leaf: leafOf(derived.commands?.run) },
+    { key: "projectProfile.paths.source", leaf: leafOf(derived.paths?.source) },
+    { key: "projectProfile.paths.tests", leaf: leafOf(derived.paths?.tests) },
+    {
+      key: "projectProfile.paths.configuration",
+      leaf: leafOf(derived.paths?.configuration),
+    },
+    {
+      key: "projectProfile.conventions.directoryLayout",
+      leaf: leafOf(derived.conventions?.directoryLayout),
+    },
+    {
+      key: "projectProfile.conventions.naming",
+      leaf: leafOf(derived.conventions?.naming),
+    },
+    {
+      key: "projectProfile.conventions.implementationLanguages",
+      leaf: leafOf(derived.conventions?.implementationLanguages),
+    },
+  ];
+}
+
+function describe({ key, leaf }: DerivedEntry): string {
+  if (leaf.status !== "derived") return `${key}: not derived`;
+  const value = Array.isArray(leaf.value)
+    ? leaf.value.join(", ")
+    : String(leaf.value);
+  return `${key}: ${value} (${leaf.evidence})`;
+}

--- a/packages/runtime/src/domain/cli/spec.ts
+++ b/packages/runtime/src/domain/cli/spec.ts
@@ -1,6 +1,7 @@
 import type { EffectPlan, WriteFilePrecondition } from "../effects.js";
 import type {
   ManagedFileObservation,
+  PartialProjectProfile,
   RepositoryEvidence,
   ResolvedInitAnswers,
 } from "../init/index.js";
@@ -108,7 +109,8 @@ export type JsonContractId =
   | "result@1.0.0"
   | "adapter-message@1.0.0"
   | "doctor-report@1.0.0"
-  | "phase-handoff@1.4.0";
+  | "phase-handoff@1.4.0"
+  | "project-profile@1.0.0";
 
 export interface Decision {
   readonly result: Result;
@@ -254,6 +256,17 @@ export type CommandObservation =
         string,
         ManagedFileObservation,
       ])[];
+    }
+  | {
+      readonly kind: "project-profile";
+      /**
+       * The profile the pure derivation produced for this project root.
+       *
+       * Only what a manifest or the directory layout actually says. A leaf it
+       * left out is reported as underived rather than filled in, because the
+       * whole point of publishing this is that nobody downstream guesses.
+       */
+      readonly derived: PartialProjectProfile;
     }
   | {
       readonly kind: "objective";

--- a/packages/runtime/src/domain/prompt-ceilings/discovery.ts
+++ b/packages/runtime/src/domain/prompt-ceilings/discovery.ts
@@ -45,15 +45,25 @@ stop and relay any refusal unchanged.
 
 ## Initialization interview
 
-Before \`kratos init\`, load \`scripts/project-profile-relay.mjs\` from this skill
-directory. Ask every exported \`projectProfileQuestions\` entry in order,
-presenting candidate suggestions derived from declarative manifests and
-repository evidence for user confirmation. Record confirmed answers as
-\`resolved\`, unconfirmed derived values with evidence as \`derived\`, explicitly
-omitted items as \`not-applicable\` with a reason, or \`unresolved\` if blank.
-Commands are exact single-line strings run from the project root, paths are
-project-relative lists, and implementation languages are programming languages
-rather than the human-language policy.
+Before \`kratos init\`, run
+\`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>\`
+from this skill directory. Its \`host.project-profile@1.0.0\` payload is the only
+source of interview candidates. Then load \`scripts/project-profile-relay.mjs\`
+from this skill directory and ask every exported \`projectProfileQuestions\` entry
+in order.
+
+Present an answer the payload reports as \`derived\` with its value and its
+evidence string for confirmation, and ask an answer it reports as \`unresolved\`
+blank. Never present a candidate the payload does not carry, and never add a
+description the payload does not carry. The runtime derives these, and a
+suggestion you author makes one repository answer differently for different
+operators.
+
+Record confirmed answers as \`resolved\`, unconfirmed derived values with their
+evidence as \`derived\`, explicitly omitted items as \`not-applicable\` with a
+reason, or \`unresolved\` if blank. Commands are exact single-line strings run
+from the project root, paths are project-relative lists, and implementation
+languages are programming languages rather than the human-language policy.
 
 Pass the keyed answers to \`relayProjectProfileAnswers\`, place its returned
 value in \`host.init-answers@1.6.0\` as \`projectProfile\`, and pipe that complete
@@ -132,15 +142,25 @@ stop and relay any refusal unchanged.
 
 ## Initialization interview
 
-Before \`kratos init\`, load \`scripts/project-profile-relay.mjs\` from this skill
-directory. Ask every exported \`projectProfileQuestions\` entry in order,
-presenting candidate suggestions derived from declarative manifests and
-repository evidence for user confirmation. Record confirmed answers as
-\`resolved\`, unconfirmed derived values with evidence as \`derived\`, explicitly
-omitted items as \`not-applicable\` with a reason, or \`unresolved\` if blank.
-Commands are exact single-line strings run from the project root, paths are
-project-relative lists, and implementation languages are programming languages
-rather than the human-language policy.
+Before \`kratos init\`, run
+\`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>\`
+from this skill directory. Its \`host.project-profile@1.0.0\` payload is the only
+source of interview candidates. Then load \`scripts/project-profile-relay.mjs\`
+from this skill directory and ask every exported \`projectProfileQuestions\` entry
+in order.
+
+Present an answer the payload reports as \`derived\` with its value and its
+evidence string for confirmation, and ask an answer it reports as \`unresolved\`
+blank. Never present a candidate the payload does not carry, and never add a
+description the payload does not carry. The runtime derives these, and a
+suggestion you author makes one repository answer differently for different
+operators.
+
+Record confirmed answers as \`resolved\`, unconfirmed derived values with their
+evidence as \`derived\`, explicitly omitted items as \`not-applicable\` with a
+reason, or \`unresolved\` if blank. Commands are exact single-line strings run
+from the project root, paths are project-relative lists, and implementation
+languages are programming languages rather than the human-language policy.
 
 Pass the keyed answers to \`relayProjectProfileAnswers\`, place its returned
 value in \`host.init-answers@1.6.0\` as \`projectProfile\`, and pipe that complete
@@ -213,15 +233,25 @@ stop and relay any refusal unchanged.
 
 ## Initialization interview
 
-Before \`kratos init\`, load \`scripts/project-profile-relay.mjs\` from this skill
-directory. Ask every exported \`projectProfileQuestions\` entry in order,
-presenting candidate suggestions derived from declarative manifests and
-repository evidence for user confirmation. Record confirmed answers as
-\`resolved\`, unconfirmed derived values with evidence as \`derived\`, explicitly
-omitted items as \`not-applicable\` with a reason, or \`unresolved\` if blank.
-Commands are exact single-line strings run from the project root, paths are
-project-relative lists, and implementation languages are programming languages
-rather than the human-language policy.
+Before \`kratos init\`, run
+\`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>\`
+from this skill directory. Its \`host.project-profile@1.0.0\` payload is the only
+source of interview candidates. Then load \`scripts/project-profile-relay.mjs\`
+from this skill directory and ask every exported \`projectProfileQuestions\` entry
+in order.
+
+Present an answer the payload reports as \`derived\` with its value and its
+evidence string for confirmation, and ask an answer it reports as \`unresolved\`
+blank. Never present a candidate the payload does not carry, and never add a
+description the payload does not carry. The runtime derives these, and a
+suggestion you author makes one repository answer differently for different
+operators.
+
+Record confirmed answers as \`resolved\`, unconfirmed derived values with their
+evidence as \`derived\`, explicitly omitted items as \`not-applicable\` with a
+reason, or \`unresolved\` if blank. Commands are exact single-line strings run
+from the project root, paths are project-relative lists, and implementation
+languages are programming languages rather than the human-language policy.
 
 Pass the keyed answers to \`relayProjectProfileAnswers\`, place its returned
 value in \`host.init-answers@1.6.0\` as \`projectProfile\`, and pipe that complete

--- a/packages/runtime/src/domain/schema/contracts.ts
+++ b/packages/runtime/src/domain/schema/contracts.ts
@@ -48,6 +48,7 @@ import type {
   ProjectConfigV1_4,
   ProjectConfigV1_5,
   PreToolUseV1,
+  ProjectProfileV1,
   RequirementDiscoveryV1,
   RepairLoopStopV1,
   RepairLoopStopV1_1,
@@ -95,6 +96,7 @@ export interface ContractValues {
   readonly "host.memory-curation": MemoryCurationV1_4;
   readonly "host.memory-migration": MemoryMigrationV1_2 | MemoryMigrationV1_4;
   readonly "host.pre-tool-use": PreToolUseV1;
+  readonly "host.project-profile": ProjectProfileV1;
   readonly "state.approval": ApprovalV1;
   readonly "state.curated-memory": CuratedMemoryV1 | CuratedMemoryV1_1;
   readonly "state.acceptance-criteria-snapshot": AcceptanceCriteriaSnapshotV1;

--- a/packages/runtime/src/infra/schema/catalog.ts
+++ b/packages/runtime/src/infra/schema/catalog.ts
@@ -23,6 +23,7 @@ import memoryMigrationV1_2Schema from "../../../../../schemas/host/memory-migrat
 import memoryMigrationV1_4Schema from "../../../../../schemas/host/memory-migration.v1.4.schema.json" with { type: "json" };
 import operationMessageSchema from "../../../../../schemas/host/operation-message.v1.schema.json" with { type: "json" };
 import preToolUseSchema from "../../../../../schemas/host/pre-tool-use.v1.schema.json" with { type: "json" };
+import projectProfileSchema from "../../../../../schemas/host/project-profile.v1.schema.json" with { type: "json" };
 import phaseHandoffV1_1Schema from "../../../../../schemas/host/phase-handoff.v1.1.schema.json" with { type: "json" };
 import phaseHandoffV1_2Schema from "../../../../../schemas/host/phase-handoff.v1.2.schema.json" with { type: "json" };
 import phaseHandoffV1_3Schema from "../../../../../schemas/host/phase-handoff.v1.3.schema.json" with { type: "json" };
@@ -291,6 +292,13 @@ export const EMBEDDED_SCHEMA_CATALOG: readonly EmbeddedSchemaEntry[] =
       version: "1.0.0",
       path: "schemas/host/pre-tool-use.v1.schema.json",
       schema: preToolUseSchema,
+    },
+    {
+      id: "host.project-profile",
+      family: "host",
+      version: "1.0.0",
+      path: "schemas/host/project-profile.v1.schema.json",
+      schema: projectProfileSchema,
     },
     {
       id: "state.acceptance-criteria-snapshot",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -98,6 +98,9 @@ The host family contains:
   current [`adapter-message.v1.1.schema.json`](host/adapter-message.v1.1.schema.json),
 - [`host.doctor-report@1.0.0`](host/doctor-report.v1.schema.json), the read-only
   effective-mode diagnostic report,
+- [`host.project-profile@1.0.0`](host/project-profile.v1.schema.json), the
+  read-only derived project profile every host presents before the
+  initialization interview,
 - [`gap-proposal.v1.schema.json`](host/gap-proposal.v1.schema.json), and
 - [`init-answers.v1.schema.json`](host/init-answers.v1.schema.json) plus its
   [`init-answers.v1.1.schema.json`](host/init-answers.v1.1.schema.json) and
@@ -135,8 +138,9 @@ The host family contains:
   [agent output contract](../docs/architecture/agent-output-contract.md) for the
   delimiter, the envelope, and the extraction rules. The
   current registry format is
-  [`contract-manifest.v1.10.schema.json`](contracts/contract-manifest.v1.10.schema.json).
+  [`contract-manifest.v1.11.schema.json`](contracts/contract-manifest.v1.11.schema.json).
   The immutable predecessors remain
+  [`contract-manifest.v1.10.schema.json`](contracts/contract-manifest.v1.10.schema.json),
   [`contract-manifest.v1.9.schema.json`](contracts/contract-manifest.v1.9.schema.json),
   [`contract-manifest.v1.8.schema.json`](contracts/contract-manifest.v1.8.schema.json),
   [`contract-manifest.v1.7.schema.json`](contracts/contract-manifest.v1.7.schema.json),

--- a/schemas/contracts/contract-manifest.v1.11.schema.json
+++ b/schemas/contracts/contract-manifest.v1.11.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kratos.dev/schemas/contracts/contract-manifest/v1.11",
+  "title": "Kratos contract family manifest v1.11",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contractVersion",
+    "pluginVersion",
+    "resultContract",
+    "reasonCatalog",
+    "stateContract",
+    "hostContract",
+    "schemas",
+    "legacyProfiles"
+  ],
+  "properties": {
+    "contractVersion": { "const": "1.0.0" },
+    "pluginVersion": { "const": "0.3.0" },
+    "resultContract": { "const": "1.0.0" },
+    "reasonCatalog": { "const": "1.11.0" },
+    "stateContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current", "readable", "migrationOnly"],
+      "properties": {
+        "current": { "const": "1.5.0" },
+        "readable": {
+          "const": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"]
+        },
+        "migrationOnly": { "const": ["0.9.0", "go-v3@0.6.5"] }
+      }
+    },
+    "hostContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current", "accepted"],
+      "properties": {
+        "current": { "const": "1.4.0" },
+        "accepted": {
+          "const": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"]
+        }
+      }
+    },
+    "schemas": {
+      "type": "array",
+      "minItems": 18,
+      "maxItems": 71,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/schemaEntry" }
+    },
+    "legacyProfiles": {
+      "type": "array",
+      "minItems": 14,
+      "maxItems": 14,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/legacyProfile" }
+    }
+  },
+  "$defs": {
+    "schemaEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "family", "version", "path", "boundary", "typeName"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^(?:state|host)\\.[a-z][a-z-]*$"
+        },
+        "family": { "enum": ["state", "host"] },
+        "version": {
+          "enum": [
+            "1.0.0",
+            "1.1.0",
+            "1.2.0",
+            "1.3.0",
+            "1.4.0",
+            "1.5.0",
+            "1.6.0"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^schemas/(?:state|host)/[a-z-]+\\.v1(?:\\.[123456])?\\.schema\\.json$"
+        },
+        "boundary": { "enum": ["persisted", "cross-process"] },
+        "typeName": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Za-z0-9]*V1(?:_[123456])?$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "family": { "const": "state" } },
+            "required": ["family"]
+          },
+          "then": {
+            "properties": {
+              "id": { "type": "string", "pattern": "^state\\." },
+              "path": { "type": "string", "pattern": "^schemas/state/" },
+              "boundary": { "const": "persisted" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "family": { "const": "host" } },
+            "required": ["family"]
+          },
+          "then": {
+            "properties": {
+              "id": { "type": "string", "pattern": "^host\\." },
+              "path": { "type": "string", "pattern": "^schemas/host/" },
+              "boundary": { "const": "cross-process" }
+            }
+          }
+        }
+      ]
+    },
+    "legacyProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "oracleId",
+        "payloadContract",
+        "schemaVersion",
+        "compatibility",
+        "parityRow"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z-]+\\.schema\\.json$"
+        },
+        "oracleId": { "const": "go-v3-v0.6.5" },
+        "payloadContract": {
+          "type": "string",
+          "pattern": "^go-v3\\.[a-z][a-z-]+@1$"
+        },
+        "schemaVersion": { "const": 1 },
+        "compatibility": { "const": "migration-only" },
+        "parityRow": {
+          "oneOf": [
+            { "type": "string", "pattern": "^SCHEMA-[A-Z-]+-JSON$" },
+            { "type": "null" }
+          ]
+        },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "name": { "const": "prd-output.schema.json" } },
+            "required": ["name"]
+          },
+          "then": {
+            "required": ["sha256"],
+            "properties": {
+              "payloadContract": { "const": "go-v3.prd-output@1" },
+              "parityRow": { "type": "null" },
+              "sha256": {
+                "const": "7fa4f468520fac2f2a0d3b766257e162d25f37520dd7507230616257f2fe503e"
+              }
+            }
+          },
+          "else": {
+            "not": { "required": ["sha256"] },
+            "properties": { "parityRow": { "type": "string" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/host/project-profile.v1.schema.json
+++ b/schemas/host/project-profile.v1.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kratos.dev/schemas/host/project-profile/v1",
+  "title": "Kratos derived project profile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contractVersion", "hostContract", "profile"],
+  "properties": {
+    "contractVersion": {
+      "const": "1.0.0"
+    },
+    "hostContract": {
+      "const": "1.4.0"
+    },
+    "profile": {
+      "$ref": "#/$defs/derivedProjectProfile"
+    }
+  },
+  "$defs": {
+    "command": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048,
+      "pattern": "^[^\\r\\n]+$"
+    },
+    "evidence": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[^\\r\\n]+$"
+    },
+    "convention": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "^[^\\r\\n]+$"
+    },
+    "implementationLanguage": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "projectPath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))(?![A-Za-z][A-Za-z0-9+.-]*:)(?!.*[\\u0000-\\u001F\\u007F]).+$"
+    },
+    "unresolved": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "const": "unresolved"
+        }
+      }
+    },
+    "derivedCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "value", "evidence"],
+      "properties": {
+        "status": {
+          "const": "derived"
+        },
+        "value": {
+          "$ref": "#/$defs/command"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "derivedPaths": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "value", "evidence"],
+      "properties": {
+        "status": {
+          "const": "derived"
+        },
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/projectPath"
+          }
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "derivedConvention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "value", "evidence"],
+      "properties": {
+        "status": {
+          "const": "derived"
+        },
+        "value": {
+          "$ref": "#/$defs/convention"
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "derivedImplementationLanguages": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "value", "evidence"],
+      "properties": {
+        "status": {
+          "const": "derived"
+        },
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/implementationLanguage"
+          }
+        },
+        "evidence": {
+          "$ref": "#/$defs/evidence"
+        }
+      }
+    },
+    "commandLeaf": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/derivedCommand"
+        },
+        {
+          "$ref": "#/$defs/unresolved"
+        }
+      ]
+    },
+    "pathsLeaf": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/derivedPaths"
+        },
+        {
+          "$ref": "#/$defs/unresolved"
+        }
+      ]
+    },
+    "conventionLeaf": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/derivedConvention"
+        },
+        {
+          "$ref": "#/$defs/unresolved"
+        }
+      ]
+    },
+    "implementationLanguagesLeaf": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/derivedImplementationLanguages"
+        },
+        {
+          "$ref": "#/$defs/unresolved"
+        }
+      ]
+    },
+    "derivedProjectProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commands", "paths", "conventions"],
+      "properties": {
+        "commands": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["test", "lint", "build", "run"],
+          "properties": {
+            "test": {
+              "$ref": "#/$defs/commandLeaf"
+            },
+            "lint": {
+              "$ref": "#/$defs/commandLeaf"
+            },
+            "build": {
+              "$ref": "#/$defs/commandLeaf"
+            },
+            "run": {
+              "$ref": "#/$defs/commandLeaf"
+            }
+          }
+        },
+        "paths": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "tests", "configuration"],
+          "properties": {
+            "source": {
+              "$ref": "#/$defs/pathsLeaf"
+            },
+            "tests": {
+              "$ref": "#/$defs/pathsLeaf"
+            },
+            "configuration": {
+              "$ref": "#/$defs/pathsLeaf"
+            }
+          }
+        },
+        "conventions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["directoryLayout", "naming", "implementationLanguages"],
+          "properties": {
+            "directoryLayout": {
+              "$ref": "#/$defs/conventionLeaf"
+            },
+            "naming": {
+              "$ref": "#/$defs/conventionLeaf"
+            },
+            "implementationLanguages": {
+              "$ref": "#/$defs/implementationLanguagesLeaf"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/check-contracts.mjs
+++ b/scripts/check-contracts.mjs
@@ -56,7 +56,7 @@ async function verifyArtifacts() {
   const manifestSchema = await readJson(
     join(
       repositoryRoot,
-      "schemas/contracts/contract-manifest.v1.10.schema.json",
+      "schemas/contracts/contract-manifest.v1.11.schema.json",
     ),
   );
   const resultSchema = await readJson(

--- a/tests/cli-commands.test.ts
+++ b/tests/cli-commands.test.ts
@@ -188,6 +188,7 @@ describe("implemented commands", () => {
       "migrate rollback",
       "narrate",
       "objective",
+      "profile derive",
       "repair",
       "repair resolve",
       "scope record",

--- a/tests/cli-contracts.test.ts
+++ b/tests/cli-contracts.test.ts
@@ -25,6 +25,7 @@ const schemaPaths = new Map([
   ["phase-handoff@1.3.0", "schemas/host/phase-handoff.v1.3.schema.json"],
   ["phase-handoff@1.1.0", "schemas/host/phase-handoff.v1.1.schema.json"],
   ["phase-handoff@1.2.0", "schemas/host/phase-handoff.v1.2.schema.json"],
+  ["project-profile@1.0.0", "schemas/host/project-profile.v1.schema.json"],
 ]);
 const validators = new Map<string, (value: unknown) => boolean>();
 

--- a/tests/command-observation.test.ts
+++ b/tests/command-observation.test.ts
@@ -82,6 +82,7 @@ describe("commands that observe before deciding", () => {
       "memory archive",
       "narrate",
       "objective",
+      "profile derive",
       "repair",
       "repair resolve",
       "start",

--- a/tests/contract-documentation.test.ts
+++ b/tests/contract-documentation.test.ts
@@ -416,6 +416,7 @@ describe("contract versioning documentation", () => {
       "contract-manifest.v1.6.schema.json",
       "contract-manifest.v1.9.schema.json",
       "contract-manifest.v1.10.schema.json",
+      "contract-manifest.v1.11.schema.json",
       "contract-manifest.v1.1.schema.json",
       "npm run contracts:generate",
       "npm run contracts:check",

--- a/tests/contract-manifest.test.ts
+++ b/tests/contract-manifest.test.ts
@@ -87,7 +87,7 @@ beforeAll(async () => {
     readJson<JsonObject>(
       join(
         repositoryRoot,
-        "schemas/contracts/contract-manifest.v1.10.schema.json",
+        "schemas/contracts/contract-manifest.v1.11.schema.json",
       ),
     ),
     readJson<Discovery>(
@@ -126,7 +126,7 @@ describe("contract family manifest", () => {
   });
 
   it("registers every readable payload schema by id and version with safe paths", async () => {
-    expect(manifest.schemas).toHaveLength(70);
+    expect(manifest.schemas).toHaveLength(71);
     expect(manifest.schemas).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -51,6 +51,7 @@ const artifacts = [
   ["host/hook-observation.v1.schema.json", "hook-observation.json", "host"],
   ["host/phase-lifecycle.v1.schema.json", "phase-lifecycle.json", "host"],
   ["host/pre-tool-use.v1.schema.json", "pre-tool-use.json", "host"],
+  ["host/project-profile.v1.schema.json", "project-profile.json", "host"],
   ["state/gap.v1.schema.json", "gap.json", "state"],
   ["state/gates.v1.schema.json", "gates.json", "state"],
   ["state/guardrails.v1.schema.json", "guardrails.json", "state"],
@@ -848,6 +849,10 @@ describe("versioned state and host schemas", () => {
     [
       "contracts/contract-manifest.v1.8.schema.json",
       "ba0d2563ea7dff1a81bea84c10fe2f4875daac9daada8ab5e21f292e04b62703",
+    ],
+    [
+      "contracts/contract-manifest.v1.10.schema.json",
+      "061fa654abbb12d4aa6dd065e1ce8dd0c19242871fc816c27730917dc1d48f0b",
     ],
     [
       "host/adapter-message.v1.1.schema.json",

--- a/tests/contract-type-generation.test.ts
+++ b/tests/contract-type-generation.test.ts
@@ -29,7 +29,7 @@ describe("schema-derived contract declarations", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe(
-      "contract families v1.0.0: verified (70 schemas; 14 legacy profiles; generated types current)\n",
+      "contract families v1.0.0: verified (71 schemas; 14 legacy profiles; generated types current)\n",
     );
     expect(after).toBe(before);
     expect(after).toContain("Generated from registered JSON Schemas.");

--- a/tests/profile-derive-command.test.ts
+++ b/tests/profile-derive-command.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ProjectProfileV1 } from "@kratos/contracts";
+import { createRuntime } from "@kratos/runtime/composition";
+import { runCommandLine } from "@kratos/runtime/composition/cli";
+import { recordingOutput } from "@kratos/runtime/infra/fake";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots: string[] = [];
+
+async function project(
+  files: Readonly<Record<string, string>>,
+): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "kratos-profile-derive-"));
+  roots.push(root);
+  for (const [path, content] of Object.entries(files)) {
+    const absolute = join(root, path);
+    await mkdir(join(absolute, ".."), { recursive: true });
+    await writeFile(absolute, content, "utf8");
+  }
+  return root;
+}
+
+async function derive(root: string, ...flags: readonly string[]) {
+  const output = recordingOutput();
+  const exitCode = await runCommandLine(
+    [...flags, "profile", "derive", "--root", root],
+    createRuntime({ output }),
+  );
+  return {
+    exitCode,
+    stdout: output.structured_.join(""),
+    stderr: output.human_.join(""),
+  };
+}
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+describe("the profile derive command", () => {
+  it("publishes every profile answer, derived ones carrying their evidence", async () => {
+    const root = await project({
+      "package.json": JSON.stringify({
+        name: "sample",
+        scripts: { test: "vitest run", lint: "eslint .", build: "tsc" },
+      }),
+      "src/index.ts": "export const value = 1;\n",
+      "tests/index.test.ts": "export const covered = true;\n",
+    });
+
+    const { exitCode, stdout } = await derive(root, "--json");
+
+    expect(exitCode).toBe(0);
+    const payload = JSON.parse(stdout) as ProjectProfileV1;
+    expect(payload.contractVersion).toBe("1.0.0");
+    expect(payload.hostContract).toBe("1.4.0");
+    expect(payload.profile).toEqual({
+      commands: {
+        test: {
+          status: "derived",
+          value: "npm test",
+          evidence: "package.json#scripts.test",
+        },
+        lint: {
+          status: "derived",
+          value: "npm run lint",
+          evidence: "package.json#scripts.lint",
+        },
+        build: {
+          status: "derived",
+          value: "npm run build",
+          evidence: "package.json#scripts.build",
+        },
+        // Nothing declares how this project runs, so nothing is offered for it.
+        run: { status: "unresolved" },
+      },
+      paths: {
+        source: {
+          status: "derived",
+          value: ["src"],
+          evidence: "directory:src",
+        },
+        tests: {
+          status: "derived",
+          value: ["tests"],
+          evidence: "directory:tests",
+        },
+        configuration: { status: "unresolved" },
+      },
+      conventions: {
+        directoryLayout: { status: "unresolved" },
+        naming: { status: "unresolved" },
+        implementationLanguages: {
+          status: "derived",
+          value: ["typescript"],
+          evidence: "census:typescript",
+        },
+      },
+    });
+  });
+
+  it("reports an answer the derivation cannot reach as unresolved rather than absent", async () => {
+    const root = await project({ "README.md": "# empty\n" });
+
+    const { exitCode, stdout } = await derive(root, "--json");
+
+    expect(exitCode).toBe(0);
+    const { profile } = JSON.parse(stdout) as ProjectProfileV1;
+    const leaves = [
+      ...Object.values(profile.commands),
+      ...Object.values(profile.paths),
+      ...Object.values(profile.conventions),
+    ];
+    expect(leaves).toEqual(
+      Array.from({ length: 10 }, () => ({ status: "unresolved" })),
+    );
+  });
+
+  it("answers one repository identically on every run", async () => {
+    const root = await project({
+      "go.mod": "module example.com/sample\n\ngo 1.24\n",
+      "app/main.go": "package main\n\nfunc main() {}\n",
+    });
+
+    const first = await derive(root, "--json");
+    const second = await derive(root, "--json");
+
+    expect(first.stdout).toBe(second.stdout);
+    const { profile } = JSON.parse(first.stdout) as ProjectProfileV1;
+    expect(profile.commands.test).toEqual({
+      status: "derived",
+      value: "go test ./...",
+      evidence: "go.mod",
+    });
+    expect(profile.paths.source).toEqual({
+      status: "derived",
+      value: ["app"],
+      evidence: "directory:app",
+    });
+  });
+
+  it("names each answer with its evidence in human output", async () => {
+    const root = await project({
+      Makefile: "test:\n\tgo test ./...\n",
+    });
+
+    const { exitCode, stdout } = await derive(root);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(
+      "projectProfile.commands.test: make test (Makefile:test)",
+    );
+    expect(stdout).toContain("projectProfile.commands.run: not derived");
+  });
+
+  it("writes nothing into the project it read", async () => {
+    const root = await project({ "package.json": '{ "name": "sample" }\n' });
+
+    expect((await derive(root, "--json")).exitCode).toBe(0);
+
+    // Reporting what a repository looks like must not be the thing that
+    // creates managed state in it.
+    expect((await readdir(root)).sort()).toEqual(["package.json"]);
+  });
+
+  it("refuses a root flag that conflicts with detection", async () => {
+    const root = await project({ "package.json": '{ "name": "sample" }\n' });
+
+    const { exitCode, stderr } = await derive(root, "--detect-root");
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("trail.uso");
+  });
+});

--- a/tests/schema-registry-fixtures.test.ts
+++ b/tests/schema-registry-fixtures.test.ts
@@ -64,6 +64,7 @@ import repairResolution from "../fixtures/contracts/v1/repair-resolution.json" w
 import repairResolutionV1_1 from "../fixtures/contracts/v1.1/repair-resolution.json" with { type: "json" };
 import repairRestart from "../fixtures/contracts/v1/repair-restart.json" with { type: "json" };
 import preToolUse from "../fixtures/contracts/v1/pre-tool-use.json" with { type: "json" };
+import projectProfile from "../fixtures/contracts/v1/project-profile.json" with { type: "json" };
 import requirementDiscovery from "../fixtures/contracts/v1/requirement-discovery.json" with { type: "json" };
 import runUsage from "../fixtures/contracts/v1/run-usage.json" with { type: "json" };
 import sessionTelemetry from "../fixtures/contracts/v1/session-telemetry.json" with { type: "json" };
@@ -341,6 +342,16 @@ const fixtures = [
     requiredField: "operation",
     structuralReasonCode: "guard.target_uninspectable",
     fixture: preToolUse,
+    invalidVersionReason: "contract.host_version_invalid",
+    unsupportedVersionReason: "contract.host_version_unsupported",
+  },
+  {
+    id: "host.project-profile",
+    version: "1.0.0",
+    versionField: "hostContract",
+    requiredField: "profile",
+    structuralReasonCode: "trail.output_invalido",
+    fixture: projectProfile,
     invalidVersionReason: "contract.host_version_invalid",
     unsupportedVersionReason: "contract.host_version_unsupported",
   },


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #200

Work ID: `ADP-12`

## Outcome and design

A host can obtain the derived project profile before it asks anything.

`kratos profile derive [--json]` publishes the profile the runtime derives for a
project root. It is a read-only observation of the same pure derivation `init`
already performs: `resolveCommandRoot`, then the existing bounded offline scan
(`observeRepositoryEvidence`), the declarative top-level manifest read
(`observeManifestContents`), and `deriveProjectProfile` over both — all through
`readOnlyPorts`, where every state-changing primitive refuses. It mutates
nothing, spawns nothing, executes no configured command, and requires no answers
document.

The problem it closes: the packaged skill told every host to present "candidate
suggestions derived from declarative manifests and repository evidence", and no
command produced them. `deriveProjectProfile` ran inside
`composition/init.ts`, *after* the answers document had already been read from
standard input, so by the time the runtime derived anything the interview was
over and the answers were fixed. Hosts filled the gap by reading the repository
with model judgment. Two operators initializing one repository were therefore
offered different candidates — the exact property ADP-08 exists to remove.

Design notes:

- **All ten answers are always present.** A leaf the derivation produced is
  `derived`, carrying the evidence string it came from; a leaf it did not
  produce is `unresolved` and carries nothing else. A host that cannot tell
  "derived nothing" from "was not asked" fills the silence with a candidate the
  runtime never produced, so absence is never used to mean either.
- **The payload contract admits no other leaf status.** `resolved` and
  `not-applicable` are answers a person gives; a derivation cannot produce them.
  Excluding them from the schema makes "a leaf the runtime did not derive
  carries no candidate" structural rather than advisory.
- **The derivation is not reimplemented.** The command observes
  `deriveProjectProfile`; `init` keeps calling it internally. One function, two
  callers.

Alternatives considered:

- *Extend `init` to emit candidates before consuming answers.* Rejected: `init`
  reads its document first by contract, and a command that sometimes writes and
  sometimes only reports is two commands wearing one name.
- *Return the profile in the `result@1.0.0` envelope only.* Rejected: the
  envelope has no data slot, so the profile would have to be parsed out of
  `why[]` prose. It is carried there for a human reader, but the machine-readable
  answer is a typed payload.
- *Reuse `host.init-answers@1.6.0` as the payload shape.* Rejected: that document
  requires `hosts`, which this command has no business knowing, and its leaves
  admit statuses a derivation cannot produce.

Out of scope: making the derivation itself richer. `derivePaths` still only
recognizes `src`/`lib`/`app`/`packages`, and directory-layout and naming
conventions still derive to nothing. This PR makes that visible and
deterministic; #198 and #201 own closing it. On the `.NET` monorepo from the
issue, the interview will now correctly show blank questions instead of
model-authored options.

## Compatibility and public contracts

- **Commands:** one addition, `profile derive`, with `--root`, `--detect-root`,
  and `--worktree-local`. No existing command changes. `init` behavior is
  unchanged for a caller that pipes a complete answers document.
- **Schemas:** new `host.project-profile@1.0.0`
  (`schemas/host/project-profile.v1.schema.json`), registered in the family
  manifest, the runtime schema catalog, `CONTRACT_VERSIONS`, and the generated
  declarations. Self-contained: it refs no other schema.
- **Contract manifest format:** registering the 71st schema exceeded
  `maxItems: 70` in `contract-manifest.v1.10`, which shipped with 0.3.0.
  `contract-manifest.v1.11.schema.json` carries the new bound and is now the
  format `check-contracts.mjs` and `tests/contract-manifest.test.ts` validate
  against. v1.10 is unchanged on disk and its digest is now frozen in
  `tests/contract-schemas.test.ts` beside the other superseded formats, rather
  than a released artifact being edited in place.
- **Host contract:** unchanged at `1.4.0`. **State contract:** unchanged at
  `1.5.0`. **Reason codes:** none added; the command reports the existing
  `runtime.orientation_ok`. **Exit codes:** unchanged.
- **Fixtures:** new `fixtures/contracts/v1/project-profile.json`.
- **Go-v3 parity:** no effect. The parity inventory describes the legacy oracle's
  30 commands and does not gain or lose a row; `npm run parity:check` reports the
  same `0 / 400`.
- **Host skills:** all three `SKILL.md` files change their initialization
  interview section, and the copies embedded in
  `packages/runtime/src/domain/prompt-ceilings/discovery.ts` change with them.
  A host now calls the command first, presents only what its payload carries,
  asks an `unresolved` answer blank, and is told plainly not to invent a
  candidate. The relay module `project-profile-relay.mjs` is unchanged: its
  `shapeProfileLeaf` already passes a typed leaf through.
- **Documentation:** `docs/user/commands.md`,
  `docs/architecture/project-initialization.md`,
  `docs/compatibility/contract-versioning.md`, `schemas/README.md`,
  `fixtures/README.md`.

## State, migration, security, and rollback

- **Project state, events, migration:** none. The command produces an empty
  effect plan, so nothing is written, no event is appended, and no lease is
  taken. `.brain` is neither read for authority nor created; the command works
  in a directory that was never initialized.
- **Filesystem:** reads only what initialization's existing bounded scan already
  reads — directory names within `SCAN_MAX_DEPTH`/`SCAN_MAX_ENTRIES`, and the
  five top-level declarative manifests. No new path is opened, and the walk
  already skips paths the filesystem refuses. Enforced structurally by
  `readOnlyPorts`, which replaces every mutating primitive with a refusal, and
  covered by a test asserting the target directory is byte-for-byte unchanged
  after a run.
- **Git, concurrency:** none. No Git command runs; no lock is acquired.
- **Privacy and security:** the payload can contain project-relative paths and
  manifest-declared command strings from the repository being read — the same
  values `init` already persists into `.brain/config.json` and the same scan
  ADP-08 shipped. No new class of data leaves the machine, and no network call
  or subprocess is made. Output passes the existing public-text and
  public-payload validators.
- **Supply chain:** no dependency added.
- **New trust boundaries, permissions, secrets:** none.
- **Rollback:** delete the command and its schema registration. Nothing persists
  it, so no state has to be undone. Reverting the manifest format means pointing
  `check-contracts.mjs` and the manifest test back at v1.10 and dropping the
  frozen digest row.

## Deterministic test evidence

- Acceptance evidence record: this PR body and
  `tests/profile-derive-command.test.ts`.
- Focused verification: below.
- Full repository verification: `npm run verify` is running locally and CI runs
  the same gates; I will post its result on this PR rather than claim it here.
- Diff hygiene: `git diff --check origin/main...HEAD` — clean, exit 0.

New suite:

```text
npx vitest run tests/profile-derive-command.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Suites whose recorded expectations this change moves:

```text
npx vitest run tests/cli-commands.test.ts tests/command-observation.test.ts \
  tests/cli-contracts.test.ts tests/contract-manifest.test.ts \
  tests/contract-schemas.test.ts tests/contract-documentation.test.ts \
  tests/schema-registry-fixtures.test.ts tests/contract-type-generation.test.ts
all passed
```

Complete suite:

```text
npx vitest run
Test Files  237 passed (237)
     Tests  5653 passed (5653)
exit=0
```

Individual gates:

```text
npm run typecheck                 pass
npm run lint                      pass (--max-warnings 0)
npm run format:check              All matched files use Prettier code style!
npm run spellcheck                Files checked: 252, Issues found: 0 in 0 files
npm run english:check             English-only source check passed.
npm run contracts:check           contract families v1.0.0: verified (71 schemas; 14 legacy profiles; generated types current)
npm run parity:check              402 keys; 30 commands; parity overall 0 / 400 (unchanged)
npm run result:check              result contract v1.0.0: verified (76 reasons; exits 0,1,2,3,4,5; 6 examples)
npm run differential:check        {"class":"self-test","equal":true,...}
npm run templates:validate        valid: documentation.yml, feature.yml, security-safe.yml
npm run prompts:ceilings:check    SUCCESS: All prompt size ceilings passed.
npm run build                     three host artifacts
npm run package:verify            Kratos package verification passed for Codex, Claude Code, and Antigravity.
```

Observed behavior on this repository:

```text
node scripts/run-built.mjs profile derive
projectProfile.commands.test: npm test (package.json#scripts.test)
projectProfile.commands.lint: npm run lint (package.json#scripts.lint)
projectProfile.commands.build: npm run build (package.json#scripts.build)
projectProfile.commands.run: not derived
projectProfile.paths.source: packages (directory:packages)
projectProfile.paths.tests: tests (directory:tests)
projectProfile.paths.configuration: not derived
projectProfile.conventions.directoryLayout: not derived
projectProfile.conventions.naming: not derived
projectProfile.conventions.implementationLanguages: typescript, javascript (census:typescript,javascript)
```

A note on the size ratchet, since it is close: `npm run performance:check`
passes at `runtimeSourceBytes: 1594495 / 1600000`. It was already tight before
this change; roughly 5.5KB of headroom remains.

## Prompt and model evaluations

Not applicable. The behavior this PR adds is deterministic and is covered by
deterministic tests. The skill-instruction change is prose whose effect is
enforced by the contract rather than measured: a host cannot present a candidate
the runtime did not derive, because the payload does not carry one.

## Failure evidence

The runtime as published has no command that returns a derived profile. Built
from `origin/main` (`ebb578f`) in a clean worktree:

```text
node <baseline-build>/codex/runtime/kratos.mjs --json profile derive
{"contractVersion":"1.0.0","status":"failure","exitCode":2,"reasonCode":"trail.uso",
 "summary":"The trail command arguments do not satisfy the operation usage contract.",
 "why":["The requested command is not registered in this runtime."],...}
exit=2
```

The new suite against that same baseline worktree, with its own installed
`node_modules` so the workspace symlinks resolve to baseline sources:

```text
npx vitest run tests/profile-derive-command.test.ts
Test Files  1 failed (1)
     Tests  5 failed | 1 passed (6)

× publishes every profile answer, derived ones carrying their evidence
    AssertionError: expected 2 to be +0
× reports an answer the derivation cannot reach as unresolved rather than absent
    AssertionError: expected 2 to be +0
× answers one repository identically on every run
× names each answer with its evidence in human output
    AssertionError: expected 2 to be +0
× writes nothing into the project it read
    AssertionError: expected 2 to be +0
```

Each failure is the same cause: exit code 2 (`trail.uso`, unregistered command)
where 0 was expected. The sixth case — "refuses a root flag that conflicts with
detection" — passes against the baseline for the wrong reason: an unknown command
and a conflicting flag both report `trail.uso`. I am recording that rather than
presenting six red tests, because only five of them are evidence.

Honest scope note: this was not written test-first commit by commit. The suite
above was authored alongside the implementation and then verified to fail
against `origin/main`, which is what the transcript shows.

## Provenance

- Sources used: this repository only — its existing `deriveProjectProfile`,
  `observeRepositoryEvidence`, `observeManifestContents`, `readOnlyPorts`, and
  the `doctor` command's typed-payload pattern, which the new command follows.
  All public, owned by this project, under its own license. No private or
  third-party material was consulted.
- Contribution method: `original`.
- Publication authority and required notices: not applicable; no adapted or
  verbatim third-party material.
- Confirmation: no secret, credential, customer or personal data, private
  infrastructure detail, or confidential business information is included. The
  fixture and the documented output contain only this repository's own public
  manifest values.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdX6DQ82KUTZrq8cqw5kzj
