### PR TITLE
feat(init): derive commands from the toolchain the census already identified (ADP-09)

### DIFF
--- a/packages/runtime/src/composition/repository.ts
+++ b/packages/runtime/src/composition/repository.ts
@@ -105,16 +105,12 @@ export async function observeManifestContents(
     packageJson?: string;
     makefile?: string;
     pyprojectToml?: string;
-    cargoToml?: string;
-    goMod?: string;
   } = {};
 
   const candidates: readonly (readonly [string, keyof ManifestContents])[] = [
     ["package.json", "packageJson"],
     ["Makefile", "makefile"],
     ["pyproject.toml", "pyprojectToml"],
-    ["Cargo.toml", "cargoToml"],
-    ["go.mod", "goMod"],
   ];
 
   for (const [filename, key] of candidates) {

--- a/packages/runtime/src/domain/init/derive.ts
+++ b/packages/runtime/src/domain/init/derive.ts
@@ -1,13 +1,23 @@
-import type { RepositoryEvidence } from "./stack.js";
-import { profileStack } from "./stack.js";
+import type {
+  DetectedStack,
+  RepositoryEvidence,
+  StackProfile,
+} from "./stack.js";
+import { STACK_COMMANDS, profileStack } from "./stack.js";
 import type { PartialProjectProfile, ProjectProfileLeaf } from "./profile.js";
 
+/**
+ * The manifests whose contents are read rather than whose names are matched.
+ *
+ * Only formats something below actually parses. Recognizing which toolchain a
+ * repository uses is the marker table's job in `stack.ts`; this is for the
+ * declarations a manifest makes about the project itself, which no file name
+ * can carry.
+ */
 export interface ManifestContents {
   readonly packageJson?: string;
   readonly makefile?: string;
   readonly pyprojectToml?: string;
-  readonly cargoToml?: string;
-  readonly goMod?: string;
 }
 
 const SOURCE_PATH_CANDIDATES = ["src", "lib", "app", "packages"] as const;
@@ -227,74 +237,59 @@ function derivePyprojectTomlCommands(
   }
 }
 
-function deriveCargoTomlCommands(
+const COMMAND_SLOTS = ["test", "lint", "build", "run"] as const;
+
+/**
+ * The longest evidence the profile schema stores. A marker buried under long
+ * directory names must not be why initialization refuses to write a profile,
+ * so the stack alone is named when its path would not fit.
+ */
+const EVIDENCE_MAX_LENGTH = 256;
+
+function stackEvidence(detected: DetectedStack): string {
+  const full = `stack:${detected.id} via ${detected.evidence}`;
+  return full.length <= EVIDENCE_MAX_LENGTH ? full : `stack:${detected.id}`;
+}
+
+/**
+ * Fill the slots the manifests did not state with the toolchain's own verbs.
+ *
+ * Runs after content derivation and never overwrites it: a declared
+ * `scripts.test` is a fact about this repository, while a canonical command is
+ * a convention about its ecosystem, and the fact wins. Stacks arrive ordered
+ * by identifier, so a polyglot repository resolves the same way every time.
+ *
+ * The evidence carries the marker that named the toolchain, so a canonical
+ * command still says where it came from and stays checkable.
+ */
+function deriveStackCommands(
+  stack: StackProfile,
   commands: Record<string, ProjectProfileLeaf<string>>,
 ): void {
-  if (!("test" in commands)) {
-    commands.test = {
-      status: "derived",
-      value: "cargo test",
-      evidence: "Cargo.toml",
-    };
-  }
-  if (!("lint" in commands)) {
-    commands.lint = {
-      status: "derived",
-      value: "cargo clippy",
-      evidence: "Cargo.toml",
-    };
-  }
-  if (!("build" in commands)) {
-    commands.build = {
-      status: "derived",
-      value: "cargo build",
-      evidence: "Cargo.toml",
-    };
-  }
-  if (!("run" in commands)) {
-    commands.run = {
-      status: "derived",
-      value: "cargo run",
-      evidence: "Cargo.toml",
-    };
+  for (const detected of stack.stacks) {
+    const canonical = STACK_COMMANDS[detected.id];
+    for (const slot of COMMAND_SLOTS) {
+      const value = canonical[slot];
+      if (value === undefined || slot in commands) continue;
+      commands[slot] = {
+        status: "derived",
+        value,
+        evidence: stackEvidence(detected),
+      };
+    }
   }
 }
 
-function deriveGoModCommands(
-  commands: Record<string, ProjectProfileLeaf<string>>,
-): void {
-  if (!("test" in commands)) {
-    commands.test = {
-      status: "derived",
-      value: "go test ./...",
-      evidence: "go.mod",
-    };
-  }
-  if (!("lint" in commands)) {
-    commands.lint = {
-      status: "derived",
-      value: "go vet ./...",
-      evidence: "go.mod",
-    };
-  }
-  if (!("build" in commands)) {
-    commands.build = {
-      status: "derived",
-      value: "go build ./...",
-      evidence: "go.mod",
-    };
-  }
-  if (!("run" in commands)) {
-    commands.run = {
-      status: "derived",
-      value: "go run .",
-      evidence: "go.mod",
-    };
-  }
-}
-
+/**
+ * Derive the four commands from what the repository declares, then from what
+ * its toolchain conventionally calls them.
+ *
+ * There is no file-name list here. The toolchain is whatever `profileStack`
+ * already named from the marker table, which is why an ecosystem that table
+ * recognizes cannot reach the interview with nothing derived.
+ */
 function deriveCommands(
-  evidence: RepositoryEvidence,
+  stack: StackProfile,
   manifests: ManifestContents,
 ): PartialProjectProfile["commands"] | undefined {
   const commands: Record<string, ProjectProfileLeaf<string>> = {};
@@ -307,32 +302,19 @@ function deriveCommands(
     derivePyprojectTomlCommands(manifests.pyprojectToml, commands);
   }
 
-  if (
-    manifests.cargoToml !== undefined ||
-    evidence.rootEntries.includes("Cargo.toml")
-  ) {
-    deriveCargoTomlCommands(commands);
-  }
-
-  if (
-    manifests.goMod !== undefined ||
-    evidence.rootEntries.includes("go.mod")
-  ) {
-    deriveGoModCommands(commands);
-  }
-
   if (manifests.makefile !== undefined) {
     deriveMakefileCommands(manifests.makefile, commands);
   }
+
+  deriveStackCommands(stack, commands);
 
   return Object.keys(commands).length > 0 ? commands : undefined;
 }
 
 function deriveConventions(
-  evidence: RepositoryEvidence,
+  stack: StackProfile,
 ): PartialProjectProfile["conventions"] | undefined {
-  const profile = profileStack(evidence);
-  const activeLanguages = profile.languages.filter((lang) => lang.files > 0);
+  const activeLanguages = stack.languages.filter((lang) => lang.files > 0);
 
   if (activeLanguages.length === 0) {
     return undefined;
@@ -356,9 +338,10 @@ export function deriveProjectProfile(
   evidence: RepositoryEvidence,
   manifests: ManifestContents = {},
 ): PartialProjectProfile {
-  const commands = deriveCommands(evidence, manifests);
+  const stack = profileStack(evidence);
+  const commands = deriveCommands(stack, manifests);
   const paths = derivePaths(evidence);
-  const conventions = deriveConventions(evidence);
+  const conventions = deriveConventions(stack);
 
   const profile: PartialProjectProfile = {
     ...(commands !== undefined ? { commands } : {}),

--- a/packages/runtime/src/domain/init/index.ts
+++ b/packages/runtime/src/domain/init/index.ts
@@ -43,6 +43,7 @@ export {
   SCAN_EXCLUDED_DIRECTORIES,
   SCAN_MAX_DEPTH,
   SCAN_MAX_ENTRIES,
+  STACK_COMMANDS,
   STACK_IDS,
 } from "./stack.js";
 export type {
@@ -52,6 +53,7 @@ export type {
   ObservedEvidence,
   ObservedExtension,
   RepositoryEvidence,
+  StackCommands,
   StackId,
   StackProfile,
 } from "./stack.js";

--- a/packages/runtime/src/domain/init/stack.ts
+++ b/packages/runtime/src/domain/init/stack.ts
@@ -286,6 +286,106 @@ const SUFFIX_MARKERS: readonly (readonly [string, StackId])[] = [
   [".vbproj", "dotnet"],
 ];
 
+/**
+ * What a toolchain calls its own test, lint, build, and run.
+ *
+ * The commands column of the marker table: a toolchain named above maps here,
+ * so recognizing an ecosystem and knowing how to drive it are one fact rather
+ * than two lists that drift. Adding an ecosystem is a marker row and a row
+ * here.
+ *
+ * Only the toolchain's own verbs. `cargo clippy` ships with the toolchain and
+ * `busted` does not, and a default naming a tool the project may never have
+ * installed is worse than asking. A slot left out is a slot the operator is
+ * asked about, which is why an ambiguous id leaves them out: `java` covers
+ * both Gradle and Maven and `haskell` both Stack and Cabal, so the id alone
+ * cannot say which binary to call. `node` leaves them out for the opposite
+ * reason -- a Node project states its commands in `package.json`, and a
+ * declared script is read from the manifest rather than assumed here.
+ *
+ * These are conventions, not facts about the repository. Anything a manifest
+ * declares outranks them, and like every derived value they reach the operator
+ * for confirmation.
+ */
+export interface StackCommands {
+  readonly test?: string;
+  readonly lint?: string;
+  readonly build?: string;
+  readonly run?: string;
+}
+
+/** No verb of its own that a project of this ecosystem reliably answers to. */
+const ASK: StackCommands = Object.freeze({});
+
+export const STACK_COMMANDS: Readonly<Record<StackId, StackCommands>> =
+  Object.freeze({
+    bun: Object.freeze({ test: "bun test" }),
+    clojure: ASK,
+    cmake: Object.freeze({
+      test: "ctest --test-dir build",
+      build: "cmake --build build",
+    }),
+    dart: Object.freeze({
+      test: "dart test",
+      lint: "dart analyze",
+      run: "dart run",
+    }),
+    deno: Object.freeze({ test: "deno test", lint: "deno lint" }),
+    dotnet: Object.freeze({
+      test: "dotnet test",
+      lint: "dotnet format",
+      build: "dotnet build",
+      run: "dotnet run",
+    }),
+    elixir: Object.freeze({
+      test: "mix test",
+      build: "mix compile",
+      run: "mix run",
+    }),
+    erlang: Object.freeze({
+      test: "rebar3 eunit",
+      build: "rebar3 compile",
+      run: "rebar3 shell",
+    }),
+    go: Object.freeze({
+      test: "go test ./...",
+      lint: "go vet ./...",
+      build: "go build ./...",
+      run: "go run .",
+    }),
+    haskell: ASK,
+    java: ASK,
+    julia: ASK,
+    lua: ASK,
+    node: ASK,
+    perl: ASK,
+    php: ASK,
+    python: Object.freeze({ test: "pytest" }),
+    r: ASK,
+    ruby: ASK,
+    rust: Object.freeze({
+      test: "cargo test",
+      lint: "cargo clippy",
+      build: "cargo build",
+      run: "cargo run",
+    }),
+    scala: Object.freeze({
+      test: "sbt test",
+      build: "sbt compile",
+      run: "sbt run",
+    }),
+    swift: Object.freeze({
+      test: "swift test",
+      build: "swift build",
+      run: "swift run",
+    }),
+    zig: Object.freeze({
+      test: "zig build test",
+      build: "zig build",
+      run: "zig build run",
+    }),
+  });
+
 /** Every toolchain this build knows, so a caller can enumerate them. */
 export const STACK_IDS: readonly StackId[] = Object.freeze(
   [

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -964,6 +964,56 @@ describe("the init command", () => {
     expect(files[".claude/settings.json"]).toContain("Bash(dotnet test)");
   });
 
+  it("derives the four commands from the toolchain the census named", async () => {
+    // The reproduction from ADP-09: a .NET solution matches no manifest the
+    // content reader parses, and the operator was asked for four commands the
+    // runtime had already identified the toolchain for.
+    const run = subject(ANSWERS, {}, {});
+    const dotnet = {
+      ...run,
+      ports: {
+        ...run.ports,
+        fileSystem: memoryFileSystem({
+          "Sample.sln": "Microsoft Visual Studio Solution File",
+          "src/Api/Api.csproj": "<Project />",
+          "src/Api/Program.cs": "class Program {}",
+        }),
+      },
+    };
+
+    expect(await runCommandLine(["init"], dotnet.ports)).toBe(0);
+
+    const files = run.storage.snapshot().files;
+    const config = JSON.parse(
+      files[".brain/config.json"] ?? "null",
+    ) as ProjectConfigV1_5;
+    expect(config.projectProfile.commands).toEqual({
+      test: {
+        status: "derived",
+        value: "dotnet test",
+        evidence: "stack:dotnet via Sample.sln",
+      },
+      lint: {
+        status: "derived",
+        value: "dotnet format",
+        evidence: "stack:dotnet via Sample.sln",
+      },
+      build: {
+        status: "derived",
+        value: "dotnet build",
+        evidence: "stack:dotnet via Sample.sln",
+      },
+      run: {
+        status: "derived",
+        value: "dotnet run",
+        evidence: "stack:dotnet via Sample.sln",
+      },
+    });
+    expect(files[".brain/01-architecture/stack-profile.md"] ?? "").toContain(
+      "### Test (derived from stack:dotnet via Sample.sln)",
+    );
+  });
+
   it("derives commands and paths from repository manifests when answers omit them", async () => {
     const pkg = JSON.stringify({
       scripts: {

--- a/tests/init-profile-derivation.test.ts
+++ b/tests/init-profile-derivation.test.ts
@@ -134,66 +134,172 @@ describe("pure project profile derivation", () => {
     });
   });
 
-  it("derives commands from Cargo.toml manifest", () => {
-    const manifests: ManifestContents = {
-      cargoToml: ["[package]", 'name = "sample"', 'version = "0.1.0"'].join(
-        "\n",
-      ),
-    };
-    const evidence = { rootEntries: ["Cargo.toml"] };
+  it("derives canonical commands from the Rust toolchain marker", () => {
+    const evidence = { rootEntries: ["Cargo.toml", "src"] };
 
-    const derived = deriveProjectProfile(evidence, manifests);
+    const derived = deriveProjectProfile(evidence, {});
 
     expect(derived.commands?.test).toEqual({
       status: "derived",
       value: "cargo test",
-      evidence: "Cargo.toml",
+      evidence: "stack:rust via Cargo.toml",
     });
     expect(derived.commands?.lint).toEqual({
       status: "derived",
       value: "cargo clippy",
-      evidence: "Cargo.toml",
+      evidence: "stack:rust via Cargo.toml",
     });
     expect(derived.commands?.build).toEqual({
       status: "derived",
       value: "cargo build",
-      evidence: "Cargo.toml",
+      evidence: "stack:rust via Cargo.toml",
     });
     expect(derived.commands?.run).toEqual({
       status: "derived",
       value: "cargo run",
-      evidence: "Cargo.toml",
+      evidence: "stack:rust via Cargo.toml",
     });
   });
 
-  it("derives commands from go.mod manifest", () => {
-    const manifests: ManifestContents = {
-      goMod: "module github.com/example/sample\n\ngo 1.22\n",
+  it("derives canonical commands from the Go toolchain marker", () => {
+    const evidence = { rootEntries: ["go.mod", "main.go"] };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "go test ./...",
+      evidence: "stack:go via go.mod",
+    });
+    expect(derived.commands?.lint).toEqual({
+      status: "derived",
+      value: "go vet ./...",
+      evidence: "stack:go via go.mod",
+    });
+    expect(derived.commands?.build).toEqual({
+      status: "derived",
+      value: "go build ./...",
+      evidence: "stack:go via go.mod",
+    });
+    expect(derived.commands?.run).toEqual({
+      status: "derived",
+      value: "go run .",
+      evidence: "stack:go via go.mod",
+    });
+  });
+
+  it("derives the four commands for a .NET solution the census names", () => {
+    const evidence = {
+      rootEntries: ["Sample.sln", "src"],
+      files: ["Sample.sln", "src/Api/Api.csproj", "src/Api/Program.cs"],
     };
-    const evidence = { rootEntries: ["go.mod"] };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "dotnet test",
+      evidence: "stack:dotnet via Sample.sln",
+    });
+    expect(derived.commands?.lint).toEqual({
+      status: "derived",
+      value: "dotnet format",
+      evidence: "stack:dotnet via Sample.sln",
+    });
+    expect(derived.commands?.build).toEqual({
+      status: "derived",
+      value: "dotnet build",
+      evidence: "stack:dotnet via Sample.sln",
+    });
+    expect(derived.commands?.run).toEqual({
+      status: "derived",
+      value: "dotnet run",
+      evidence: "stack:dotnet via Sample.sln",
+    });
+  });
+
+  it("names the nested marker that identified the toolchain", () => {
+    const evidence = {
+      rootEntries: ["src", "README.md"],
+      files: ["src/Api/Api.csproj", "src/Api/Program.cs"],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.commands?.build).toEqual({
+      status: "derived",
+      value: "dotnet build",
+      evidence: "stack:dotnet via src/Api/Api.csproj",
+    });
+  });
+
+  it("names the stack alone when the marker path would not fit the evidence", () => {
+    // A profile whose evidence exceeds what the schema stores would refuse to
+    // be written, and refusing to initialize is worse than a shorter answer.
+    const buried = `${"nested".repeat(45)}/Api.csproj`;
+    const evidence = { rootEntries: ["src"], files: [buried] };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "dotnet test",
+      evidence: "stack:dotnet",
+    });
+  });
+
+  it("keeps a declared manifest command ahead of the toolchain default", () => {
+    const manifests: ManifestContents = {
+      packageJson: JSON.stringify({ scripts: { test: "vitest run" } }),
+    };
+    const evidence = { rootEntries: ["package.json", "Cargo.toml"] };
 
     const derived = deriveProjectProfile(evidence, manifests);
 
     expect(derived.commands?.test).toEqual({
       status: "derived",
-      value: "go test ./...",
-      evidence: "go.mod",
-    });
-    expect(derived.commands?.lint).toEqual({
-      status: "derived",
-      value: "go vet ./...",
-      evidence: "go.mod",
+      value: "npm test",
+      evidence: "package.json#scripts.test",
     });
     expect(derived.commands?.build).toEqual({
       status: "derived",
-      value: "go build ./...",
-      evidence: "go.mod",
+      value: "cargo build",
+      evidence: "stack:rust via Cargo.toml",
     });
-    expect(derived.commands?.run).toEqual({
+  });
+
+  it("keeps a Makefile target ahead of the toolchain default", () => {
+    const manifests: ManifestContents = {
+      makefile: ["test:", "\tcargo nextest run"].join("\n"),
+    };
+    const evidence = { rootEntries: ["Makefile", "Cargo.toml"] };
+
+    const derived = deriveProjectProfile(evidence, manifests);
+
+    expect(derived.commands?.test).toEqual({
       status: "derived",
-      value: "go run .",
-      evidence: "go.mod",
+      value: "make test",
+      evidence: "Makefile:test",
     });
+  });
+
+  it("derives no command when the census cannot name the toolchain", () => {
+    const evidence = {
+      rootEntries: ["README.md", "src"],
+      files: ["src/tool.awk"],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.commands).toBeUndefined();
+  });
+
+  it("derives no command for an ecosystem whose toolchain the id cannot pin", () => {
+    const evidence = { rootEntries: ["pom.xml", "src"] };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.commands).toBeUndefined();
   });
 
   it("derives canonical source, tests, and configuration paths from directory layout", () => {

--- a/tests/init-stack-profile.test.ts
+++ b/tests/init-stack-profile.test.ts
@@ -3,6 +3,7 @@ import {
   profileStack,
   renderStackProfile,
   SCAN_EXCLUDED_DIRECTORIES,
+  STACK_COMMANDS,
   STACK_IDS,
   type StackId,
   unresolvedProjectProfile,
@@ -115,6 +116,31 @@ describe("toolchain markers", () => {
     expect([...STACK_IDS]).toEqual([...STACK_IDS].sort());
     expect(new Set(STACK_IDS).size).toBe(STACK_IDS.length);
     expect(STACK_IDS).toContain<StackId>("elixir");
+  });
+
+  it("gives every enumerated toolchain a commands row", () => {
+    // Command derivation reads this column instead of a list of its own, so a
+    // toolchain the markers name and the column forgets is an ecosystem that
+    // reaches the interview with nothing derived.
+    expect(Object.keys(STACK_COMMANDS).sort()).toEqual([...STACK_IDS]);
+    for (const id of STACK_IDS) {
+      const row = STACK_COMMANDS[id];
+      for (const slot of ["test", "lint", "build", "run"] as const) {
+        const command = row[slot];
+        if (command === undefined) continue;
+        expect(command.trim()).toBe(command);
+        expect(command.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("names the canonical .NET commands", () => {
+    expect(STACK_COMMANDS.dotnet).toEqual({
+      test: "dotnet test",
+      lint: "dotnet format",
+      build: "dotnet build",
+      run: "dotnet run",
+    });
   });
 });
 

--- a/tests/profile-derive-command.test.ts
+++ b/tests/profile-derive-command.test.ts
@@ -135,7 +135,7 @@ describe("the profile derive command", () => {
     expect(profile.commands.test).toEqual({
       status: "derived",
       value: "go test ./...",
-      evidence: "go.mod",
+      evidence: "stack:go via go.mod",
     });
     expect(profile.paths.source).toEqual({
       status: "derived",


### PR DESCRIPTION
Closes #196

## Problem

`kratos init` ran two independent detections and the second threw away what the
first found. `profileStack` already named the toolchain from the marker table,
and `deriveCommands` re-detected from a private list of five file names
(`package.json`, `Makefile`, `pyproject.toml`, `Cargo.toml`, `go.mod`). A `.NET`
solution matched none of the five, so the interview asked for the test, lint,
build, and run commands of a toolchain the runtime had already identified as
`dotnet`.

## Design

The marker table in `packages/runtime/src/domain/init/stack.ts` gains a commands
column, `STACK_COMMANDS`, keyed by `StackId` and exhaustive by type — the
compiler demands the row when a new marker names a new toolchain, so the two
lists cannot drift apart again. `deriveCommands` takes the `StackProfile` that
`profileStack` already produces (now computed once and shared with
`deriveConventions`) and has no file-name list of its own.

**Only the toolchain's own verbs are canonical.** `cargo clippy` ships with the
toolchain and `busted` does not, and a default naming a tool the project may
never have installed is worse than asking. So the rows are deliberately
incomplete where the id cannot decide: `java` covers both Gradle and Maven and
`haskell` both Stack and Cabal, so neither can say which binary to call, and
those slots stay questions. `node` leaves them empty for the opposite reason —
a Node project states its commands in `package.json`, and a declared script is
read from the manifest rather than assumed from a table.

**Precedence:** manifest content, then the toolchain default. A declared
\`scripts.test\` is a fact about that repository; a canonical command is a
convention about its ecosystem, and the fact wins. Each stage only fills a slot
still empty.

**Evidence:** \`stack:dotnet via src/Api/Api.csproj\` — a derived command still
says which marker produced it. When the marker path would exceed the 256 bytes
the profile schema stores, the evidence falls back to \`stack:dotnet\`: refusing
to write the profile because a directory name is long would be worse than a
shorter answer.

### Alternative considered

Splitting `java` into `gradle`/`maven` and `haskell` into `stack`/`cabal` would
let those ecosystems carry defaults, but `StackId` keys the rules files and the
permission table, so it is a public-contract change belonging to its own issue.
Leaving those slots unanswered is the behavior the issue asks for anyway: a
toolchain the census cannot pin still asks.

## Public contract

- `STACK_COMMANDS` and `StackCommands` are exported from
  `@kratos/runtime/domain/init`.
- `ManifestContents` drops `cargoToml` and `goMod`. No parser read either — they
  were file-name detection wearing a content field — and composition no longer
  opens those two files. Rust and Go now come from the table, so their evidence
  changed from `Cargo.toml` to `stack:rust via Cargo.toml` and from `go.mod` to
  `stack:go via go.mod`.
- No schema, state, or migration change: `derived` leaves already carried
  arbitrary single-line evidence under 256 bytes.
- Security: derivation stays pure — no subprocess, no clock, no network — and a
  canonical command is still `derived`, never `resolved`, so it reaches the
  operator for confirmation and cannot on its own satisfy a gate requiring an
  operator decision.

## Acceptance

| Criterion | Evidence |
| --- | --- |
| A `.NET` repository initializes with the four commands derived, each carrying the marker that produced it | `tests/init-profile-derivation.test.ts` (`Sample.sln`, and a nested `src/Api/Api.csproj`), plus end-to-end in `tests/init-command.test.ts` asserting the persisted `.brain/config.json` and the `stack-profile.md` provenance line |
| A repository whose `package.json` declares `scripts.test` keeps `npm test` rather than the toolchain default | `tests/init-profile-derivation.test.ts` — `package.json` beside `Cargo.toml` keeps `npm test` and takes `cargo build` for the empty slot; a `Makefile` target likewise outranks the default |
| A repository whose toolchain the census cannot name still asks, unchanged | `tests/init-profile-derivation.test.ts` — a tree of `.awk` files derives no command, and so does a `pom.xml` whose id cannot pin the binary |
| `deriveCommands` has no private file-name list | `packages/runtime/src/domain/init/derive.ts` — it reads `StackProfile` and `STACK_COMMANDS`; `tests/init-stack-profile.test.ts` asserts every `STACK_ID` has a row |

## Verification

| Command | Result |
| --- | --- |
| `npx vitest run` | 237 files, 5664 tests passed |
| `npm run typecheck` | passed |
| `npm run lint` | passed |
| `npm run format:check` | passed |
| `npm run english:check` | passed |
| `npm run spellcheck` | 252 files, 0 issues |
| `npm run contracts:check` | 71 schemas verified, generated types current |
| `npm run result:check` | 76 reasons verified |
| `npm run performance:check` | `runtimeSourceBytes: 1599037 / 1600000` |

Failure evidence from the cycle: before the fix, `tests/init-profile-derivation.test.ts`
derived nothing for a `.sln`/`.csproj` tree; after it, the stale evidence
assertion in `tests/profile-derive-command.test.ts` failed with
`expected "go.mod" to be "stack:go via go.mod"`, which is exactly the provenance
change this PR makes and is updated here.

## Note for the reviewer

`runtimeSourceBytes` lands at 1599037 of a 1600000 budget — about 950 bytes of
headroom — so the next change under `packages/runtime/src` will likely need the
budget raised, as #194 did for the schema budget. I left it alone because this
change passes under the current ceiling.

`STACK_TOOLCHAIN_COMMANDS` in `permissions.ts` remains a separate per-stack
table. It answers a different question (which commands the host may run without
asking) and unifying it would change the generated allowlist, so it is out of
scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159rV3bKBBdweMLrjFBLjG6