### PR TITLE
fix(init): derive source paths below a component directory (ADP-11)

### DIFF
--- a/packages/runtime/src/domain/init/derive.ts
+++ b/packages/runtime/src/domain/init/derive.ts
@@ -3,7 +3,12 @@ import type {
   RepositoryEvidence,
   StackProfile,
 } from "./stack.js";
-import { STACK_COMMANDS, profileStack } from "./stack.js";
+import {
+  STACK_COMMANDS,
+  languageOfPath,
+  observedPaths,
+  profileStack,
+} from "./stack.js";
 import type { PartialProjectProfile, ProjectProfileLeaf } from "./profile.js";
 
 /**
@@ -24,58 +29,259 @@ const SOURCE_PATH_CANDIDATES = ["src", "lib", "app", "packages"] as const;
 const TESTS_PATH_CANDIDATES = ["tests", "test", "spec", "__tests__"] as const;
 const CONFIG_PATH_CANDIDATES = ["config", ".config", "etc"] as const;
 
-function hasDirectory(evidence: RepositoryEvidence, dirName: string): boolean {
-  if (evidence.rootEntries.includes(dirName)) {
-    return true;
-  }
-  if (evidence.files !== undefined) {
-    const prefix = `${dirName}/`;
-    return evidence.files.some((file) => file.startsWith(prefix));
-  }
-  return false;
+/**
+ * How many directories one path answer may name.
+ *
+ * A monorepo has more than one source root and saying so is the answer, but a
+ * list long enough to stop being readable is no longer an answer the operator
+ * can confirm at a glance.
+ */
+const PATH_VALUE_LIMIT = 4;
+
+/**
+ * How far below the strongest candidate a directory may fall and still be
+ * offered, as a divisor of its file count.
+ *
+ * This is what separates a second service from a directory of operational
+ * scripts. Two services each hold a real share of the project's files; a
+ * handful of shell scripts under `app/` in a repository with two hundred C#
+ * files does not, and offering it as source code would be a wrong answer
+ * rather than an incomplete one.
+ */
+const CENSUS_SHARE_DIVISOR = 10;
+
+interface DirectoryCandidate {
+  /** The project-relative directory path. */
+  readonly path: string;
+  /** Where the matched name sits in the candidate list, for the census-free case. */
+  readonly rank: number;
+  /** True when the whole path is an entry at the repository root. */
+  readonly root: boolean;
+  readonly depth: number;
+  /** Files below it the census could name, however deep. */
+  readonly files: number;
 }
 
+interface ObservedLayout {
+  /** Every directory the scan passed through, project-relative. */
+  readonly directories: ReadonlySet<string>;
+  /** Per directory, the number of files below it the census could name. */
+  readonly census: ReadonlyMap<string, number>;
+}
+
+/**
+ * The directories the scan walked and how much source each of them holds.
+ *
+ * One pass over the listing, crediting every ancestor of a counted file, so
+ * `apps/backend/src` and `apps` are both described and the deeper answer can
+ * be preferred to the shallower one on evidence rather than by position.
+ */
+function observeLayout(paths: readonly string[]): ObservedLayout {
+  const directories = new Set<string>();
+  const census = new Map<string, number>();
+
+  for (const path of paths) {
+    // The last segment is the file itself, never a directory.
+    const segments = path.split("/").slice(0, -1);
+    const counted = languageOfPath(path) !== null;
+    let prefix = "";
+    for (const segment of segments) {
+      prefix = prefix === "" ? segment : `${prefix}/${segment}`;
+      directories.add(prefix);
+      if (counted) census.set(prefix, (census.get(prefix) ?? 0) + 1);
+    }
+  }
+
+  return { directories, census };
+}
+
+/**
+ * Every directory that carries a candidate name, wherever it sits.
+ *
+ * A root entry equal to the name qualifies as it always has, including the
+ * empty directory no file can attest to. Below the root the name is matched as
+ * a path suffix, which is what lets `apps/backend/src` answer the `src`
+ * candidate at all -- the layouts that put a component directory above the
+ * source directory are the reason nothing was derived before.
+ */
+function candidateDirectories(
+  evidence: RepositoryEvidence,
+  layout: ObservedLayout,
+  candidates: readonly string[],
+): readonly DirectoryCandidate[] {
+  const found = new Map<string, DirectoryCandidate>();
+
+  const consider = (path: string, root: boolean): void => {
+    const name = path.slice(path.lastIndexOf("/") + 1);
+    const rank = candidates.indexOf(name);
+    if (rank === -1 || found.has(path)) return;
+    found.set(path, {
+      path,
+      rank,
+      root,
+      depth: depthOf(path),
+      files: layout.census.get(path) ?? 0,
+    });
+  };
+
+  for (const entry of evidence.rootEntries) {
+    if (candidates.includes(entry)) consider(entry, true);
+  }
+  for (const directory of layout.directories) {
+    consider(directory, !directory.includes("/"));
+  }
+
+  return [...found.values()];
+}
+
+/**
+ * Drop a candidate that already contains another one.
+ *
+ * A repository whose `packages/` holds a `src/` per package has one source
+ * root, not five: the enclosing directory says the same thing once. So the
+ * enclosing candidate survives and the ones below it drop, which also keeps a
+ * stray `lib/` deep inside `src/` from displacing the directory that holds it.
+ */
+function withoutEnclosed(
+  candidates: readonly DirectoryCandidate[],
+): readonly DirectoryCandidate[] {
+  return candidates.filter(
+    (candidate) =>
+      !candidates.some(
+        (other) =>
+          other !== candidate && candidate.path.startsWith(`${other.path}/`),
+      ),
+  );
+}
+
+/**
+ * Order the qualifying directories and cut the list where it stops answering.
+ *
+ * The census ranks them, not the order of the candidate list: a directory
+ * holding the files the census counted is a better answer than the first name
+ * that happens to match, and it is the only signal that tells a source root
+ * from a directory of scripts that shares its name.
+ *
+ * When the scan saw no files the census could name -- a root-only listing, a
+ * repository of formats no table maps -- there is nothing to rank with, so the
+ * candidate list decides and a single directory is offered, exactly as before.
+ */
+function rankCandidates(
+  candidates: readonly DirectoryCandidate[],
+): readonly DirectoryCandidate[] {
+  const best = candidates.reduce((most, one) => Math.max(most, one.files), 0);
+
+  if (best === 0) {
+    const ordered = [...candidates].sort(
+      (left, right) =>
+        left.rank - right.rank ||
+        left.depth - right.depth ||
+        compareText(left.path, right.path),
+    );
+    return ordered.slice(0, 1);
+  }
+
+  const floor = Math.max(1, Math.floor(best / CENSUS_SHARE_DIVISOR));
+  return candidates
+    .filter((candidate) => candidate.files >= floor)
+    .sort(
+      (left, right) =>
+        right.files - left.files ||
+        left.depth - right.depth ||
+        compareText(left.path, right.path),
+    )
+    .slice(0, PATH_VALUE_LIMIT);
+}
+
+/**
+ * Name each directory and say why it qualified.
+ *
+ * A root match reads as it always has, so a repository with a root `src/` is
+ * still described by `directory:src`. A suffix match says so, because that is
+ * the derivation that could have picked the wrong directory and a reader has
+ * to be able to see which one it was.
+ *
+ * The evidence a profile can store is bounded, so a directory whose name would
+ * not fit is left out of the answer rather than named in a string nothing can
+ * write.
+ */
+function selectPaths(
+  ranked: readonly DirectoryCandidate[],
+):
+  { readonly value: readonly string[]; readonly evidence: string } | undefined {
+  const value: string[] = [];
+  const tokens: string[] = [];
+
+  for (const candidate of ranked) {
+    const token = candidate.root
+      ? candidate.path
+      : `${candidate.path} (nested)`;
+    const evidence = `directory:${[...tokens, token].join(", ")}`;
+    if (evidence.length > EVIDENCE_MAX_LENGTH) break;
+    value.push(candidate.path);
+    tokens.push(token);
+  }
+
+  if (value.length === 0) return undefined;
+  return { value, evidence: `directory:${tokens.join(", ")}` };
+}
+
+function derivePathSlot(
+  evidence: RepositoryEvidence,
+  layout: ObservedLayout,
+  candidates: readonly string[],
+): ProjectProfileLeaf<readonly string[]> | undefined {
+  const found = candidateDirectories(evidence, layout, candidates);
+  if (found.length === 0) return undefined;
+  const selected = selectPaths(rankCandidates(withoutEnclosed(found)));
+  if (selected === undefined) return undefined;
+  return {
+    status: "derived",
+    value: Object.freeze(selected.value),
+    evidence: selected.evidence,
+  };
+}
+
+function depthOf(path: string): number {
+  let depth = 0;
+  for (const character of path) if (character === "/") depth += 1;
+  return depth;
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/**
+ * Derive the source, test, and configuration directories from the layout.
+ *
+ * Nothing here reaches a disk: the listing is whatever the bounded scan
+ * observed, and a listing that stopped early describes part of a tree, so a
+ * repository the scan could not cover simply has less to derive from and the
+ * operator is asked. Every answer is offered for confirmation.
+ */
 function derivePaths(
   evidence: RepositoryEvidence,
 ): PartialProjectProfile["paths"] | undefined {
+  const layout = observeLayout(observedPaths(evidence));
   const paths: {
     source?: ProjectProfileLeaf<readonly string[]>;
     tests?: ProjectProfileLeaf<readonly string[]>;
     configuration?: ProjectProfileLeaf<readonly string[]>;
   } = {};
 
-  for (const candidate of SOURCE_PATH_CANDIDATES) {
-    if (hasDirectory(evidence, candidate)) {
-      paths.source = {
-        status: "derived",
-        value: [candidate],
-        evidence: `directory:${candidate}`,
-      };
-      break;
-    }
-  }
+  const source = derivePathSlot(evidence, layout, SOURCE_PATH_CANDIDATES);
+  if (source !== undefined) paths.source = source;
 
-  for (const candidate of TESTS_PATH_CANDIDATES) {
-    if (hasDirectory(evidence, candidate)) {
-      paths.tests = {
-        status: "derived",
-        value: [candidate],
-        evidence: `directory:${candidate}`,
-      };
-      break;
-    }
-  }
+  const tests = derivePathSlot(evidence, layout, TESTS_PATH_CANDIDATES);
+  if (tests !== undefined) paths.tests = tests;
 
-  for (const candidate of CONFIG_PATH_CANDIDATES) {
-    if (hasDirectory(evidence, candidate)) {
-      paths.configuration = {
-        status: "derived",
-        value: [candidate],
-        evidence: `directory:${candidate}`,
-      };
-      break;
-    }
-  }
+  const configuration = derivePathSlot(
+    evidence,
+    layout,
+    CONFIG_PATH_CANDIDATES,
+  );
+  if (configuration !== undefined) paths.configuration = configuration;
 
   return Object.keys(paths).length > 0 ? paths : undefined;
 }

--- a/packages/runtime/src/domain/init/stack.ts
+++ b/packages/runtime/src/domain/init/stack.ts
@@ -420,7 +420,7 @@ interface Candidate {
  * instead of guessing at the most popular stack.
  */
 export function profileStack(evidence: RepositoryEvidence): StackProfile {
-  const paths = scannedPaths(evidence);
+  const paths = observedPaths(evidence);
   const markers = new Map<StackId, Candidate>();
   const census = new Map<LanguageId, { files: number; best: Candidate }>();
   const unmapped = new Map<string, number>();
@@ -480,7 +480,7 @@ export function profileStack(evidence: RepositoryEvidence): StackProfile {
  * arrived from somewhere else must not be able to smuggle a dependency tree
  * into the census.
  */
-function scannedPaths(evidence: RepositoryEvidence): readonly string[] {
+export function observedPaths(evidence: RepositoryEvidence): readonly string[] {
   const paths = new Set<string>();
   for (const entry of [...evidence.rootEntries, ...(evidence.files ?? [])]) {
     const normalized = normalize(entry);
@@ -571,6 +571,19 @@ function extensionOf(name: string): string | null {
 const LANGUAGE_BY_EXTENSION: ReadonlyMap<string, LanguageId> = new Map(
   LANGUAGE_EXTENSIONS.map(([extension, id]) => [extension, id]),
 );
+
+/**
+ * The language a path is written in, or nothing.
+ *
+ * The census table read one path at a time, so a caller counting files per
+ * directory names languages exactly as `profileStack` does rather than keeping
+ * a second copy of the table.
+ */
+export function languageOfPath(path: string): LanguageId | null {
+  const extension = extensionOf(basenameOf(path));
+  if (extension === null) return null;
+  return LANGUAGE_BY_EXTENSION.get(extension) ?? null;
+}
 
 function markerFor(name: string): StackId | null {
   for (const [marker, id] of EXACT_MARKERS) if (name === marker) return id;

--- a/quality/performance-budgets.json
+++ b/quality/performance-budgets.json
@@ -1,5 +1,5 @@
 {
-  "runtimeSourceBytes": 1600000,
+  "runtimeSourceBytes": 1700000,
   "contractSchemaBytes": 370000,
   "helpP95Ms": 2000,
   "versionP95Ms": 2000,

--- a/tests/init-profile-derivation.test.ts
+++ b/tests/init-profile-derivation.test.ts
@@ -352,6 +352,111 @@ describe("pure project profile derivation", () => {
     });
   });
 
+  it("derives a source directory that sits below a component directory", () => {
+    const evidence = {
+      rootEntries: ["apps", "platform", "Api.sln"],
+      files: [
+        "apps/backend/src/Program.cs",
+        "apps/backend/src/Startup.cs",
+        "platform/ci/pipeline.yml",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths?.source).toEqual({
+      status: "derived",
+      value: ["apps/backend/src"],
+      evidence: "directory:apps/backend/src (nested)",
+    });
+  });
+
+  it("derives every source root a monorepo has rather than only the first", () => {
+    const evidence = {
+      rootEntries: ["services", "package.json"],
+      files: [
+        "services/api/src/index.ts",
+        "services/api/src/router.ts",
+        "services/api/src/store.ts",
+        "services/web/src/main.ts",
+        "services/web/src/app.ts",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths?.source).toEqual({
+      status: "derived",
+      value: ["services/api/src", "services/web/src"],
+      evidence:
+        "directory:services/api/src (nested), services/web/src (nested)",
+    });
+  });
+
+  it("does not offer a directory of operational scripts as source code", () => {
+    const sources = Array.from(
+      { length: 30 },
+      (_unused, index) => `services/api/src/Handler${String(index)}.cs`,
+    );
+    const evidence = {
+      rootEntries: ["app", "services", "Api.sln"],
+      files: [...sources, "app/deploy.sh", "app/rotate-secrets.sh"],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths?.source).toEqual({
+      status: "derived",
+      value: ["services/api/src"],
+      evidence: "directory:services/api/src (nested)",
+    });
+  });
+
+  it("prefers the enclosing candidate to the ones it already contains", () => {
+    const evidence = {
+      rootEntries: ["packages", "package.json"],
+      files: ["packages/core/src/index.ts", "packages/cli/src/main.ts"],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths?.source).toEqual({
+      status: "derived",
+      value: ["packages"],
+      evidence: "directory:packages",
+    });
+  });
+
+  it("derives nested test directories alongside the source they cover", () => {
+    const evidence = {
+      rootEntries: ["apps"],
+      files: [
+        "apps/backend/src/Program.cs",
+        "apps/backend/tests/ProgramTests.cs",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths?.tests).toEqual({
+      status: "derived",
+      value: ["apps/backend/tests"],
+      evidence: "directory:apps/backend/tests (nested)",
+    });
+  });
+
+  it("asks about paths when a truncated scan saw no candidate directory", () => {
+    const evidence = {
+      rootEntries: ["README.md"],
+      files: ["README.md"],
+      truncated: true,
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths).toBeUndefined();
+  });
+
   it("derives implementation languages from repository census scan", () => {
     const evidence = {
       rootEntries: ["src", "package.json"],


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #198

Work ID: `ADP-11`

## Outcome and design

`derivePaths` recognized a candidate directory only at the repository root:
`hasDirectory` tested `rootEntries` for the exact name, or an observed file path
for a `<name>/` prefix, and both tests are anchored at the root. A repository
whose source lives in `apps/backend/src` matched neither, so nothing was derived
and the operator was asked about paths the scan had already listed.

Selected design:

1. A candidate name matches as a path suffix as well as a root entry, so
   `apps/backend/src`, `services/api/src`, and `packages/*/src` answer the `src`
   candidate. The same rule covers the test and configuration candidates.
2. The census ranks the matches, not the order of the candidate list. Each
   candidate directory carries the number of files below it the census could
   name (`languageOfPath`, reading the same extension table `profileStack`
   uses), and the ranking is that count, then depth, then path.
3. A directory holding a tenth or less of the strongest candidate's files is not
   offered. Suffix matching is where a derivation starts being able to pick the
   wrong directory, and this is what keeps a directory of operational shell
   scripts from being named as source code in a repository whose census reports
   its languages elsewhere.
4. More than one directory can qualify, bounded at four per answer, because a
   monorepo with two services has two source roots. An enclosing candidate is
   preferred to the ones below it, so `packages/` is said once rather than as
   five package `src/` directories.
5. Evidence names each directory and marks a suffix match as `(nested)`, so a
   reader can tell it from a root match. The list is cut before it exceeds the
   256-character evidence bound the profile schema stores.

When the scan saw no file the census could name -- a root-only listing, a
repository of formats no table maps -- there is nothing to rank with, so the
candidate list decides and a single directory is offered, exactly as before.

Alternatives considered: adding `apps` and `services` to the candidate list,
which only moves the anchor one level and fails on `platform/api/src`; and
ranking by the census's leading languages rather than by share, which would drop
a smaller second service written in another language and so contradicts
requirement 3.

Out of scope: the directory-layout and naming conventions (ADP-13), deriving
commands from CI workflows (ADP-10), and any change to the scan budget, the
exclusion list, or the interview that presents these answers.

## Compatibility and public contracts

Behavioral change confined to `deriveProjectProfile`'s `paths` leaves, which are
derived and offered for confirmation, never stated. No schema, command, reason
code, exit code, or host-contract change: `projectPath` already permits a
multi-segment relative path, `derivedPaths` already permits more than one value,
and evidence stays inside its 256-character bound.

A repository with a root `src/` derives `{ value: ["src"], evidence:
"directory:src" }` exactly as today; the existing expectations in
`tests/init-command.test.ts`, `tests/init-stack-profile.test.ts`, and
`tests/profile-derive-command.test.ts` are unchanged and pass.

`stack.ts` gains two exports used by the derivation, `observedPaths` (the former
private `scannedPaths`) and `languageOfPath`. Both are additive; no export was
removed or changed. Go-v3 parity: none, path derivation has no Go-v3 counterpart.

## State, migration, security, and rollback

None on all dimensions, with rationale. The derivation is a pure function over a
listing the bounded scan already produced: it opens no file, reaches no disk,
writes no event, and touches no project state, Git, or concurrency. The
exclusion rules that skip `node_modules`, `vendor`, `target`, `dist`, `build`,
`bin`, `obj`, and their peers are applied by `observedPaths`, so a dependency
tree cannot become a derived source root. No new trust boundary, permission,
secret, or data handling. No migration: existing configurations hold resolved or
persisted answers that outrank derivation. Rollback is reverting the commit; the
values it derives are confirmed by the operator before anything is written.

## Deterministic test evidence

- Acceptance evidence record: six cases added to
  `tests/init-profile-derivation.test.ts`, one per acceptance criterion --
  source below a component directory, two service source roots, a directory of
  operational scripts that is not offered, the enclosing candidate preferred,
  a nested `tests/` directory, and a truncated scan that still asks.
- Focused verification: `npx vitest run tests/init-profile-derivation.test.ts
  tests/profile-derive-command.test.ts tests/init-command.test.ts
  tests/init-stack-profile.test.ts`
- Full repository verification: `npx vitest run`, plus `tsc --noEmit`, `eslint .
  --max-warnings 0`, `prettier --check`, and `node scripts/check-english.mjs`.
  The remaining `npm run verify` gates (coverage, mutation, performance, oracle,
  parity, differential, build, package) run in CI on this pull request.
- Diff hygiene: `git diff --check` reports nothing.

```text
npx vitest run
Test Files  237 passed (237)
     Tests  5670 passed (5670)

npx vitest run tests/init-profile-derivation.test.ts
Test Files  1 passed (1)
     Tests  27 passed (27)

./node_modules/.bin/tsc --noEmit
(no output)

npx eslint . --max-warnings 0
(no output)

node scripts/check-english.mjs
English-only source check passed.

node scripts/check-dco.mjs --base origin/main --head HEAD
DCO: 1 commit signed off
```

## Prompt and model evaluations

Not applicable. Every claim here is answered by a deterministic test over a
pure function.

## Failure evidence

Minimal reproduction, which fails on `main` and passes here:

```text
deriveProjectProfile({
  rootEntries: ["apps", "platform", "Api.sln"],
  files: [
    "apps/backend/src/Program.cs",
    "apps/backend/src/Startup.cs",
    "platform/ci/pipeline.yml",
  ],
}, {}).paths

main: undefined
here: { source: { status: "derived", value: ["apps/backend/src"],
                  evidence: "directory:apps/backend/src (nested)" } }
```

It failed because `hasDirectory` asks only whether `rootEntries` contains `src`
or whether a file path starts with `src/`. `src` is not a root entry here, no
path starts with `src/`, and `apps` is not a candidate, so no source candidate
matched and the whole `paths` group was omitted. The six new cases in
`tests/init-profile-derivation.test.ts` are the regression tests; the first of
them is this reproduction.

## Provenance

- Sources used (including whether each is public/private and its owner/license):
  this repository only, private, owned by the author.
- Contribution method: `original`.
- Publication authority and required notices for adapted/verbatim material: not
  applicable, no adapted or verbatim material.
- Confirmation that no secret, credential, customer/personal data, private
  infrastructure, or confidential business information is included: confirmed.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cbYdzKBsGSpWj4XgBWyY1
