### PR TITLE
feat(init): derive the directory-layout and naming conventions (ADP-13)

### DIFF
--- a/packages/runtime/src/domain/init/derive.ts
+++ b/packages/runtime/src/domain/init/derive.ts
@@ -226,19 +226,30 @@ function selectPaths(
   return { value, evidence: `directory:${tokens.join(", ")}` };
 }
 
+interface DerivedPathSlot {
+  readonly leaf: ProjectProfileLeaf<readonly string[]>;
+  /** The directories the answer names, kept so the layout can be described. */
+  readonly directories: readonly DirectoryCandidate[];
+}
+
 function derivePathSlot(
   evidence: RepositoryEvidence,
   layout: ObservedLayout,
   candidates: readonly string[],
-): ProjectProfileLeaf<readonly string[]> | undefined {
+): DerivedPathSlot | undefined {
   const found = candidateDirectories(evidence, layout, candidates);
   if (found.length === 0) return undefined;
-  const selected = selectPaths(rankCandidates(withoutEnclosed(found)));
+  const ranked = rankCandidates(withoutEnclosed(found));
+  const selected = selectPaths(ranked);
   if (selected === undefined) return undefined;
+  const named = new Set(selected.value);
   return {
-    status: "derived",
-    value: Object.freeze(selected.value),
-    evidence: selected.evidence,
+    leaf: {
+      status: "derived",
+      value: Object.freeze(selected.value),
+      evidence: selected.evidence,
+    },
+    directories: ranked.filter((candidate) => named.has(candidate.path)),
   };
 }
 
@@ -252,6 +263,14 @@ function compareText(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
+interface DerivedPaths {
+  /** The three path answers, absent when the layout attested to none of them. */
+  readonly leaves: PartialProjectProfile["paths"] | undefined;
+  /** The directories each answer names, for the convention derivation below. */
+  readonly source: readonly DirectoryCandidate[];
+  readonly tests: readonly DirectoryCandidate[];
+}
+
 /**
  * Derive the source, test, and configuration directories from the layout.
  *
@@ -262,8 +281,8 @@ function compareText(left: string, right: string): number {
  */
 function derivePaths(
   evidence: RepositoryEvidence,
-): PartialProjectProfile["paths"] | undefined {
-  const layout = observeLayout(observedPaths(evidence));
+  layout: ObservedLayout,
+): DerivedPaths {
   const paths: {
     source?: ProjectProfileLeaf<readonly string[]>;
     tests?: ProjectProfileLeaf<readonly string[]>;
@@ -271,19 +290,23 @@ function derivePaths(
   } = {};
 
   const source = derivePathSlot(evidence, layout, SOURCE_PATH_CANDIDATES);
-  if (source !== undefined) paths.source = source;
+  if (source !== undefined) paths.source = source.leaf;
 
   const tests = derivePathSlot(evidence, layout, TESTS_PATH_CANDIDATES);
-  if (tests !== undefined) paths.tests = tests;
+  if (tests !== undefined) paths.tests = tests.leaf;
 
   const configuration = derivePathSlot(
     evidence,
     layout,
     CONFIG_PATH_CANDIDATES,
   );
-  if (configuration !== undefined) paths.configuration = configuration;
+  if (configuration !== undefined) paths.configuration = configuration.leaf;
 
-  return Object.keys(paths).length > 0 ? paths : undefined;
+  return {
+    leaves: Object.keys(paths).length > 0 ? paths : undefined,
+    source: source?.directories ?? [],
+    tests: tests?.directories ?? [],
+  };
 }
 
 function derivePackageJsonCommands(
@@ -452,6 +475,9 @@ const COMMAND_SLOTS = ["test", "lint", "build", "run"] as const;
  */
 const EVIDENCE_MAX_LENGTH = 256;
 
+/** The longest convention string the profile schema stores. */
+const CONVENTION_MAX_LENGTH = 1024;
+
 function stackEvidence(detected: DetectedStack): string {
   const full = `stack:${detected.id} via ${detected.evidence}`;
   return full.length <= EVIDENCE_MAX_LENGTH ? full : `stack:${detected.id}`;
@@ -517,23 +543,368 @@ function deriveCommands(
   return Object.keys(commands).length > 0 ? commands : undefined;
 }
 
-function deriveConventions(
-  stack: StackProfile,
-): PartialProjectProfile["conventions"] | undefined {
-  const activeLanguages = stack.languages.filter((lang) => lang.files > 0);
+/**
+ * How many file names of one language the casing census needs before it will
+ * state a convention.
+ *
+ * A convention is a regularity, and three files are not one. Below this the
+ * leaf is left for the operator, because a naming rule derived from a handful
+ * of names is applied silently to every file a phase agent writes afterwards.
+ */
+const NAMING_MIN_SAMPLE = 5;
 
-  if (activeLanguages.length === 0) {
-    return undefined;
+/**
+ * The share of counted names the winning form must hold.
+ *
+ * A repository split between two casings has no naming convention to preserve,
+ * and saying it does would be a wrong answer rather than a missing one.
+ */
+const NAMING_DOMINANCE = 0.8;
+
+type NamingForm =
+  "PascalCase" | "camelCase" | "kebab-case" | "snake_case" | "lowercase";
+
+const NAMING_FORMS: readonly NamingForm[] = [
+  "PascalCase",
+  "camelCase",
+  "kebab-case",
+  "snake_case",
+  "lowercase",
+];
+
+/**
+ * The identifying part of a file name, or nothing when it carries no casing.
+ *
+ * Everything from the first dot onwards is extension, not name: `Order.Tests.cs`
+ * and `order.test.ts` are both named by their first segment, which is the part
+ * a phase agent chooses when it creates the file. A leading dot is a hidden
+ * file rather than a name, and a name with no letters cannot attest to a
+ * casing.
+ */
+function nameStem(path: string): string | null {
+  const base = path.slice(path.lastIndexOf("/") + 1);
+  const dot = base.indexOf(".");
+  const stem = dot <= 0 ? (dot === 0 ? "" : base) : base.slice(0, dot);
+  if (stem.length === 0 || !/[A-Za-z]/u.test(stem)) return null;
+  return stem;
+}
+
+/**
+ * The casing a single name attests to, or nothing when it attests to none.
+ *
+ * A name mixing separators, or carrying characters no convention describes,
+ * is left out of the count rather than pushed into the nearest bucket: the
+ * census reports what it could read, and a name it could not read is not
+ * evidence for anything.
+ */
+function namingFormOf(stem: string): NamingForm | null {
+  if (/^[a-z0-9]+(?:-[a-z0-9]+)+$/u.test(stem)) return "kebab-case";
+  if (/^[a-z0-9]+(?:_[a-z0-9]+)+$/u.test(stem)) return "snake_case";
+  if (/^[A-Z][A-Za-z0-9]*$/u.test(stem) && /[a-z]/u.test(stem)) {
+    return "PascalCase";
+  }
+  if (/^[a-z][a-z0-9]*[A-Z][A-Za-z0-9]*$/u.test(stem)) return "camelCase";
+  if (/^[a-z][a-z0-9]*$/u.test(stem)) return "lowercase";
+  return null;
+}
+
+interface NamingCensus {
+  readonly counts: ReadonlyMap<NamingForm, number>;
+  readonly total: number;
+}
+
+/** Count the casings observed among one language's file names. */
+function censusNames(paths: readonly string[]): NamingCensus {
+  const counts = new Map<NamingForm, number>();
+  let total = 0;
+  for (const path of paths) {
+    const stem = nameStem(path);
+    if (stem === null) continue;
+    const form = namingFormOf(stem);
+    if (form === null) continue;
+    counts.set(form, (counts.get(form) ?? 0) + 1);
+    total += 1;
+  }
+  return { counts, total };
+}
+
+/**
+ * The one casing a census supports, with the names that support it.
+ *
+ * A single-word lowercase name is compatible with both separator forms, so it
+ * is counted for the separator form when exactly one of them is present and no
+ * capitalized form is: `parse-order.ts` beside `parser.ts` is one convention,
+ * not two. Everywhere else the forms compete on their own counts, and a tie
+ * supports nothing.
+ */
+function dominantNaming(
+  census: NamingCensus,
+): { readonly form: NamingForm; readonly files: number } | null {
+  const count = (form: NamingForm): number => census.counts.get(form) ?? 0;
+  const kebab = count("kebab-case");
+  const snake = count("snake_case");
+  const lowercase = count("lowercase");
+  const capitalized = count("PascalCase") + count("camelCase");
+
+  if (capitalized === 0 && kebab > 0 && snake === 0) {
+    return { form: "kebab-case", files: kebab + lowercase };
+  }
+  if (capitalized === 0 && snake > 0 && kebab === 0) {
+    return { form: "snake_case", files: snake + lowercase };
   }
 
-  const languageIds = activeLanguages.map((lang) => lang.id);
+  let best: NamingForm | null = null;
+  let bestFiles = 0;
+  let tied = false;
+  for (const form of NAMING_FORMS) {
+    const files = count(form);
+    if (files === 0) continue;
+    if (files > bestFiles) {
+      best = form;
+      bestFiles = files;
+      tied = false;
+    } else if (files === bestFiles) {
+      tied = true;
+    }
+  }
+  if (best === null || tied) return null;
+  return { form: best, files: bestFiles };
+}
+
+const NAMING_INSTRUCTION: Readonly<Record<NamingForm, string>> = Object.freeze({
+  PascalCase: "Name new files in PascalCase",
+  camelCase: "Name new files in camelCase",
+  "kebab-case": "Name new files in kebab-case",
+  snake_case: "Name new files in snake_case",
+  lowercase: "Name new files in lowercase single words",
+});
+
+/**
+ * State the naming convention the repository already follows, or nothing.
+ *
+ * Measured per language and reported on the one that carries the most readable
+ * names, because casing is a property of a language's community rather than of
+ * a repository: a C# project with a handful of shell scripts names its C#
+ * files `PascalCase.cs` and that is the convention a phase agent must keep.
+ */
+function deriveNaming(
+  stack: StackProfile,
+  paths: readonly string[],
+): ProjectProfileLeaf<string> | undefined {
+  const byLanguage = new Map<string, string[]>();
+  for (const path of paths) {
+    const language = languageOfPath(path);
+    if (language === null) continue;
+    const seen = byLanguage.get(language);
+    if (seen === undefined) byLanguage.set(language, [path]);
+    else seen.push(path);
+  }
+
+  let chosen:
+    | {
+        readonly language: string;
+        readonly form: NamingForm;
+        readonly files: number;
+        readonly total: number;
+      }
+    | undefined;
+
+  // Languages arrive most-counted first, ties broken by identifier, so the
+  // language the project is mostly written in is the one measured. A language
+  // too small to attest to anything is passed over -- two shell scripts in a
+  // C# service say nothing about how its files are named -- but the first
+  // language large enough to measure is the only one measured: falling through
+  // to the next would answer a question about C# with a convention read off
+  // the shell scripts.
+  for (const language of stack.languages) {
+    const observed = byLanguage.get(language.id);
+    if (observed === undefined) continue;
+    const census = censusNames(observed);
+    if (census.total < NAMING_MIN_SAMPLE) continue;
+    const dominant = dominantNaming(census);
+    if (dominant === null) break;
+    if (dominant.files / census.total < NAMING_DOMINANCE) break;
+    chosen = {
+      language: language.id,
+      form: dominant.form,
+      files: dominant.files,
+      total: census.total,
+    };
+    break;
+  }
+
+  if (chosen === undefined) return undefined;
+
   return {
-    implementationLanguages: {
+    status: "derived",
+    value: `${NAMING_INSTRUCTION[chosen.form]}, as the ${chosen.language} files in this project already are.`,
+    evidence: `naming:${chosen.form} on ${String(chosen.files)} of ${String(chosen.total)} ${chosen.language} files`,
+  };
+}
+
+/** The directory a path sits in, or the empty string at the repository root. */
+function parentOf(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index === -1 ? "" : path.slice(0, index);
+}
+
+function nameOf(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1);
+}
+
+/** True when every path shares the trailing name and the same grandparent. */
+function repeatedShape(
+  directories: readonly DirectoryCandidate[],
+): { readonly parent: string; readonly name: string } | null {
+  const first = directories[0];
+  if (first === undefined || first.root) return null;
+  const name = nameOf(first.path);
+  const parent = parentOf(parentOf(first.path));
+  for (const directory of directories) {
+    if (directory.root) return null;
+    if (nameOf(directory.path) !== name) return null;
+    if (parentOf(parentOf(directory.path)) !== parent) return null;
+  }
+  return { parent, name };
+}
+
+/**
+ * Whether the scan saw test files living inside the source tree.
+ *
+ * The alternative to a sibling test directory is a test beside the code it
+ * covers, and that is a layout instruction of its own. A name is a test when
+ * it says so -- `order.test.ts`, `test_order.py`, `OrderTests.cs` -- which is
+ * the same kind of observation the casing census makes.
+ */
+function colocatedTests(
+  paths: readonly string[],
+  sources: readonly DirectoryCandidate[],
+): number {
+  let found = 0;
+  for (const path of paths) {
+    if (languageOfPath(path) === null) continue;
+    if (!sources.some((source) => path.startsWith(`${source.path}/`))) continue;
+    const base = nameOf(path);
+    if (/(?:^|[._-])(?:tests?|specs?)(?:[._-]|$)/iu.test(base)) found += 1;
+  }
+  return found;
+}
+
+/** A counted noun, so evidence a person reads is evidence a person can read. */
+function countOf(files: number, noun: string): string {
+  return `${String(files)} ${noun}${files === 1 ? "" : "s"}`;
+}
+
+function filesUnder(directories: readonly DirectoryCandidate[]): number {
+  return directories.reduce((total, one) => total + one.files, 0);
+}
+
+/**
+ * State where this repository puts its code, or nothing.
+ *
+ * Only a shape the scan saw repeat, or a single unambiguous root: a tree whose
+ * source directories sit at different depths, or under different parents, has
+ * no one layout to preserve and the operator is asked instead. What is derived
+ * is an instruction about placement, because that is what the leaf is for.
+ */
+function deriveDirectoryLayout(
+  paths: DerivedPaths,
+  observed: readonly string[],
+): ProjectProfileLeaf<string> | undefined {
+  const sources = paths.source;
+  const first = sources[0];
+  if (first === undefined) return undefined;
+
+  const sourceFiles = filesUnder(sources);
+  const testFiles = filesUnder(paths.tests);
+  const counts = (): string =>
+    paths.tests.length > 0
+      ? `${countOf(sourceFiles, "source file")}, ${countOf(testFiles, "test file")}`
+      : countOf(sourceFiles, "source file");
+
+  if (sources.length === 1 && first.root) {
+    const sibling = paths.tests.find((directory) => directory.root);
+    const colocated = colocatedTests(observed, sources);
+    const tail =
+      sibling !== undefined
+        ? ` and its tests in the sibling \`${sibling.path}/\` directory`
+        : colocated > 0
+          ? " and its tests beside the code they cover"
+          : "";
+    return layoutLeaf(
+      `Place new source under \`${first.path}/\` at the repository root${tail}.`,
+      `layout:root ${first.path}; ${counts()}`,
+    );
+  }
+
+  const shape = repeatedShape(sources);
+  if (shape === null) return undefined;
+
+  const placement =
+    shape.parent === ""
+      ? `Place new source in \`<component>/${shape.name}/\`, one directory per component at the repository root`
+      : `Place new source in \`<component>/${shape.name}/\` below \`${shape.parent}/\``;
+  const tests = repeatedShape(paths.tests);
+  const tail =
+    tests !== null && tests.parent === shape.parent
+      ? `, and its tests in \`<component>/${tests.name}/\``
+      : "";
+  return layoutLeaf(
+    `${placement}${tail}.`,
+    `layout:${countOf(sources.length, "component")} under ${shape.parent === "" ? "the root" : shape.parent}; ${counts()}`,
+  );
+}
+
+/**
+ * A layout answer, dropped when its evidence would not fit what a profile can
+ * store -- an answer nothing can write is worse than the question.
+ */
+function layoutLeaf(
+  value: string,
+  evidence: string,
+): ProjectProfileLeaf<string> | undefined {
+  if (evidence.length > EVIDENCE_MAX_LENGTH) return undefined;
+  if (value.length > CONVENTION_MAX_LENGTH) return undefined;
+  return { status: "derived", value, evidence };
+}
+
+/**
+ * Derive the three conventions a phase agent has to preserve.
+ *
+ * Each is an observed regularity rather than a stated preference, which is why
+ * they can be derived at all, and each is offered for confirmation like every
+ * other derived leaf.
+ */
+function deriveConventions(
+  stack: StackProfile,
+  paths: DerivedPaths,
+  observed: readonly string[],
+): PartialProjectProfile["conventions"] | undefined {
+  const conventions: {
+    directoryLayout?: ProjectProfileLeaf<string>;
+    naming?: ProjectProfileLeaf<string>;
+    implementationLanguages?: ProjectProfileLeaf<readonly string[]>;
+  } = {};
+
+  const activeLanguages = stack.languages.filter((lang) => lang.files > 0);
+  if (activeLanguages.length > 0) {
+    const languageIds = activeLanguages.map((lang) => lang.id);
+    conventions.implementationLanguages = {
       status: "derived",
       value: Object.freeze(languageIds),
       evidence: `census:${languageIds.join(",")}`,
-    },
-  };
+    };
+  }
+
+  const directoryLayout = deriveDirectoryLayout(paths, observed);
+  if (directoryLayout !== undefined) {
+    conventions.directoryLayout = directoryLayout;
+  }
+
+  const naming = deriveNaming(stack, observed);
+  if (naming !== undefined) conventions.naming = naming;
+
+  return Object.keys(conventions).length > 0 ? conventions : undefined;
 }
 
 /**
@@ -545,13 +916,14 @@ export function deriveProjectProfile(
   manifests: ManifestContents = {},
 ): PartialProjectProfile {
   const stack = profileStack(evidence);
+  const observed = observedPaths(evidence);
   const commands = deriveCommands(stack, manifests);
-  const paths = derivePaths(evidence);
-  const conventions = deriveConventions(stack);
+  const paths = derivePaths(evidence, observeLayout(observed));
+  const conventions = deriveConventions(stack, paths, observed);
 
   const profile: PartialProjectProfile = {
     ...(commands !== undefined ? { commands } : {}),
-    ...(paths !== undefined ? { paths } : {}),
+    ...(paths.leaves !== undefined ? { paths: paths.leaves } : {}),
     ...(conventions !== undefined ? { conventions } : {}),
   };
 

--- a/tests/init-command.test.ts
+++ b/tests/init-command.test.ts
@@ -1081,7 +1081,13 @@ describe("the init command", () => {
         },
       },
       conventions: {
-        directoryLayout: { status: "unresolved" },
+        directoryLayout: {
+          status: "derived",
+          value:
+            "Place new source under `src/` at the repository root and its tests in the sibling `tests/` directory.",
+          evidence: "layout:root src; 1 source file, 1 test file",
+        },
+        // Two file names attest to no casing, so that one is still asked.
         naming: { status: "unresolved" },
         implementationLanguages: {
           status: "derived",

--- a/tests/init-profile-derivation.test.ts
+++ b/tests/init-profile-derivation.test.ts
@@ -470,8 +470,221 @@ describe("pure project profile derivation", () => {
       value: ["typescript", "javascript"],
       evidence: "census:typescript,javascript",
     });
-    expect(derived.conventions?.directoryLayout).toBeUndefined();
+    // Three names, none of them discriminating, attest to no casing.
     expect(derived.conventions?.naming).toBeUndefined();
+  });
+
+  it("derives the layout of a monorepo from the shape its components repeat", () => {
+    const evidence = {
+      rootEntries: ["apps", "Api.sln"],
+      files: [
+        "apps/backend/src/Program.cs",
+        "apps/backend/src/OrderService.cs",
+        "apps/backend/tests/OrderServiceTests.cs",
+        "apps/worker/src/Worker.cs",
+        "apps/worker/src/QueueReader.cs",
+        "apps/worker/tests/WorkerTests.cs",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.conventions?.directoryLayout).toEqual({
+      status: "derived",
+      value:
+        "Place new source in `<component>/src/` below `apps/`, and its tests in `<component>/tests/`.",
+      evidence: "layout:2 components under apps; 4 source files, 2 test files",
+    });
+    expect(derived.conventions?.naming).toEqual({
+      status: "derived",
+      value:
+        "Name new files in PascalCase, as the csharp files in this project already are.",
+      evidence: "naming:PascalCase on 6 of 6 csharp files",
+    });
+  });
+
+  it("describes components that sit at the repository root", () => {
+    const evidence = {
+      rootEntries: ["backend", "worker"],
+      files: [
+        "backend/src/handler.ts",
+        "backend/src/router.ts",
+        "backend/tests/handler.test.ts",
+        "worker/src/queue.ts",
+        "worker/src/runner.ts",
+        "worker/tests/queue.test.ts",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.conventions?.directoryLayout).toEqual({
+      status: "derived",
+      value:
+        "Place new source in `<component>/src/`, one directory per component at the repository root, and its tests in `<component>/tests/`.",
+      evidence:
+        "layout:2 components under the root; 4 source files, 2 test files",
+    });
+  });
+
+  it("derives a root layout and says where its tests sit", () => {
+    const evidence = {
+      rootEntries: ["src", "tests", "package.json"],
+      files: [
+        "src/parse-order.ts",
+        "src/user-store.ts",
+        "src/http-server.ts",
+        "src/index.ts",
+        "tests/parse-order.test.ts",
+        "tests/user-store.test.ts",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.conventions?.directoryLayout).toEqual({
+      status: "derived",
+      value:
+        "Place new source under `src/` at the repository root and its tests in the sibling `tests/` directory.",
+      evidence: "layout:root src; 4 source files, 2 test files",
+    });
+    // A single-word lowercase name is compatible with kebab-case, so it
+    // supports the convention the separated names attest to.
+    expect(derived.conventions?.naming).toEqual({
+      status: "derived",
+      value:
+        "Name new files in kebab-case, as the typescript files in this project already are.",
+      evidence: "naming:kebab-case on 6 of 6 typescript files",
+    });
+  });
+
+  it("says tests sit beside the code when no test directory holds them", () => {
+    const evidence = {
+      rootEntries: ["src", "pyproject.toml"],
+      files: [
+        "src/parse_order.py",
+        "src/user_store.py",
+        "src/http_server.py",
+        "src/queue_reader.py",
+        "src/test_parse_order.py",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.conventions?.directoryLayout).toEqual({
+      status: "derived",
+      value:
+        "Place new source under `src/` at the repository root and its tests beside the code they cover.",
+      evidence: "layout:root src; 5 source files",
+    });
+    expect(derived.conventions?.naming).toEqual({
+      status: "derived",
+      value:
+        "Name new files in snake_case, as the python files in this project already are.",
+      evidence: "naming:snake_case on 5 of 5 python files",
+    });
+  });
+
+  it("asks about naming when the observed file names are split between casings", () => {
+    const evidence = {
+      rootEntries: ["src", "package.json"],
+      files: [
+        "src/parse-order.ts",
+        "src/other-thing.ts",
+        "src/UserStore.ts",
+        "src/OrderThing.ts",
+        "src/httpServer.ts",
+        "src/api_client.ts",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.conventions?.naming).toBeUndefined();
+    expect(derived.conventions?.directoryLayout).toEqual({
+      status: "derived",
+      value: "Place new source under `src/` at the repository root.",
+      evidence: "layout:root src; 6 source files",
+    });
+  });
+
+  it("asks about naming when too few names were observed to call it a convention", () => {
+    const evidence = {
+      rootEntries: ["src", "package.json"],
+      files: ["src/parse-order.ts", "src/user-store.ts", "src/http-server.ts"],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.conventions?.naming).toBeUndefined();
+  });
+
+  it("measures naming on the language the census counted most", () => {
+    const evidence = {
+      rootEntries: ["src"],
+      files: [
+        "src/OrderService.cs",
+        "src/UserRepository.cs",
+        "src/Program.cs",
+        "src/QueueReader.cs",
+        "src/HttpClientFactory.cs",
+        "src/deploy_release.sh",
+        "src/rotate_secrets.sh",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.conventions?.naming).toEqual({
+      status: "derived",
+      value:
+        "Name new files in PascalCase, as the csharp files in this project already are.",
+      evidence: "naming:PascalCase on 5 of 5 csharp files",
+    });
+  });
+
+  it("asks about naming rather than answering off a smaller language", () => {
+    const evidence = {
+      rootEntries: ["src"],
+      files: [
+        "src/order-service.ts",
+        "src/UserStore.ts",
+        "src/httpServer.ts",
+        "src/queue_reader.ts",
+        "src/OrderThing.ts",
+        "src/other-thing.ts",
+        "src/deploy_release.sh",
+        "src/rotate_secrets.sh",
+        "src/publish_bundle.sh",
+        "src/tag_release.sh",
+        "src/sign_artifact.sh",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    // The project is written in TypeScript and its TypeScript names disagree.
+    // The shell scripts are consistent, and answering with their convention
+    // would instruct an agent writing TypeScript in the shell one.
+    expect(derived.conventions?.naming).toBeUndefined();
+  });
+
+  it("asks about the layout when the source directories share no shape", () => {
+    const evidence = {
+      rootEntries: ["services"],
+      files: [
+        "services/api/src/handler.ts",
+        "services/api/src/router.ts",
+        "services/worker/lib/queue.ts",
+        "services/worker/lib/runner.ts",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths?.source).toBeDefined();
+    expect(derived.conventions?.directoryLayout).toBeUndefined();
   });
 
   it("produces deterministic output for arbitrary manifest and entry orders", () => {

--- a/tests/profile-derive-command.test.ts
+++ b/tests/profile-derive-command.test.ts
@@ -93,7 +93,13 @@ describe("the profile derive command", () => {
         configuration: { status: "unresolved" },
       },
       conventions: {
-        directoryLayout: { status: "unresolved" },
+        directoryLayout: {
+          status: "derived",
+          value:
+            "Place new source under `src/` at the repository root and its tests in the sibling `tests/` directory.",
+          evidence: "layout:root src; 1 source file, 1 test file",
+        },
+        // Two file names are not a naming convention, so that one is asked.
         naming: { status: "unresolved" },
         implementationLanguages: {
           status: "derived",


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #201

Work ID: `ADP-13`

## Outcome and design

`deriveConventions` filled only `implementationLanguages`, so
`conventions.directoryLayout` and `conventions.naming` were initialized
`unresolved` in `profile.ts` and nothing ever moved them. A Node project with
`package.json` scripts, `src/`, `tests/`, and `config/` -- the best case --
derived seven of ten leaves and `kratos doctor` reported `stack-profile: warn`.

Both leaves are instructions to a phase agent about where to place and how to
name a file it creates, which makes them derivable: the convention is the
observed regularity, not a stated preference.

Selected design:

1. `derivePathSlot` returns the `DirectoryCandidate`s behind each path answer
   alongside the leaf, so the layout is described from the directories the path
   derivation already ranked rather than from a second walk over the listing.
2. `deriveDirectoryLayout` states placement from the shape the scan saw. A
   single root source directory names its sibling test directory, or says tests
   sit beside the code they cover when test-named files live inside the source
   tree, or states the source directory alone. A shape the components repeat --
   the same trailing name under one common parent -- is stated once with
   `<component>` standing for the repeated directory, including components that
   sit at the repository root.
3. `deriveNaming` runs a casing census over file-name stems, per language,
   measured on the language the file census counted most. A stem is everything
   before the first dot, which is the part an agent chooses when it creates the
   file, so `Order.Tests.cs` and `order.test.ts` are both read by their leading
   identifier.
4. Only names that discriminate are counted: `kebab-case`, `snake_case`,
   `PascalCase`, `camelCase`, and the single lowercase word. A name the census
   cannot read is left out rather than pushed into the nearest bucket. A
   lowercase single word supports a separator form only when exactly one
   separator form is present and no capitalized form is, because `parser.ts`
   beside `parse-order.ts` is one convention rather than two.
5. Regularity thresholds decide whether anything is stated at all. Naming needs
   five readable names of that language and eighty percent dominance; a tie
   supports nothing; and the first language large enough to measure is the only
   one measured, so a project whose main language disagrees with itself derives
   nothing rather than answering with the convention of its shell scripts. A
   tree whose source directories share no shape derives nothing the same way.
6. Evidence names what was counted -- `layout:root src; 5 source files, 2 test
   files`, `naming:kebab-case on 8 of 8 typescript files` -- and an answer whose
   value or evidence would exceed the 1024- and 256-character bounds the profile
   schema stores is dropped rather than written.

These leaves instruct an agent that will create files, so a wrongly derived
convention is applied silently to everything it writes, which is worse than the
blank that exists today. The thresholds above are that safety property, not a
refinement of it.

Alternatives considered: counting every file name, including the single
lowercase word, as evidence for one bucket, which would report `lowercase` for a
kebab-cased repository whose short names happen to outnumber its compound ones;
and falling through to the next language when the largest one is ambiguous,
which answers a question about C# with a convention read off two shell scripts.

Out of scope: deriving commands from CI workflows (ADP-10), the language policy
leaf, the scan budget, the exclusion list, and the interview that presents these
answers for confirmation.

## Compatibility and public contracts

Behavioral change confined to `deriveProjectProfile`'s `conventions` leaves,
which are derived and offered for confirmation, never stated. No schema,
command, reason code, exit code, or host-contract change: `conventionLeaf`
already admits `derivedConvention`, and both the value and the evidence stay
inside the `convention` (1024) and `evidence` (256) bounds the state schema
defines, enforced in the derivation itself.

Three existing expectations that asserted these leaves `unresolved` now assert
the derived layout, in `tests/init-command.test.ts` and
`tests/profile-derive-command.test.ts`; both of those repositories hold two file
names, which is below the naming sample floor, so `naming` stays `unresolved`
there and the change is visible as exactly what it is.

`distribution/shared/project-profile-relay.mjs` is unchanged: it relays host
answers and the two interview questions, and the runtime derivation fills these
leaves when the host omits them. Go-v3 parity: none, convention derivation has
no Go-v3 counterpart.

## State, migration, security, and rollback

None on all dimensions, with rationale. The derivation is a pure function over
the listing the bounded scan already produced: it opens no file, reaches no
disk, writes no event, and touches no project state, Git, or concurrency. It
reads the same `observedPaths` output the census reads, so the exclusion rules
that skip `node_modules`, `vendor`, `dist`, and their peers apply unchanged and
a dependency tree cannot become the naming convention of the project that
vendored it. No new trust boundary, permission, secret, or data handling. No
migration: existing configurations hold resolved or persisted answers that
outrank derivation. Rollback is reverting the commit; every value it derives is
confirmed by the operator before anything is written.

## Deterministic test evidence

- Acceptance evidence record: nine cases in
  `tests/init-profile-derivation.test.ts` -- a monorepo layout with repeated
  components, components at the repository root, a root layout with a sibling
  test directory, tests colocated with the code, mixed casing that derives
  nothing, a sample too small to call a convention, a main language that
  disagrees with itself while a smaller one agrees, source directories that
  share no shape, and the existing census case now asserting that three
  non-discriminating names attest to no casing.
- Focused verification: `npx vitest run tests/init-profile-derivation.test.ts
  tests/profile-derive-command.test.ts tests/init-command.test.ts
  tests/init-stack-profile.test.ts`
- Full repository verification: `npx vitest run`, plus `tsc --noEmit`, `eslint .
  --max-warnings 0`, `prettier --check .`, `node scripts/check-english.mjs`,
  `node scripts/check-performance.mjs`, and `npx cspell`. The remaining
  `npm run verify` gates (coverage, mutation, oracle, parity, differential,
  build, package) run in CI on this pull request.
- Diff hygiene: `git diff --check` reports nothing.

```text
npx vitest run
Test Files  237 passed (237)
     Tests  5679 passed (5679)

npx vitest run tests/init-profile-derivation.test.ts tests/profile-derive-command.test.ts tests/init-command.test.ts tests/init-stack-profile.test.ts
Test Files  4 passed (4)
     Tests  138 passed (138)

npm run typecheck
(no output)

npx eslint . --max-warnings 0
(no output)

npx prettier --check .
All matched files use Prettier code style!

node scripts/check-english.mjs
English-only source check passed.

node scripts/check-performance.mjs
runtimeSourceBytes: 1620321 / 1700000
contractSchemaBytes: 365892 / 370000

node scripts/check-dco.mjs --base origin/main --head HEAD
DCO: 1 commit signed off
```

The acceptance case was also observed end to end against a real repository, via
`kratos profile derive --root <tmp>` on a Node project holding `package.json`
scripts, `src/`, `tests/`, `config/`, and kebab-cased TypeScript file names. All
ten leaves derive, so `unresolvedProjectProfileKeys` is empty, which is what
`deriveStackProfileCheck` requires for `pass`:

```text
conventions.directoryLayout  derived  "Place new source under `src/` at the
  repository root and its tests in the sibling `tests/` directory."
  evidence: layout:root src; 5 source files, 2 test files
conventions.naming           derived  "Name new files in kebab-case, as the
  typescript files in this project already are."
  evidence: naming:kebab-case on 8 of 8 typescript files
```

## Prompt and model evaluations

Not applicable. Every claim here is answered by a deterministic test over a pure
function.

## Failure evidence

Minimal reproduction, which fails on `main` and passes here:

```text
deriveProjectProfile({
  rootEntries: ["apps", "Api.sln"],
  files: [
    "apps/backend/src/Program.cs",
    "apps/backend/src/OrderService.cs",
    "apps/backend/tests/OrderServiceTests.cs",
    "apps/worker/src/Worker.cs",
    "apps/worker/src/QueueReader.cs",
    "apps/worker/tests/WorkerTests.cs",
  ],
}, {}).conventions

main: { implementationLanguages: { ... } }
      directoryLayout and naming absent, so both reach the interview blank
here: directoryLayout: { status: "derived",
        value: "Place new source in `<component>/src/` below `apps/`, and its
                tests in `<component>/tests/`.",
        evidence: "layout:2 components under apps; 4 source files, 2 test files" }
      naming: { status: "derived",
        value: "Name new files in PascalCase, as the csharp files in this
                project already are.",
        evidence: "naming:PascalCase on 6 of 6 csharp files" }
```

It failed because `deriveConventions` took only the `StackProfile` and returned
a single leaf, `implementationLanguages`. No code path in any language read the
tree shape or the file names for these two answers, so they were `unresolved` by
construction rather than by observation. The nine cases in
`tests/init-profile-derivation.test.ts` are the regression tests; the first of
them is this reproduction, and three of them assert the derivation stays silent
where the observation is not regular enough to state.

## Provenance

- Sources used (including whether each is public/private and its owner/license):
  this repository only, private, owned by the author.
- Contribution method: `original`.
- Publication authority and required notices for adapted/verbatim material: not
  applicable, no adapted or verbatim material.
- Confirmation that no secret, credential, customer/personal data, private
  infrastructure, or confidential business information is included: confirmed.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJrtvZ6RQy57dZFLc8NWaq
