### PR TITLE
feat(init): derive commands from the CI workflows the project already runs (ADP-10)

### DIFF
--- a/packages/runtime/src/composition/init.ts
+++ b/packages/runtime/src/composition/init.ts
@@ -82,7 +82,7 @@ export async function observeInitialization(
   const evidence = await observeRepositoryEvidence(anchored.fileSystem);
   const manifests = await observeManifestContents(
     anchored.fileSystem,
-    evidence.rootEntries,
+    evidence,
   );
   const derived = deriveProjectProfile(evidence, manifests);
 

--- a/packages/runtime/src/composition/profile.ts
+++ b/packages/runtime/src/composition/profile.ts
@@ -36,7 +36,7 @@ export async function observeProjectProfile(
   const evidence = await observeRepositoryEvidence(anchored.fileSystem);
   const manifests = await observeManifestContents(
     anchored.fileSystem,
-    evidence.rootEntries,
+    evidence,
   );
   return {
     kind: "observed",

--- a/packages/runtime/src/composition/repository.ts
+++ b/packages/runtime/src/composition/repository.ts
@@ -1,8 +1,11 @@
 import {
+  CI_FILE_MAX_BYTES,
+  CI_WORKFLOW_MAX_FILES,
   SCAN_EXCLUDED_DIRECTORIES,
   SCAN_MAX_DEPTH,
   SCAN_MAX_ENTRIES,
   type ManifestContents,
+  type ManifestFile,
   type RepositoryEvidence,
 } from "../domain/init/index.js";
 import type { FileSystem } from "../ports/index.js";
@@ -94,27 +97,69 @@ function compareText(left: string, right: string): number {
 }
 
 /**
- * Safely read declarative top-level manifest files present in root entries.
- * Missing, unreadable, or failing files are skipped silently.
+ * Where a devcontainer configuration is allowed to sit, most conventional
+ * first.
+ */
+const DEVCONTAINER_PATHS: readonly string[] = [
+  ".devcontainer/devcontainer.json",
+  ".devcontainer.json",
+  "devcontainer.json",
+];
+
+/**
+ * The task-runner files, by the spellings a repository actually uses.
+ *
+ * Each entry is tried in order and the first one present answers, so a
+ * repository holding both `Taskfile.yml` and `Taskfile.yaml` is read once and
+ * deterministically.
+ */
+const TASK_RUNNER_CANDIDATES: readonly (readonly [
+  "taskfile" | "justfile" | "miseToml",
+  readonly string[],
+])[] = [
+  ["taskfile", ["Taskfile.yml", "Taskfile.yaml", "taskfile.yml"]],
+  ["justfile", ["justfile", "Justfile", ".justfile"]],
+  ["miseToml", ["mise.toml", ".mise.toml", "mise/config.toml"]],
+];
+
+/**
+ * Safely read the declarative files that state what this project runs.
+ *
+ * Three kinds of file, in one pass: the top-level manifests whose contents are
+ * parsed, the language-agnostic task runners that name their tasks the way a
+ * Makefile names targets, and the CI workflows that record the literal
+ * commands this repository runs on every push.
+ *
+ * Everything stays bounded and offline. Only paths the scan already saw are
+ * opened, each is measured before it is read, and a missing, oversized, or
+ * unreadable file is skipped in silence rather than failing initialization.
  */
 export async function observeManifestContents(
   fileSystem: FileSystem,
-  rootEntries: readonly string[],
+  evidence: RepositoryEvidence,
 ): Promise<ManifestContents> {
   const manifests: {
     packageJson?: string;
     makefile?: string;
     pyprojectToml?: string;
+    taskfile?: ManifestFile;
+    justfile?: ManifestFile;
+    miseToml?: ManifestFile;
+    devcontainerJson?: ManifestFile;
+    workflows?: readonly ManifestFile[];
   } = {};
 
-  const candidates: readonly (readonly [string, keyof ManifestContents])[] = [
+  const candidates: readonly (readonly [
+    string,
+    "packageJson" | "makefile" | "pyprojectToml",
+  ])[] = [
     ["package.json", "packageJson"],
     ["Makefile", "makefile"],
     ["pyproject.toml", "pyprojectToml"],
   ];
 
   for (const [filename, key] of candidates) {
-    if (rootEntries.includes(filename)) {
+    if (evidence.rootEntries.includes(filename)) {
       try {
         manifests[key] = await fileSystem.read(filename);
       } catch {
@@ -123,5 +168,78 @@ export async function observeManifestContents(
     }
   }
 
+  const observed = new Set([
+    ...evidence.rootEntries,
+    ...(evidence.files ?? []),
+  ]);
+
+  for (const [key, paths] of TASK_RUNNER_CANDIDATES) {
+    const file = await readBounded(fileSystem, observed, paths);
+    if (file !== undefined) manifests[key] = file;
+  }
+
+  const devcontainer = await readBounded(
+    fileSystem,
+    observed,
+    DEVCONTAINER_PATHS,
+  );
+  if (devcontainer !== undefined) manifests.devcontainerJson = devcontainer;
+
+  const workflows = await readWorkflows(fileSystem, evidence);
+  if (workflows.length > 0) manifests.workflows = Object.freeze(workflows);
+
   return Object.freeze(manifests);
+}
+
+/**
+ * Read the first of several paths the scan saw, within the size ceiling.
+ *
+ * A file larger than the ceiling is not read at all: it is measured first, so
+ * a repository holding a generated configuration of any size costs one `stat`
+ * rather than the memory to hold it.
+ */
+async function readBounded(
+  fileSystem: FileSystem,
+  observed: ReadonlySet<string>,
+  paths: readonly string[],
+): Promise<ManifestFile | undefined> {
+  for (const path of paths) {
+    if (!observed.has(path)) continue;
+    try {
+      const stat = await fileSystem.stat(path);
+      if (stat === null || stat.kind === "directory") continue;
+      if (stat.size > CI_FILE_MAX_BYTES) continue;
+      return Object.freeze({ path, content: await fileSystem.read(path) });
+    } catch {
+      // Unreadable is indistinguishable from absent for a derivation.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The workflow files the scan saw, in path order and within both ceilings.
+ *
+ * Path order rather than directory order, so the command a repository derives
+ * does not depend on how a filesystem happened to enumerate its entries.
+ */
+async function readWorkflows(
+  fileSystem: FileSystem,
+  evidence: RepositoryEvidence,
+): Promise<readonly ManifestFile[]> {
+  const paths = (evidence.files ?? [])
+    .filter(
+      (path) =>
+        path.startsWith(".github/workflows/") &&
+        (path.endsWith(".yml") || path.endsWith(".yaml")),
+    )
+    .sort(compareText)
+    .slice(0, CI_WORKFLOW_MAX_FILES);
+
+  const workflows: ManifestFile[] = [];
+  for (const path of paths) {
+    const file = await readBounded(fileSystem, new Set([path]), [path]);
+    if (file !== undefined) workflows.push(file);
+  }
+  return workflows;
 }

--- a/packages/runtime/src/domain/init/derive.ts
+++ b/packages/runtime/src/domain/init/derive.ts
@@ -10,6 +10,14 @@ import {
   profileStack,
 } from "./stack.js";
 import type { PartialProjectProfile, ProjectProfileLeaf } from "./profile.js";
+import {
+  deriveDevcontainerCommands,
+  deriveJustfileCommands,
+  deriveMiseCommands,
+  deriveTaskfileCommands,
+  deriveWorkflowCommands,
+  type ManifestFile,
+} from "./tasks.js";
 
 /**
  * The manifests whose contents are read rather than whose names are matched.
@@ -23,6 +31,19 @@ export interface ManifestContents {
   readonly packageJson?: string;
   readonly makefile?: string;
   readonly pyprojectToml?: string;
+  /** A Taskfile, a justfile, or a mise configuration, when the project has one. */
+  readonly taskfile?: ManifestFile;
+  readonly justfile?: ManifestFile;
+  readonly miseToml?: ManifestFile;
+  readonly devcontainerJson?: ManifestFile;
+  /**
+   * The workflow files under `.github/workflows/`, in path order.
+   *
+   * These are the only files here whose contents are not a declaration about
+   * the project but a record of what a machine runs against it, which is why
+   * they answer after every declaration and before any convention.
+   */
+  readonly workflows?: readonly ManifestFile[];
 }
 
 const SOURCE_PATH_CANDIDATES = ["src", "lib", "app", "packages"] as const;
@@ -513,12 +534,18 @@ function deriveStackCommands(
 }
 
 /**
- * Derive the four commands from what the repository declares, then from what
- * its toolchain conventionally calls them.
+ * Derive the four commands, most specific evidence first.
  *
- * There is no file-name list here. The toolchain is whatever `profileStack`
- * already named from the marker table, which is why an ecosystem that table
- * recognizes cannot reach the interview with nothing derived.
+ * A declaration the project makes about itself wins, because it is this
+ * repository stating its own answer. Failing that, what CI runs on every push
+ * is a literal command a maintainer wrote for this repository. Failing both,
+ * the toolchain's canonical verb is a convention about the ecosystem, which is
+ * the weakest of the three and still better than asking.
+ *
+ * There is no file-name list for the last of these. The toolchain is whatever
+ * `profileStack` already named from the marker table, which is why an
+ * ecosystem that table recognizes cannot reach the interview with nothing
+ * derived.
  */
 function deriveCommands(
   stack: StackProfile,
@@ -536,6 +563,26 @@ function deriveCommands(
 
   if (manifests.makefile !== undefined) {
     deriveMakefileCommands(manifests.makefile, commands);
+  }
+
+  if (manifests.taskfile !== undefined) {
+    deriveTaskfileCommands(manifests.taskfile, commands);
+  }
+
+  if (manifests.justfile !== undefined) {
+    deriveJustfileCommands(manifests.justfile, commands);
+  }
+
+  if (manifests.miseToml !== undefined) {
+    deriveMiseCommands(manifests.miseToml, commands);
+  }
+
+  if (manifests.devcontainerJson !== undefined) {
+    deriveDevcontainerCommands(manifests.devcontainerJson, commands);
+  }
+
+  if (manifests.workflows !== undefined) {
+    deriveWorkflowCommands(manifests.workflows, commands);
   }
 
   deriveStackCommands(stack, commands);

--- a/packages/runtime/src/domain/init/index.ts
+++ b/packages/runtime/src/domain/init/index.ts
@@ -19,6 +19,18 @@ export type {
 } from "./profile.js";
 export { deriveProjectProfile } from "./derive.js";
 export type { ManifestContents } from "./derive.js";
+export {
+  CI_FILE_MAX_BYTES,
+  CI_WORKFLOW_MAX_FILES,
+  deriveDevcontainerCommands,
+  deriveJustfileCommands,
+  deriveMiseCommands,
+  deriveTaskfileCommands,
+  deriveWorkflowCommands,
+  readWorkflowSteps,
+  slotOfName,
+} from "./tasks.js";
+export type { CommandSlot, ManifestFile } from "./tasks.js";
 export { detectLanguageConventions } from "./detect.js";
 export type {
   DetectedLanguageConventions,

--- a/packages/runtime/src/domain/init/tasks.ts
+++ b/packages/runtime/src/domain/init/tasks.ts
@@ -1,0 +1,433 @@
+import type { ProjectProfileLeaf } from "./profile.js";
+
+/**
+ * One file read from disk, with the path it was read from.
+ *
+ * The path travels with the content because the evidence has to name the file
+ * the operator will open, and a repository writes `Taskfile.yaml` as readily
+ * as `Taskfile.yml`.
+ */
+export interface ManifestFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+/** The four answers a command derivation can fill. */
+export type CommandSlot = "test" | "lint" | "build" | "run";
+
+const COMMAND_SLOTS: readonly CommandSlot[] = ["test", "lint", "build", "run"];
+
+/** The longest evidence string the profile schema stores. */
+const EVIDENCE_MAX_LENGTH = 256;
+
+/** The longest command the profile schema stores. */
+const COMMAND_MAX_LENGTH = 2048;
+
+/**
+ * How many workflow files one repository contributes, and how large each may
+ * be.
+ *
+ * A ceiling on both is what keeps this reader a bounded pass over text rather
+ * than an open invitation to parse whatever a repository happens to hold. Past
+ * either limit the file is skipped, exactly as an unreadable manifest is.
+ */
+export const CI_WORKFLOW_MAX_FILES = 16;
+export const CI_FILE_MAX_BYTES = 65_536;
+
+/**
+ * What a task name has to say before a command is attributed to a slot.
+ *
+ * Names are matched, never command text: `dotnet test --filter X` under a step
+ * named `Install dependencies` is an install command, and guessing from the
+ * verb is how a lint command becomes the test command. `run` is stated by a
+ * word that means starting the thing, because "Run" alone is how every other
+ * step begins.
+ */
+const SLOT_PATTERNS: readonly (readonly [CommandSlot, RegExp])[] = [
+  ["test", /\b(?:tests?|testing)\b/iu],
+  ["lint", /\b(?:lint|lints|linting|linter|format|formatting)\b/iu],
+  ["build", /\b(?:build|builds|building|compile|compiles|compilation)\b/iu],
+  ["run", /\b(?:start|starts|serve|serves|launch|launches)\b/iu],
+];
+
+/**
+ * The one slot a name states, or nothing.
+ *
+ * A name that states two -- `Build and test` -- states neither for this
+ * purpose: it names a step that does both, and half of it is not the answer to
+ * either question.
+ */
+export function slotOfName(name: string): CommandSlot | null {
+  let found: CommandSlot | null = null;
+  for (const [slot, pattern] of SLOT_PATTERNS) {
+    if (!pattern.test(name)) continue;
+    if (found !== null) return null;
+    found = slot;
+  }
+  return found;
+}
+
+/**
+ * Record a derived command, unless a more specific source already answered.
+ *
+ * Every reader here is additive and none overwrites: precedence is the order
+ * the callers run in, so the first answer for a slot is the most specific one
+ * available.
+ */
+function offer(
+  commands: Record<string, ProjectProfileLeaf<string>>,
+  slot: CommandSlot,
+  value: string,
+  evidence: string,
+): void {
+  if (slot in commands) return;
+  const command = value.trim();
+  if (command.length === 0 || command.length > COMMAND_MAX_LENGTH) return;
+  if (/[\r\n]/u.test(command)) return;
+  if (evidence.length > EVIDENCE_MAX_LENGTH) return;
+  commands[slot] = { status: "derived", value: command, evidence };
+}
+
+/** A YAML or TOML scalar with its quoting removed, if it carried any. */
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const first = trimmed[0];
+  if ((first === '"' || first === "'") && trimmed.endsWith(first)) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function indentOf(line: string): number {
+  let indent = 0;
+  while (line[indent] === " ") indent += 1;
+  return indent;
+}
+
+function isIgnorable(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.length === 0 || trimmed.startsWith("#");
+}
+
+/** Split `key: value` into its two halves, or nothing when it is not a key. */
+function keyOf(
+  body: string,
+): { readonly key: string; readonly value: string } | null {
+  const match = /^([A-Za-z0-9_.\-$]+)\s*:(?:\s+(.*))?$/u.exec(body);
+  if (match?.[1] === undefined) return null;
+  return { key: match[1], value: match[2] ?? "" };
+}
+
+interface WorkflowStep {
+  readonly job: string;
+  readonly jobName: string | undefined;
+  readonly name: string | undefined;
+  readonly run: string;
+}
+
+interface StepDraft {
+  /** Column the step's own keys sit at, past the `- ` that opened the item. */
+  readonly contentIndent: number;
+  name?: string;
+  run?: string;
+}
+
+/**
+ * The `run:` steps a GitHub workflow declares, with the job and step that
+ * named them.
+ *
+ * This is a bounded pass over indented text, not a YAML implementation: no
+ * anchor is resolved, no file includes another, nothing is evaluated. A
+ * construct it does not model -- a block scalar, a matrix expression -- yields
+ * no step rather than a guessed one, which is the same silence an unreadable
+ * manifest produces.
+ */
+export function readWorkflowSteps(content: string): readonly WorkflowStep[] {
+  const steps: WorkflowStep[] = [];
+  let inJobs = false;
+  let jobIndent: number | undefined;
+  let job: { readonly id: string; name?: string } | undefined;
+  let jobBodyIndent: number | undefined;
+  let stepsIndent: number | undefined;
+  let step: StepDraft | undefined;
+
+  const flush = (): void => {
+    if (step?.run !== undefined && job !== undefined) {
+      steps.push({
+        job: job.id,
+        jobName: job.name,
+        name: step.name,
+        run: step.run,
+      });
+    }
+    step = undefined;
+  };
+
+  const assign = (draft: StepDraft, body: string): void => {
+    const entry = keyOf(body);
+    if (entry === null) return;
+    if (entry.key === "name") draft.name = unquote(entry.value);
+    // A block scalar is many commands under one key; the single-line form is
+    // the only one that answers "what does this project run".
+    if (entry.key === "run" && !/^[|>]/u.test(entry.value.trim())) {
+      const command = unquote(entry.value);
+      if (command.length > 0) draft.run = command;
+    }
+  };
+
+  for (const line of content.split("\n")) {
+    if (isIgnorable(line)) continue;
+    // YAML forbids tabs in indentation, so a file using them is one this
+    // reader cannot place in a tree and does not try to.
+    if (/^\s*\t/u.test(line)) return [];
+    const indent = indentOf(line);
+    const body = line.slice(indent);
+
+    if (!inJobs) {
+      if (indent === 0 && /^jobs\s*:/u.test(body)) inJobs = true;
+      continue;
+    }
+
+    if (indent === 0) {
+      flush();
+      inJobs = false;
+      job = undefined;
+      continue;
+    }
+
+    if (
+      stepsIndent !== undefined &&
+      indent >= stepsIndent &&
+      body.startsWith("-")
+    ) {
+      flush();
+      const rest = body.slice(1);
+      const offset = rest.length - rest.trimStart().length;
+      step = { contentIndent: indent + 1 + offset };
+      assign(step, rest.trim());
+      continue;
+    }
+
+    if (step !== undefined && indent >= step.contentIndent) {
+      if (indent === step.contentIndent) assign(step, body);
+      continue;
+    }
+
+    flush();
+    jobIndent ??= indent;
+
+    if (indent === jobIndent) {
+      const entry = keyOf(body);
+      job = entry === null ? undefined : { id: entry.key };
+      jobBodyIndent = undefined;
+      stepsIndent = undefined;
+      continue;
+    }
+
+    if (job === undefined || indent < jobIndent) continue;
+    jobBodyIndent ??= indent;
+    if (indent !== jobBodyIndent) continue;
+    const entry = keyOf(body);
+    if (entry === null) continue;
+    if (entry.key === "name") job.name = unquote(entry.value);
+    if (entry.key === "steps") stepsIndent = indent;
+  }
+
+  flush();
+  return steps;
+}
+
+/** How many `run:` steps a job declares, keyed by job identifier. */
+function countRunSteps(
+  steps: readonly WorkflowStep[],
+): ReadonlyMap<string, number> {
+  const counts = new Map<string, number>();
+  for (const step of steps) {
+    counts.set(step.job, (counts.get(step.job) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Derive commands from what the repository's CI actually runs.
+ *
+ * The command is a literal string a maintainer wrote for this repository, so
+ * it is more specific evidence than any convention about its ecosystem -- and
+ * less specific than what the project declares about itself, which is why this
+ * runs after the manifest readers and before the toolchain defaults.
+ *
+ * A job name answers only for a job that runs a single command: `test` is what
+ * the job is for, but in a job of six steps it says nothing about which of
+ * them is the test, and `npm ci` under a job named `test` is not the test
+ * command.
+ */
+export function deriveWorkflowCommands(
+  workflows: readonly ManifestFile[],
+  commands: Record<string, ProjectProfileLeaf<string>>,
+): void {
+  for (const workflow of workflows) {
+    let steps: readonly WorkflowStep[];
+    try {
+      steps = readWorkflowSteps(workflow.content);
+    } catch {
+      // A workflow this reader cannot place is skipped, never fatal.
+      continue;
+    }
+    const runsPerJob = countRunSteps(steps);
+    for (const step of steps) {
+      const stated = step.name === undefined ? null : slotOfName(step.name);
+      const slot =
+        stated ??
+        (runsPerJob.get(step.job) === 1
+          ? slotOfName(step.jobName ?? step.job)
+          : null);
+      if (slot === null) continue;
+      const where =
+        step.name === undefined
+          ? `job:${step.job}`
+          : `job:${step.job}/step:${step.name}`;
+      offer(commands, slot, step.run, `${workflow.path}#${where}`);
+    }
+  }
+}
+
+/**
+ * Derive commands from a Taskfile's named tasks.
+ *
+ * The task runner is the command: `task test` is what a maintainer types, and
+ * what the task expands to is the runner's business rather than the profile's.
+ */
+export function deriveTaskfileCommands(
+  file: ManifestFile,
+  commands: Record<string, ProjectProfileLeaf<string>>,
+): void {
+  const names = new Set<string>();
+  let tasksIndent: number | undefined;
+  let nameIndent: number | undefined;
+
+  for (const line of file.content.split("\n")) {
+    if (isIgnorable(line)) continue;
+    const indent = indentOf(line);
+    const body = line.slice(indent);
+    if (tasksIndent === undefined) {
+      if (indent === 0 && /^tasks\s*:/u.test(body)) tasksIndent = indent;
+      continue;
+    }
+    if (indent <= tasksIndent) break;
+    nameIndent ??= indent;
+    if (indent !== nameIndent) continue;
+    const entry = keyOf(body);
+    if (entry !== null) names.add(entry.key);
+  }
+
+  for (const slot of COMMAND_SLOTS) {
+    if (!names.has(slot)) continue;
+    offer(commands, slot, `task ${slot}`, `${file.path}#tasks.${slot}`);
+  }
+}
+
+/**
+ * Derive commands from a justfile's recipes.
+ *
+ * A recipe is declared at the left margin and its body is indented, which is
+ * the same shape the Makefile reader already relies on.
+ */
+export function deriveJustfileCommands(
+  file: ManifestFile,
+  commands: Record<string, ProjectProfileLeaf<string>>,
+): void {
+  const names = new Set<string>();
+
+  for (const line of file.content.split("\n")) {
+    if (isIgnorable(line)) continue;
+    if (indentOf(line) > 0 || line.startsWith("\t")) continue;
+    const match = /^@?([a-zA-Z0-9_-]+)(?:\s+[^:]*)?:(?!=)/u.exec(line);
+    if (match?.[1] !== undefined) names.add(match[1]);
+  }
+
+  for (const slot of COMMAND_SLOTS) {
+    if (!names.has(slot)) continue;
+    offer(commands, slot, `just ${slot}`, `${file.path}:${slot}`);
+  }
+}
+
+/**
+ * Derive commands from the tasks a mise configuration names.
+ *
+ * Both spellings state the same thing: a `[tasks.test]` table, or a `test =`
+ * entry under `[tasks]`.
+ */
+export function deriveMiseCommands(
+  file: ManifestFile,
+  commands: Record<string, ProjectProfileLeaf<string>>,
+): void {
+  const names = new Set<string>();
+  let inTasks = false;
+
+  for (const line of file.content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith("[")) {
+      const table = /^\[+\s*([^\]]*?)\s*\]+$/u.exec(trimmed)?.[1];
+      inTasks = table === "tasks";
+      const named = /^tasks\.["']?([A-Za-z0-9_-]+)["']?$/u.exec(table ?? "");
+      if (named?.[1] !== undefined) names.add(named[1]);
+      continue;
+    }
+    if (!inTasks) continue;
+    const key = /^["']?([A-Za-z0-9_-]+)["']?\s*=/u.exec(trimmed)?.[1];
+    if (key !== undefined) names.add(key);
+  }
+
+  for (const slot of COMMAND_SLOTS) {
+    if (!names.has(slot)) continue;
+    offer(commands, slot, `mise run ${slot}`, `${file.path}#tasks.${slot}`);
+  }
+}
+
+/** The devcontainer lifecycle keys that can carry named commands. */
+const DEVCONTAINER_LIFECYCLE = [
+  "onCreateCommand",
+  "updateContentCommand",
+  "postCreateCommand",
+  "postStartCommand",
+  "postAttachCommand",
+] as const;
+
+/**
+ * Derive commands from the named lifecycle commands of a devcontainer.
+ *
+ * Only the object form is read, because only there does a maintainer give each
+ * command a name -- and a name is what this reader attributes from. The string
+ * form is one unnamed command whose purpose nothing states.
+ */
+export function deriveDevcontainerCommands(
+  file: ManifestFile,
+  commands: Record<string, ProjectProfileLeaf<string>>,
+): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(file.content);
+  } catch {
+    // A configuration with comments, or none at all, derives nothing.
+    return;
+  }
+  if (typeof parsed !== "object" || parsed === null) return;
+  const document = parsed as Record<string, unknown>;
+
+  for (const lifecycle of DEVCONTAINER_LIFECYCLE) {
+    const entry = document[lifecycle];
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      continue;
+    }
+    for (const [name, command] of Object.entries(
+      entry as Record<string, unknown>,
+    )) {
+      if (typeof command !== "string") continue;
+      const slot = slotOfName(name);
+      if (slot === null) continue;
+      offer(commands, slot, command, `${file.path}#${lifecycle}.${name}`);
+    }
+  }
+}

--- a/tests/init-ci-command-derivation.test.ts
+++ b/tests/init-ci-command-derivation.test.ts
@@ -1,0 +1,487 @@
+import { observeManifestContents } from "@kratos/runtime/composition/repository";
+import {
+  CI_WORKFLOW_MAX_FILES,
+  deriveProjectProfile,
+  type ManifestContents,
+  type ProjectProfileLeaf,
+} from "@kratos/runtime/domain/init";
+import { memoryFileSystem } from "@kratos/runtime/infra/fake";
+import { describe, expect, it } from "vitest";
+
+function workflow(content: string, path = ".github/workflows/ci.yml") {
+  return { path, content };
+}
+
+/** The command a leaf carries, or nothing when the slot went unanswered. */
+function commandOf(
+  leaf: ProjectProfileLeaf<string> | undefined,
+): string | undefined {
+  return leaf !== undefined && "value" in leaf ? leaf.value : undefined;
+}
+
+const DOTNET_WORKFLOW = [
+  "name: CI",
+  "on: [push]",
+  "jobs:",
+  "  verify:",
+  "    runs-on: ubuntu-latest",
+  "    steps:",
+  "      - uses: actions/checkout@v4",
+  "      - name: Restore dependencies",
+  "        run: dotnet restore",
+  "      - name: Run tests",
+  "        run: dotnet test --filter Category!=Integration",
+  "      - name: Lint the solution",
+  "        run: dotnet format --verify-no-changes",
+].join("\n");
+
+describe("commands derived from CI workflows", () => {
+  it("derives the command a named workflow step runs, naming file, job, and step", () => {
+    const manifests: ManifestContents = {
+      workflows: [workflow(DOTNET_WORKFLOW)],
+    };
+    const evidence = { rootEntries: ["Api.csproj"] };
+
+    const derived = deriveProjectProfile(evidence, manifests);
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "dotnet test --filter Category!=Integration",
+      evidence: ".github/workflows/ci.yml#job:verify/step:Run tests",
+    });
+    expect(derived.commands?.lint).toEqual({
+      status: "derived",
+      value: "dotnet format --verify-no-changes",
+      evidence: ".github/workflows/ci.yml#job:verify/step:Lint the solution",
+    });
+  });
+
+  it("keeps a manifest declaration over what the workflow runs", () => {
+    const manifests: ManifestContents = {
+      packageJson: JSON.stringify({ scripts: { test: "vitest run" } }),
+      workflows: [
+        workflow(
+          [
+            "jobs:",
+            "  ci:",
+            "    steps:",
+            "      - name: Run tests",
+            "        run: npm test --workspaces",
+          ].join("\n"),
+        ),
+      ],
+    };
+
+    const derived = deriveProjectProfile(
+      { rootEntries: ["package.json"] },
+      manifests,
+    );
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "npm test",
+      evidence: "package.json#scripts.test",
+    });
+  });
+
+  it("prefers the workflow command to the toolchain default", () => {
+    const manifests: ManifestContents = {
+      workflows: [
+        workflow(
+          [
+            "jobs:",
+            "  ci:",
+            "    steps:",
+            "      - name: Test",
+            "        run: go test ./... -race",
+          ].join("\n"),
+        ),
+      ],
+    };
+
+    const derived = deriveProjectProfile(
+      { rootEntries: ["go.mod"] },
+      manifests,
+    );
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "go test ./... -race",
+      evidence: ".github/workflows/ci.yml#job:ci/step:Test",
+    });
+    // The slots the workflow said nothing about still fall to the toolchain.
+    expect(commandOf(derived.commands?.build)).toBe("go build ./...");
+  });
+
+  it("derives nothing from a step whose name states no purpose", () => {
+    const manifests: ManifestContents = {
+      workflows: [
+        workflow(
+          [
+            "jobs:",
+            "  ci:",
+            "    steps:",
+            "      - name: Everything",
+            "        run: npm test",
+            "      - run: npm run lint",
+          ].join("\n"),
+        ),
+      ],
+    };
+
+    const derived = deriveProjectProfile({ rootEntries: [] }, manifests);
+
+    expect(derived.commands).toBeUndefined();
+  });
+
+  it("derives nothing from a step whose name states two purposes", () => {
+    const manifests: ManifestContents = {
+      workflows: [
+        workflow(
+          [
+            "jobs:",
+            "  ci:",
+            "    steps:",
+            "      - name: Build and test",
+            "        run: make ci",
+          ].join("\n"),
+        ),
+      ],
+    };
+
+    expect(
+      deriveProjectProfile({ rootEntries: [] }, manifests).commands,
+    ).toBeUndefined();
+  });
+
+  it("lets a job name answer only when the job runs a single command", () => {
+    const single: ManifestContents = {
+      workflows: [
+        workflow(
+          [
+            "jobs:",
+            "  lint:",
+            "    name: Lint",
+            "    steps:",
+            "      - uses: actions/checkout@v4",
+            "      - run: ruff check .",
+          ].join("\n"),
+        ),
+      ],
+    };
+    const many: ManifestContents = {
+      workflows: [
+        workflow(
+          [
+            "jobs:",
+            "  lint:",
+            "    steps:",
+            "      - run: pip install ruff",
+            "      - run: ruff check .",
+          ].join("\n"),
+        ),
+      ],
+    };
+
+    expect(
+      deriveProjectProfile({ rootEntries: [] }, single).commands?.lint,
+    ).toEqual({
+      status: "derived",
+      value: "ruff check .",
+      evidence: ".github/workflows/ci.yml#job:lint",
+    });
+    expect(
+      deriveProjectProfile({ rootEntries: [] }, many).commands,
+    ).toBeUndefined();
+  });
+
+  it("skips a block scalar rather than deriving half of it", () => {
+    const manifests: ManifestContents = {
+      workflows: [
+        workflow(
+          [
+            "jobs:",
+            "  ci:",
+            "    steps:",
+            "      - name: Run tests",
+            "        run: |",
+            "          set -e",
+            "          npm test",
+            "      - name: Lint",
+            "        run: npm run lint",
+          ].join("\n"),
+        ),
+      ],
+    };
+
+    const derived = deriveProjectProfile({ rootEntries: [] }, manifests);
+
+    expect(derived.commands?.test).toBeUndefined();
+    expect(commandOf(derived.commands?.lint)).toBe("npm run lint");
+  });
+
+  it("skips a malformed workflow without failing the derivation", () => {
+    const manifests: ManifestContents = {
+      workflows: [
+        workflow(
+          "jobs:\n\t- this is not: [ valid, yaml",
+          ".github/workflows/broken.yml",
+        ),
+        workflow(
+          [
+            "jobs:",
+            "  ci:",
+            "    steps:",
+            "      - name: Tests",
+            "        run: cargo test",
+          ].join("\n"),
+          ".github/workflows/ci.yml",
+        ),
+      ],
+    };
+
+    const derived = deriveProjectProfile({ rootEntries: [] }, manifests);
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "cargo test",
+      evidence: ".github/workflows/ci.yml#job:ci/step:Tests",
+    });
+  });
+
+  it("reads the same workflows the same way every time", () => {
+    const manifests: ManifestContents = {
+      workflows: [workflow(DOTNET_WORKFLOW)],
+    };
+
+    expect(deriveProjectProfile({ rootEntries: [] }, manifests)).toEqual(
+      deriveProjectProfile({ rootEntries: [] }, manifests),
+    );
+  });
+});
+
+describe("commands derived from language-agnostic task runners", () => {
+  it("derives task names from a Taskfile", () => {
+    const derived = deriveProjectProfile(
+      { rootEntries: ["Taskfile.yml"] },
+      {
+        taskfile: {
+          path: "Taskfile.yml",
+          content: [
+            "version: '3'",
+            "tasks:",
+            "  test:",
+            "    cmds:",
+            "      - go test ./...",
+            "  build:",
+            "    cmds:",
+            "      - go build ./...",
+          ].join("\n"),
+        },
+      },
+    );
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "task test",
+      evidence: "Taskfile.yml#tasks.test",
+    });
+    expect(commandOf(derived.commands?.build)).toBe("task build");
+  });
+
+  it("derives recipes from a justfile", () => {
+    const derived = deriveProjectProfile(
+      { rootEntries: ["justfile"] },
+      {
+        justfile: {
+          path: "justfile",
+          content: [
+            "export RUST_LOG := 'info'",
+            "",
+            "test:",
+            "    cargo test",
+            "",
+            "lint arg='':",
+            "    cargo clippy {{arg}}",
+          ].join("\n"),
+        },
+      },
+    );
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "just test",
+      evidence: "justfile:test",
+    });
+    expect(commandOf(derived.commands?.lint)).toBe("just lint");
+  });
+
+  it("derives tasks from a mise configuration in either spelling", () => {
+    const derived = deriveProjectProfile(
+      { rootEntries: ["mise.toml"] },
+      {
+        miseToml: {
+          path: "mise.toml",
+          content: [
+            "[tools]",
+            'node = "24"',
+            "",
+            "[tasks.test]",
+            'run = "npm test"',
+            "",
+            "[tasks]",
+            'lint = "eslint ."',
+          ].join("\n"),
+        },
+      },
+    );
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "mise run test",
+      evidence: "mise.toml#tasks.test",
+    });
+    expect(commandOf(derived.commands?.lint)).toBe("mise run lint");
+  });
+
+  it("derives only the named lifecycle commands of a devcontainer", () => {
+    const derived = deriveProjectProfile(
+      { rootEntries: [] },
+      {
+        devcontainerJson: {
+          path: ".devcontainer/devcontainer.json",
+          content: JSON.stringify({
+            postCreateCommand: { install: "npm ci", build: "npm run build" },
+            postStartCommand: "npm start",
+          }),
+        },
+      },
+    );
+
+    expect(derived.commands?.build).toEqual({
+      status: "derived",
+      value: "npm run build",
+      evidence: ".devcontainer/devcontainer.json#postCreateCommand.build",
+    });
+    // The string form names nothing, so it answers nothing.
+    expect(derived.commands?.run).toBeUndefined();
+  });
+
+  it("keeps a task runner over the workflow that invokes it", () => {
+    const derived = deriveProjectProfile(
+      { rootEntries: ["justfile"] },
+      {
+        justfile: { path: "justfile", content: "test:\n    cargo test\n" },
+        workflows: [
+          workflow(
+            [
+              "jobs:",
+              "  ci:",
+              "    steps:",
+              "      - name: Run tests",
+              "        run: just test --verbose",
+            ].join("\n"),
+          ),
+        ],
+      },
+    );
+
+    expect(commandOf(derived.commands?.test)).toBe("just test");
+  });
+});
+
+describe("reading the files a derivation needs", () => {
+  it("reads the workflows and task runners the scan saw", async () => {
+    const fileSystem = memoryFileSystem({
+      "package.json": JSON.stringify({ scripts: { test: "vitest" } }),
+      "Taskfile.yml": "tasks:\n  test:\n    cmds:\n      - vitest\n",
+      justfile: "test:\n    vitest\n",
+      "mise.toml": "[tasks.lint]\nrun = 'eslint .'\n",
+      ".devcontainer/devcontainer.json": "{}",
+      ".github/workflows/ci.yml": DOTNET_WORKFLOW,
+      ".github/workflows/release.yaml": "jobs:\n",
+      ".github/workflows/notes.md": "not a workflow",
+    });
+
+    const evidence = {
+      rootEntries: [
+        ".devcontainer",
+        ".github",
+        "Taskfile.yml",
+        "justfile",
+        "mise.toml",
+        "package.json",
+      ],
+      files: [
+        ".devcontainer/devcontainer.json",
+        ".github/workflows/ci.yml",
+        ".github/workflows/notes.md",
+        ".github/workflows/release.yaml",
+        "Taskfile.yml",
+        "justfile",
+        "mise.toml",
+        "package.json",
+      ],
+    };
+
+    const manifests = await observeManifestContents(fileSystem, evidence);
+
+    expect(manifests.packageJson).toContain("vitest");
+    expect(manifests.taskfile?.path).toBe("Taskfile.yml");
+    expect(manifests.justfile?.path).toBe("justfile");
+    expect(manifests.miseToml?.path).toBe("mise.toml");
+    expect(manifests.devcontainerJson?.path).toBe(
+      ".devcontainer/devcontainer.json",
+    );
+    expect(manifests.workflows?.map((file) => file.path)).toEqual([
+      ".github/workflows/ci.yml",
+      ".github/workflows/release.yaml",
+    ]);
+  });
+
+  it("reads nothing the scan did not see", async () => {
+    const fileSystem = memoryFileSystem({
+      ".github/workflows/ci.yml": DOTNET_WORKFLOW,
+    });
+
+    const manifests = await observeManifestContents(fileSystem, {
+      rootEntries: [".github"],
+    });
+
+    expect(manifests.workflows).toBeUndefined();
+  });
+
+  it("stops at the workflow count ceiling, in path order", async () => {
+    const files: Record<string, string> = {};
+    const paths: string[] = [];
+    for (let index = 0; index < CI_WORKFLOW_MAX_FILES + 4; index += 1) {
+      const path = `.github/workflows/w${String(index).padStart(3, "0")}.yml`;
+      files[path] = "jobs:\n";
+      paths.push(path);
+    }
+
+    const manifests = await observeManifestContents(memoryFileSystem(files), {
+      rootEntries: [".github"],
+      files: paths,
+    });
+
+    expect(manifests.workflows).toHaveLength(CI_WORKFLOW_MAX_FILES);
+    expect(manifests.workflows?.[0]?.path).toBe(paths[0]);
+  });
+
+  it("skips a file too large to parse and every file it cannot read", async () => {
+    const fileSystem = memoryFileSystem({
+      ".github/workflows/huge.yml": "#".repeat(70_000),
+      justfile: "test:\n    vitest\n",
+    });
+
+    const manifests = await observeManifestContents(fileSystem, {
+      rootEntries: ["justfile"],
+      files: [".github/workflows/huge.yml", "justfile", "Taskfile.yml"],
+    });
+
+    expect(manifests.workflows).toBeUndefined();
+    expect(manifests.taskfile).toBeUndefined();
+    expect(manifests.justfile?.content).toContain("vitest");
+  });
+});

--- a/tests/profile-derive-command.test.ts
+++ b/tests/profile-derive-command.test.ts
@@ -150,6 +150,42 @@ describe("the profile derive command", () => {
     });
   });
 
+  it("derives the command CI runs, and survives a workflow it cannot parse", async () => {
+    const root = await project({
+      "Api.csproj": "<Project />\n",
+      "src/Program.cs": "class Program {}\n",
+      ".github/workflows/broken.yml": "jobs:\n\t- not: [ yaml\n",
+      ".github/workflows/ci.yml": [
+        "name: CI",
+        "on: [push]",
+        "jobs:",
+        "  verify:",
+        "    runs-on: ubuntu-latest",
+        "    steps:",
+        "      - uses: actions/checkout@v4",
+        "      - name: Run tests",
+        "        run: dotnet test --filter Category!=Integration",
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode, stdout } = await derive(root, "--json");
+
+    expect(exitCode).toBe(0);
+    const { profile } = JSON.parse(stdout) as ProjectProfileV1;
+    expect(profile.commands.test).toEqual({
+      status: "derived",
+      value: "dotnet test --filter Category!=Integration",
+      evidence: ".github/workflows/ci.yml#job:verify/step:Run tests",
+    });
+    // The workflow says nothing about building, so the toolchain still does.
+    expect(profile.commands.build).toEqual({
+      status: "derived",
+      value: "dotnet build",
+      evidence: "stack:dotnet via Api.csproj",
+    });
+  });
+
   it("names each answer with its evidence in human output", async () => {
     const root = await project({
       Makefile: "test:\n\tgo test ./...\n",


### PR DESCRIPTION
## Problem

A toolchain default answers what a project of that kind usually runs. It does not answer what this project runs. `dotnet test` is right until the repository runs `dotnet test --filter Category!=Integration`, and `npm test` is right until the suite is split across workspaces. In each case the real command is already written down in plain text, in the CI workflow that runs it on every push — and `observeManifestContents` read five files without ever opening one.

## Why a separate reader

Every other derivation source is per-ecosystem: a `package.json` reader knows npm, a `Cargo.toml` reader knows Rust. A workflow reader knows neither and serves both, because what it extracts is a literal string a maintainer wrote rather than a convention inferred from a file extension. The same shape covers the language-agnostic task runners, so `Taskfile.yml`, `justfile`, `mise.toml`, and `devcontainer.json` go through the same reader that `Makefile` targets already went through.

## What it does

- **Attribution is by name, never by command text.** A step named `Run tests` whose `run:` is `dotnet test --filter X` answers the test slot; the same command under `Install dependencies` answers nothing. Guessing from the verb is how a lint command becomes the test command, so a step whose name states no purpose — or two — derives nothing rather than the wrong thing. A job name answers only when the job runs a single command.
- **Evidence names file, job, and step** (`.github/workflows/ci.yml#job:verify/step:Run tests`), so the operator confirming the answer can open the exact line.
- **Precedence, most specific first:** what the project declares about itself, then what CI runs on every push, then the toolchain's canonical verb. A project declaring `scripts.test` keeps the declaration; a slot no workflow mentions still falls through to the convention.

## What is not lost

Reading stays bounded and offline. Only paths the existing scan already saw are opened, each is measured before it is read, the workflow set is capped at sixteen files taken in path order so the answer does not depend on directory enumeration, and any file past a ceiling — or malformed, or unreadable — is skipped in the same silence an unreadable manifest is skipped in today. No YAML anchors across files, no network, no subprocess.

A CI command can carry CI-only flags that are wrong on a workstation. This is derivation, not a stated answer, and it reaches the operator for confirmation like every other derived leaf.

## Acceptance

| Criterion | Test |
| --- | --- |
| `dotnet test --filter …` under a step named `Run tests` derives that command, with file, job, and step as evidence | `derives the command a named workflow step runs, naming file, job, and step` |
| A `package.json` declaring `scripts.test` keeps the declaration over the workflow | `keeps a manifest declaration over what the workflow runs` |
| A step with no name that states its purpose derives nothing | `derives nothing from a step whose name states no purpose` |
| A malformed workflow is skipped without failing `init` | `skips a malformed workflow without failing the derivation` |

## Verification

`typecheck`, `lint`, `format:check`, `english:check`, `result:check`, `contracts:check` clean. `vitest run`: 238 files, 5698 tests passing. `test:coverage` green (`tasks.ts` 91.4% statements / 88.6% branches, `repository.ts` 100%). `mutation:check` 4/4. `performance:check` at 1,639,971 / 1,700,000 runtime source bytes.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kj3juwFnqhAK61MG14WM8