### PR TITLE
fix(contracts): read a configuration an older plugin wrote

### DIFF
--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -55,12 +55,12 @@
 // source: https://kratos.dev/schemas/state/migration/v1.1 sha256:4223e8c4d4f69d60453edc2aaa880f0b0d04fdfea435ea45e378abff0d6aea38
 // source: https://kratos.dev/schemas/state/narration/v1 sha256:b3d99195b1792dbfb6d0d693f24fcfc546f0993c9fafcce4d873218aa7058e5f
 // source: https://kratos.dev/schemas/state/phase-measurement/v1 sha256:c783ccba225a9cd283460d11f9f1b590195c70ddcc8af28bf2bd891014888548
-// source: https://kratos.dev/schemas/state/project-config/v1 sha256:1dab1c54555c62b2b1fd6bd8d73232d5a363ca33ce1127fd1d2d0f7403b4993c
-// source: https://kratos.dev/schemas/state/project-config/v1.1 sha256:0128b06de2ff573a4b07f2ee867c782e673c15012690591f518e1923a9f9799c
-// source: https://kratos.dev/schemas/state/project-config/v1.2 sha256:e9974da03424b1434214b017e9ed3713336bfc9976dcb221518ac10eb54235f0
-// source: https://kratos.dev/schemas/state/project-config/v1.3 sha256:72709c73c7ed91b5695ee7f640ec4cb49b2c0b9de546448c7e2b516a6bcb2120
-// source: https://kratos.dev/schemas/state/project-config/v1.4 sha256:ef6a7b72d92f7f0b292e582e8dc7ce5dbbfaed5fb54d66c372f5c276befec929
-// source: https://kratos.dev/schemas/state/project-config/v1.5 sha256:a24bdd38c01b74471bf458f6778cad24cd4fcfca72c3c487f6a0fa94d170a6ea
+// source: https://kratos.dev/schemas/state/project-config/v1 sha256:14f90509bf59676c51980214418e4a67c86ba29b63d03626d93d17df65b70cd3
+// source: https://kratos.dev/schemas/state/project-config/v1.1 sha256:f03afbf773e7994a80535497ff8c067ba10714bc0dc315b373c2c8eff2870052
+// source: https://kratos.dev/schemas/state/project-config/v1.2 sha256:b80f716eb284153fcadc12bddaeb83ae1e0a476b18247fedb69c458b7ddeab97
+// source: https://kratos.dev/schemas/state/project-config/v1.3 sha256:f09065e00c907658c78d774452b614ecce4eaa6d663bc985e48980bfb5310ddb
+// source: https://kratos.dev/schemas/state/project-config/v1.4 sha256:9a0c8dcc4e895336e64482f049643b88791345b95e785d9d94bb592d4a7b492a
+// source: https://kratos.dev/schemas/state/project-config/v1.5 sha256:9fdb7e0bec669edcd59beedf7aa7c5310f43e5fe3f75102f7118a1722baee5f7
 // source: https://kratos.dev/schemas/state/requirement-discovery/v1 sha256:7974861ace6571c08cc3cee2921715f06800e48fb5ee9767cdcf45c0dc4354b4
 // source: https://kratos.dev/schemas/state/repair-loop-stop/v1 sha256:bf18ca66a29e1615e4714bcc081b8d41257cd553d9e3466d26846ce7d441d21b
 // source: https://kratos.dev/schemas/state/repair-loop-stop/v1.1 sha256:8dde526faeb7bc240f31e6edef90f6c2670e166dad0b75cda25ab58734386124
@@ -4675,10 +4675,12 @@ export namespace PhaseMeasurementV1Contract {
 }
 export type PhaseMeasurementV1 = PhaseMeasurementV1Contract.PhaseMeasurementV1;
 export namespace ProjectConfigV1Contract {
+  export type PluginVersion = string;
+
   export interface ProjectConfigV1 {
     contractVersion: "1.0.0";
     stateContract: "1.0.0";
-    pluginVersion: "0.3.0";
+    pluginVersion: PluginVersion;
     hostContract: "1.0.0";
     language: "en" | "pt-BR";
     policyMode: "standard" | "strict";
@@ -4691,6 +4693,7 @@ export namespace ProjectConfigV1Contract {
 }
 export type ProjectConfigV1 = ProjectConfigV1Contract.ProjectConfigV1;
 export namespace ProjectConfigV1_1Contract {
+  export type PluginVersion = string;
   export type Assignment =
     | Id
     | {
@@ -4702,7 +4705,7 @@ export namespace ProjectConfigV1_1Contract {
   export interface ProjectConfigV1_1 {
     contractVersion: "1.1.0";
     stateContract: "1.1.0";
-    pluginVersion: "0.3.0";
+    pluginVersion: PluginVersion;
     hostContract: "1.1.0";
     language: "en" | "pt-BR";
     policyMode: "standard" | "strict";
@@ -4725,6 +4728,7 @@ export namespace ProjectConfigV1_1Contract {
 }
 export type ProjectConfigV1_1 = ProjectConfigV1_1Contract.ProjectConfigV1_1;
 export namespace ProjectConfigV1_2Contract {
+  export type PluginVersion = string;
   export type LanguageCode = "en" | "pt-BR";
   export type Assignment =
     | Id
@@ -4737,7 +4741,7 @@ export namespace ProjectConfigV1_2Contract {
   export interface ProjectConfigV1_2 {
     contractVersion: "1.2.0";
     stateContract: "1.2.0";
-    pluginVersion: "0.3.0";
+    pluginVersion: PluginVersion;
     hostContract: "1.2.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4770,6 +4774,7 @@ export namespace ProjectConfigV1_2Contract {
 }
 export type ProjectConfigV1_2 = ProjectConfigV1_2Contract.ProjectConfigV1_2;
 export namespace ProjectConfigV1_3Contract {
+  export type PluginVersion = string;
   export type LanguageCode = "en" | "pt-BR";
   export type Assignment =
     | Id
@@ -4792,7 +4797,7 @@ export namespace ProjectConfigV1_3Contract {
   export interface ProjectConfigV1_3 {
     contractVersion: "1.3.0";
     stateContract: "1.3.0";
-    pluginVersion: "0.3.0";
+    pluginVersion: PluginVersion;
     hostContract: "1.3.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4876,6 +4881,7 @@ export namespace ProjectConfigV1_3Contract {
 }
 export type ProjectConfigV1_3 = ProjectConfigV1_3Contract.ProjectConfigV1_3;
 export namespace ProjectConfigV1_4Contract {
+  export type PluginVersion = string;
   export type LanguageCode = "en" | "pt-BR";
   export type GateMode = "shadow" | "warn" | "enforce";
   export type Assignment =
@@ -4899,7 +4905,7 @@ export namespace ProjectConfigV1_4Contract {
   export interface ProjectConfigV1_4 {
     contractVersion: "1.4.0";
     stateContract: "1.4.0";
-    pluginVersion: "0.3.0";
+    pluginVersion: PluginVersion;
     hostContract: "1.4.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";
@@ -4995,6 +5001,7 @@ export namespace ProjectConfigV1_4Contract {
 }
 export type ProjectConfigV1_4 = ProjectConfigV1_4Contract.ProjectConfigV1_4;
 export namespace ProjectConfigV1_5Contract {
+  export type PluginVersion = string;
   export type LanguageCode = "en" | "pt-BR";
   export type GateMode = "shadow" | "warn" | "enforce";
   export type Assignment =
@@ -5025,7 +5032,7 @@ export namespace ProjectConfigV1_5Contract {
   export interface ProjectConfigV1_5 {
     contractVersion: "1.5.0";
     stateContract: "1.5.0";
-    pluginVersion: "0.3.0";
+    pluginVersion: PluginVersion;
     hostContract: "1.4.0";
     language: LanguagePolicy;
     policyMode: "standard" | "strict";

--- a/schemas/state/project-config.v1.1.schema.json
+++ b/schemas/state/project-config.v1.1.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "contractVersion": { "const": "1.1.0" },
     "stateContract": { "const": "1.1.0" },
-    "pluginVersion": { "const": "0.3.0" },
+    "pluginVersion": { "$ref": "#/$defs/pluginVersion" },
     "hostContract": { "const": "1.1.0" },
     "language": { "enum": ["en", "pt-BR"] },
     "policyMode": { "enum": ["standard", "strict"] },
@@ -34,6 +34,10 @@
     "modelRoles": { "$ref": "#/$defs/modelRoles" }
   },
   "$defs": {
+    "pluginVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
     "id": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,127}$"

--- a/schemas/state/project-config.v1.2.schema.json
+++ b/schemas/state/project-config.v1.2.schema.json
@@ -17,7 +17,7 @@
   "properties": {
     "contractVersion": { "const": "1.2.0" },
     "stateContract": { "const": "1.2.0" },
-    "pluginVersion": { "const": "0.3.0" },
+    "pluginVersion": { "$ref": "#/$defs/pluginVersion" },
     "hostContract": { "const": "1.2.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },
@@ -34,6 +34,10 @@
     "modelRoles": { "$ref": "#/$defs/modelRoles" }
   },
   "$defs": {
+    "pluginVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
     "languageCode": {
       "enum": ["en", "pt-BR"]
     },

--- a/schemas/state/project-config.v1.3.schema.json
+++ b/schemas/state/project-config.v1.3.schema.json
@@ -18,7 +18,7 @@
   "properties": {
     "contractVersion": { "const": "1.3.0" },
     "stateContract": { "const": "1.3.0" },
-    "pluginVersion": { "const": "0.3.0" },
+    "pluginVersion": { "$ref": "#/$defs/pluginVersion" },
     "hostContract": { "const": "1.3.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },
@@ -36,6 +36,10 @@
     "projectProfile": { "$ref": "#/$defs/projectProfile" }
   },
   "$defs": {
+    "pluginVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
     "languageCode": { "enum": ["en", "pt-BR"] },
     "languagePolicy": {
       "type": "object",

--- a/schemas/state/project-config.v1.4.schema.json
+++ b/schemas/state/project-config.v1.4.schema.json
@@ -19,7 +19,7 @@
   "properties": {
     "contractVersion": { "const": "1.4.0" },
     "stateContract": { "const": "1.4.0" },
-    "pluginVersion": { "const": "0.3.0" },
+    "pluginVersion": { "$ref": "#/$defs/pluginVersion" },
     "hostContract": { "const": "1.4.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },
@@ -43,6 +43,10 @@
     "projectProfile": { "$ref": "#/$defs/projectProfile" }
   },
   "$defs": {
+    "pluginVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
     "gateMode": { "enum": ["shadow", "warn", "enforce"] },
     "gateModes": {
       "type": "object",

--- a/schemas/state/project-config.v1.5.schema.json
+++ b/schemas/state/project-config.v1.5.schema.json
@@ -19,7 +19,7 @@
   "properties": {
     "contractVersion": { "const": "1.5.0" },
     "stateContract": { "const": "1.5.0" },
-    "pluginVersion": { "const": "0.3.0" },
+    "pluginVersion": { "$ref": "#/$defs/pluginVersion" },
     "hostContract": { "const": "1.4.0" },
     "language": { "$ref": "#/$defs/languagePolicy" },
     "policyMode": { "enum": ["standard", "strict"] },
@@ -43,6 +43,10 @@
     "projectProfile": { "$ref": "#/$defs/projectProfile" }
   },
   "$defs": {
+    "pluginVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
     "gateMode": { "enum": ["shadow", "warn", "enforce"] },
     "gateModes": {
       "type": "object",

--- a/schemas/state/project-config.v1.schema.json
+++ b/schemas/state/project-config.v1.schema.json
@@ -16,7 +16,7 @@
   "properties": {
     "contractVersion": { "const": "1.0.0" },
     "stateContract": { "const": "1.0.0" },
-    "pluginVersion": { "const": "0.3.0" },
+    "pluginVersion": { "$ref": "#/$defs/pluginVersion" },
     "hostContract": { "const": "1.0.0" },
     "language": { "enum": ["en", "pt-BR"] },
     "policyMode": { "enum": ["standard", "strict"] },
@@ -29,6 +29,12 @@
         "eventLog": { "const": "events.jsonl" },
         "snapshots": { "type": "boolean" }
       }
+    }
+  },
+  "$defs": {
+    "pluginVersion": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
     }
   }
 }

--- a/scripts/check-contracts.mjs
+++ b/scripts/check-contracts.mjs
@@ -115,7 +115,28 @@ async function verifyArtifacts() {
       throw new VerificationError("registered schema could not be compiled");
     }
   }
+  assertPluginVersionIsNotPinned(registeredSchemas);
   return manifest;
+}
+
+/**
+ * A versioned state schema must not pin `pluginVersion` to one constant.
+ *
+ * A legacy schema exists to read a document an older plugin wrote, so pinning
+ * it to the shipping version makes every pre-upgrade configuration invalid and
+ * leaves `migrate config` with nothing it can read. The constant was rewritten
+ * across the whole historical set at each release, which is what made this
+ * recur; this check is what stops the next release from doing it again.
+ */
+function assertPluginVersionIsNotPinned(schemas) {
+  for (const schema of schemas) {
+    const pluginVersion = schema.properties?.pluginVersion;
+    if (pluginVersion?.const !== undefined) {
+      throw new VerificationError(
+        `${schema.$id} pins pluginVersion to a constant`,
+      );
+    }
+  }
 }
 
 function parseArguments(argv) {

--- a/tests/config-migration.test.ts
+++ b/tests/config-migration.test.ts
@@ -352,6 +352,66 @@ describe("configuration migration", () => {
     expect(after[SNAPSHOT_REF]).toBe(before[SNAPSHOT_REF]);
   });
 
+  it("migrates a configuration an older plugin wrote, not only one this version wrote", async () => {
+    // A v0.2.0 project carries `pluginVersion: "0.2.0"`. Pinning the legacy
+    // schema to the shipping version made that document unreadable, so the
+    // upgrade the command exists to perform was refused as corrupt.
+    const source: ProjectConfigV1_4 = {
+      contractVersion: "1.4.0",
+      stateContract: "1.4.0",
+      pluginVersion: "0.2.0",
+      hostContract: "1.4.0",
+      language: {
+        conversation: "en",
+        documentation: "en",
+        comments: "en",
+        identifiers: "en",
+        commits: "en",
+        preserveConventions: true,
+        enforcement: "advisory",
+      },
+      policyMode: "strict",
+      gateModes: { "spec-approved": "enforce" },
+      managedState: {
+        directory: ".brain",
+        eventLog: "events.jsonl",
+        snapshots: true,
+      },
+      modelRoles: { codex: codexCatalog().defaults },
+      projectProfile: {
+        commands: {
+          test: { status: "resolved", value: "npm test" },
+          lint: { status: "unresolved" },
+          build: { status: "unresolved" },
+          run: { status: "unresolved" },
+        },
+        paths: {
+          source: { status: "resolved", value: ["src"] },
+          tests: { status: "unresolved" },
+          configuration: { status: "unresolved" },
+        },
+        conventions: {
+          directoryLayout: { status: "unresolved" },
+          naming: { status: "unresolved" },
+          implementationLanguages: { status: "unresolved" },
+        },
+      },
+      acceptanceAttemptCeiling: 3,
+    };
+    const run = legacyProjectWithHistory([null, null], undefined, {
+      [CONFIG_REF]: `${JSON.stringify(source, null, 2)}\n`,
+    });
+
+    expect(await runAuthorizedConfigMigration(run)).toBe(0);
+
+    const migrated = JSON.parse(
+      run.storage.snapshot().files[CONFIG_REF] ?? "null",
+    ) as ProjectConfigV1_5;
+    expect(migrated.stateContract).toBe("1.5.0");
+    // The upgrade carries the writing version forward rather than restating it.
+    expect(migrated.pluginVersion).toBe("0.2.0");
+  });
+
   it("migrates 1.3 configuration without rewriting predecessor history", async () => {
     const source: ProjectConfigV1_3 = {
       contractVersion: "1.3.0",

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -824,7 +824,7 @@ describe("versioned state and host schemas", () => {
   it.each([
     [
       "state/project-config.v1.schema.json",
-      "1dab1c54555c62b2b1fd6bd8d73232d5a363ca33ce1127fd1d2d0f7403b4993c",
+      "14f90509bf59676c51980214418e4a67c86ba29b63d03626d93d17df65b70cd3",
     ],
     [
       "state/event.v1.schema.json",
@@ -884,15 +884,15 @@ describe("versioned state and host schemas", () => {
     ],
     [
       "state/project-config.v1.1.schema.json",
-      "0128b06de2ff573a4b07f2ee867c782e673c15012690591f518e1923a9f9799c",
+      "f03afbf773e7994a80535497ff8c067ba10714bc0dc315b373c2c8eff2870052",
     ],
     [
       "state/project-config.v1.2.schema.json",
-      "e9974da03424b1434214b017e9ed3713336bfc9976dcb221518ac10eb54235f0",
+      "b80f716eb284153fcadc12bddaeb83ae1e0a476b18247fedb69c458b7ddeab97",
     ],
     [
       "state/project-config.v1.3.schema.json",
-      "72709c73c7ed91b5695ee7f640ec4cb49b2c0b9de546448c7e2b516a6bcb2120",
+      "f09065e00c907658c78d774452b614ecce4eaa6d663bc985e48980bfb5310ddb",
     ],
   ])("keeps the published %s schema byte-identical", async (path, digest) => {
     const bytes = await readFile(join(schemaRoot, path));


### PR DESCRIPTION
## Problem

Upgrading a project from v0.2.0 to v0.3.0 left it with no migration path: `migrate config` refused the existing `.brain/config.json` as `guard.config_corrupt`, and `doctor` reported the same project as `runtime.state_corrupt` with gates blocked. The only way through was to hand-edit `pluginVersion` inside the managed surface — the one thing the migration command exists to avoid.

## Cause

Every versioned project-config schema pinned `pluginVersion` to the shipping version, and the constant was rewritten across the whole historical set at each release. `git log -p` on `project-config.v1.4.schema.json` tells the story:

| Commit | Value |
| --- | --- |
| authored | `0.0.0-development` |
| `f32d1af` (v0.2.0 release) | `0.2.0` |
| `ebb578f` (v0.3.0 release) | `0.3.0` |

`observeConfig` validates a source document against the schema for its own `stateContract` before planning the upgrade. That validation can never pass for a document an older plugin wrote, because the schema for the *old* contract demands the *new* plugin version.

## Fix

A legacy schema exists to read what an older plugin wrote, which is why a constant is the wrong *shape* for this field rather than merely a stale value. Freezing each constant at authoring time would repair the versions already shipped and break the next one — the destination schema has the same defect in the other direction, so after v0.4.0 ships, a document v0.3.0 wrote at contract 1.5 fails identically.

So `pluginVersion` becomes a semver pattern in all six versioned schemas (`v1`, `v1.1`–`v1.5`), shared through one `$defs/pluginVersion`. Which plugin versions are actually supported stays where it was already decided: in the migration logic, not in the schema.

`check-contracts` gains the guard that keeps this from returning — a versioned state schema pinning `pluginVersion` to a constant now fails contract verification, so the next release cannot reintroduce the rewrite by hand.

## What reviewers should look at

The three published legacy schemas change bytes, and their digest pins in `tests/contract-schemas.test.ts` are updated to match. That is deliberate: the pinned bytes are the defect. This is the one place where the byte-identity guarantee is knowingly spent.

## Verification

The regression test (`migrates a configuration an older plugin wrote, not only one this version wrote`) migrates a 1.4 document carrying `pluginVersion: "0.2.0"` through to 1.5. It is not vacuous — restoring the `const` on `v1.4` alone makes it fail with the issue's exit code 2, and the new contract guard fires with `project-config/v1.4 pins pluginVersion to a constant`.

`vitest run`: 238 files, 5680 tests passing. `typecheck`, `lint`, `format:check`, `english:check`, `contracts:check` clean (generated types regenerated).

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kj3juwFnqhAK61MG14WM8