### PR TITLE
fix(cli): render the migration preview and publish the plan it authorizes

### DIFF
--- a/docs/compatibility/contract-versioning.md
+++ b/docs/compatibility/contract-versioning.md
@@ -94,6 +94,12 @@ follow `CONTRACT_VERSIONS`:
   profile `kratos profile derive` publishes. Every answer is present: a leaf
   the derivation produced carries its `derived` value and evidence, and a leaf
   it did not carries `unresolved` and nothing else.
+- `host.migration-plan@1.0.0` is the structured configuration migration plan
+  `kratos migrate config` publishes. It replaces the result envelope on that
+  command's successful `--json` output. A preview and a completed apply carry
+  the plan digest, the plan instant, and the exact write paths; a configuration
+  already on the current contract carries `status: "current"` and a null plan,
+  because there is no plan to carry.
 - The current memory-aware selectors are `host.phase-handoff@1.4.0`,
   `host.agent-output@1.3.0`, `host.memory-capture@1.2.0`,
   `host.memory-change@1.4.0`, `host.memory-curation@1.4.0`, and

--- a/docs/user/commands.md
+++ b/docs/user/commands.md
@@ -297,7 +297,15 @@ the current configuration/state version constants.
 The preview performs no writes and prints the source, destination, answers,
 catalog, and plan digests; confirmed hosts; every canonical assignment and
 default; resolved project-profile answers; the plan time; six exact write
-paths; and the complete apply command.
+paths; and the complete apply command. A `--root` the operator passed as an
+absolute path is named rather than echoed, because the result contract does not
+publish absolute paths.
+
+With `--json` the command publishes `host.migration-plan@1.0.0` in place of the
+result envelope, so a host can authorize the apply from the machine-readable
+output alone: the payload carries `planDigest`, `planTime`, and the exact write
+paths. A configuration already on the current contract answers
+`status: "current"` with a null plan.
 Apply requires the exact caller-carried values:
 
 ```bash

--- a/fixtures/contracts/v1/migration-plan.json
+++ b/fixtures/contracts/v1/migration-plan.json
@@ -1,0 +1,15 @@
+{
+  "contractVersion": "1.0.0",
+  "hostContract": "1.4.0",
+  "status": "preview",
+  "plan": {
+    "planDigest": "11fb2b79000000000000000000000000000000000000000000000000000d0d54",
+    "planTime": "2026-08-29T00:00:00.000Z",
+    "writes": [
+      {
+        "path": ".brain/config.json",
+        "sha256": "4934fb90ff8365eb3129ec2bbca57c65d5755698c4579688bbf1824d5a2e3231"
+      }
+    ]
+  }
+}

--- a/packages/contracts/catalogs/contract-families.v1.json
+++ b/packages/contracts/catalogs/contract-families.v1.json
@@ -190,6 +190,14 @@
       "typeName": "MemoryMigrationV1_4"
     },
     {
+      "id": "host.migration-plan",
+      "family": "host",
+      "version": "1.0.0",
+      "path": "schemas/host/migration-plan.v1.schema.json",
+      "boundary": "cross-process",
+      "typeName": "MigrationPlanV1"
+    },
+    {
       "id": "host.operation-message",
       "family": "host",
       "version": "1.0.0",

--- a/packages/contracts/src/generated/contracts.ts
+++ b/packages/contracts/src/generated/contracts.ts
@@ -23,6 +23,7 @@
 // source: https://kratos.dev/schemas/host/memory-curation/v1.4 sha256:c55c4b72817340d0f4cd190fd01e57dc1a2028c95b1a6968284218a08c08e589
 // source: https://kratos.dev/schemas/host/memory-migration/v1.2 sha256:8d55797500d2758dba1b7cca53dab0d873a10f8d12bf69fb391621a9276a2d01
 // source: https://kratos.dev/schemas/host/memory-migration/v1.4 sha256:f07bf84b45234ab5031cf4db421a5cb3d9f9ee4036a1066e1687dd75cef0425b
+// source: https://kratos.dev/schemas/host/migration-plan/v1 sha256:80e3908c6aec1ad8bc655322fecc9909f8aa3ae80c269aa9f4bb281922d1a1ac
 // source: https://kratos.dev/schemas/host/operation-message/v1 sha256:8ba8d2a6a61a30e80c5a215130eeb8c60456d087012369f5284be92c81d2152a
 // source: https://kratos.dev/schemas/host/phase-handoff/v1.1 sha256:1d86294f4b9add65d6d71d9c9174072c526a9799141d798ab78733820e6236ae
 // source: https://kratos.dev/schemas/host/phase-handoff/v1.2 sha256:a88b38d5d78813221ed554217de8cc39a2470687467a58f113e5b77dc972023a
@@ -2173,6 +2174,31 @@ export namespace MemoryMigrationV1_4Contract {
 }
 export type MemoryMigrationV1_4 =
   MemoryMigrationV1_4Contract.MemoryMigrationV1_4;
+export namespace MigrationPlanV1Contract {
+  export type Sha256 = string;
+  export type Instant = string;
+  export type Path = string;
+
+  export interface MigrationPlanV1 {
+    contractVersion: "1.0.0";
+    hostContract: "1.4.0";
+    status: "current" | "preview" | "applied";
+    plan: null | Plan;
+  }
+  export interface Plan {
+    planDigest: Sha256;
+    planTime: Instant;
+    /**
+     * @maxItems 256
+     */
+    writes: Write[];
+  }
+  export interface Write {
+    path: Path;
+    sha256: Sha256;
+  }
+}
+export type MigrationPlanV1 = MigrationPlanV1Contract.MigrationPlanV1;
 export namespace HostOperationMessageV1Contract {
   export type HostOperationMessageV1 =
     | ApprovalMessage

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -124,6 +124,7 @@ export type {
   MemoryCurationV1_4,
   MemoryMigrationV1_2,
   MemoryMigrationV1_4,
+  MigrationPlanV1,
 } from "./generated/contracts.js";
 
 export type LanguagePolicyV1 = ProjectConfigV1_5Contract.LanguagePolicy;

--- a/packages/runtime/src/composition/cli.ts
+++ b/packages/runtime/src/composition/cli.ts
@@ -1,6 +1,7 @@
 import {
   CONTRACT_VERSIONS,
   type DoctorReportV1,
+  type MigrationPlanV1,
   type ProjectProfileV1,
 } from "@kratos/contracts";
 
@@ -151,6 +152,24 @@ function prepareDoctorReportPayload(
   return { canonical: prepared.canonical, value: prepared.value };
 }
 
+function prepareMigrationPlanPayload(
+  payload: unknown,
+  registry: SchemaRegistry,
+): { readonly canonical: string; readonly value: MigrationPlanV1 } {
+  const version = declaredContractVersion(payload, "contractVersion", "1.0.0");
+  const prepared = prepareContract(registry, {
+    id: "host.migration-plan",
+    version,
+    value: payload,
+    structuralReasonCode: "trail.output_invalido",
+  });
+  if (prepared.kind === "invalid") {
+    throw new Error("Command payload does not satisfy its declared contract");
+  }
+  validatePublicPayload(prepared.value);
+  return { canonical: prepared.canonical, value: prepared.value };
+}
+
 function prepareProjectProfilePayload(
   payload: unknown,
   registry: SchemaRegistry,
@@ -271,6 +290,18 @@ export async function runCommandLine(
       );
       preparedOutput = json
         ? `${doctor.canonical}\n`
+        : (decision.humanStdout ?? `${decision.result.summary}\n`);
+      if (!json) validatePublicText(preparedOutput);
+    } else if (invocation.command.jsonContract === "migration-plan@1.0.0") {
+      if (decision.payload === undefined) {
+        throw new Error("Command payload is absent");
+      }
+      const migration = prepareMigrationPlanPayload(
+        decision.payload,
+        schemaRegistry,
+      );
+      preparedOutput = json
+        ? `${migration.canonical}\n`
         : (decision.humanStdout ?? `${decision.result.summary}\n`);
       if (!json) validatePublicText(preparedOutput);
     } else if (invocation.command.jsonContract === "project-profile@1.0.0") {

--- a/packages/runtime/src/domain/cli/index.ts
+++ b/packages/runtime/src/domain/cli/index.ts
@@ -3,6 +3,7 @@ export { DEFAULT_REGISTRY } from "./commands.js";
 export { dispatch } from "./dispatch.js";
 export { initCommand } from "./init.js";
 export {
+  configMigrationApplyArgv,
   memoryMigrationApplyArgv,
   renderMemoryMigrationApply,
 } from "./migration.js";

--- a/packages/runtime/src/domain/cli/migration.ts
+++ b/packages/runtime/src/domain/cli/migration.ts
@@ -1,4 +1,4 @@
-import type { MigrationV1 } from "@kratos/contracts";
+import type { MigrationPlanV1, MigrationV1 } from "@kratos/contracts";
 
 import {
   authorizeMigration,
@@ -16,7 +16,6 @@ import { observingCommand } from "./observed.js";
 import {
   renderApplyInstructions,
   renderPosixCommand,
-  shellArgument,
 } from "./shell-argument.js";
 import type {
   CommandObservation,
@@ -97,7 +96,7 @@ export const migrateConfigCommand: CommandSpec = observingCommand(
       },
     ],
     positionals: { min: 0, max: 0 },
-    jsonContract: "result@1.0.0",
+    jsonContract: "migration-plan@1.0.0",
   },
   (invocation, observation) => migrateConfig(invocation, observation),
 );
@@ -282,9 +281,12 @@ function migrateConfig(
 ): Decision {
   const operation = observation.operation;
   if (operation.kind === "config-current") {
-    return orientation(
-      `Project configuration ${operation.sha256} is already current.`,
-    );
+    return {
+      ...orientation(
+        `Project configuration ${operation.sha256} is already current.`,
+      ),
+      payload: migrationPlanPayload("current", null),
+    };
   }
   if (operation.kind !== "config") return corrupt();
 
@@ -301,9 +303,15 @@ function migrateConfig(
         `Plan digest: ${operation.planDigest}`,
         `Plan time: ${operation.now}`,
         ...details,
-        `Apply command: ${configApplyCommand(invocation, operation.planDigest, operation.now)}`,
+        ...renderApplyInstructions(
+          configMigrationApplyArgv(
+            invocation,
+            operation.planDigest,
+            operation.now,
+          ),
+        ),
       ].join("\n")}\n`,
-      payload: null,
+      payload: migrationPlanPayload("preview", operation),
     };
   }
   if (
@@ -322,6 +330,7 @@ function migrateConfig(
       })),
       why: operation.defaulted.map((path) => `defaulted: ${path}`),
     }),
+    payload: migrationPlanPayload("applied", operation),
     plan: planOf(
       ...operation.guards.map(({ path, content, expected }) => ({
         kind: "write_file" as const,
@@ -337,7 +346,37 @@ function migrateConfig(
       })),
     ),
     humanStdout: null,
-    payload: null,
+  };
+}
+
+/**
+ * The plan as a host reads it, rather than as a sentence it would have to
+ * parse.
+ *
+ * The apply is authorized by the exact digest and the exact instant the
+ * preview planned at, and the digest is derived from that instant, so a caller
+ * holding only the machine-readable output could not reconstruct the
+ * invocation while these lived in the human render alone.
+ */
+function migrationPlanPayload(
+  status: MigrationPlanV1["status"],
+  operation: ConfigOperation | null,
+): MigrationPlanV1 {
+  return {
+    contractVersion: "1.0.0",
+    hostContract: "1.4.0",
+    status,
+    plan:
+      operation === null
+        ? null
+        : {
+            planDigest: operation.planDigest,
+            planTime: operation.now,
+            writes: operation.writes.map(({ path, sha256 }) => ({
+              path,
+              sha256,
+            })),
+          },
   };
 }
 
@@ -602,24 +641,25 @@ function chunk(value: string, maximum: number): string[] {
   return chunks;
 }
 
-function configApplyCommand(
+/**
+ * The exact argv that authorizes this preview.
+ *
+ * Values are collected unquoted; quoting belongs to whichever shell display
+ * `renderApplyInstructions` renders, and the argv line itself is the authority
+ * a host reads.
+ */
+export function configMigrationApplyArgv(
   invocation: Invocation,
   planDigest: string,
   planTime: string,
-): string {
-  const arguments_: string[] = ["kratos", "migrate", "config"];
+): string[] {
+  const argv: string[] = ["kratos", "migrate", "config"];
   for (const flag of ["--root", "--answers"] as const) {
     const value = invocation.flags.get(flag);
-    if (typeof value === "string") arguments_.push(flag, shellArgument(value));
+    if (typeof value === "string") argv.push(flag, value);
   }
-  arguments_.push(
-    "--yes",
-    "--plan-digest",
-    planDigest,
-    "--plan-time",
-    planTime,
-  );
-  return arguments_.join(" ");
+  argv.push("--yes", "--plan-digest", planDigest, "--plan-time", planTime);
+  return argv;
 }
 
 function json(value: unknown): string {

--- a/packages/runtime/src/domain/cli/shell-argument.ts
+++ b/packages/runtime/src/domain/cli/shell-argument.ts
@@ -1,3 +1,5 @@
+import { validatePublicText } from "../result/index.js";
+
 const SAFE_SHELL_ARGUMENT = /^[A-Za-z0-9_./:@=-]+$/u;
 
 /** Render one literal POSIX shell argument without evaluating its contents. */
@@ -17,8 +19,27 @@ export function renderPowerShellCommand(argv: readonly string[]): string {
   return `& ${argv.map((value) => `'${value.replaceAll("'", "''")}'`).join(" ")}`;
 }
 
-/** Canonical shell-neutral authority followed by copyable shell displays. */
+/**
+ * Canonical shell-neutral authority followed by copyable shell displays.
+ *
+ * The exact argv is rendered whenever it can be published. It often cannot:
+ * the result contract refuses to publish an absolute path, and `--root` holds
+ * one whenever the operator passed one, so echoing the argv verbatim made the
+ * whole preview unpublishable -- which is how the human preview failed as an
+ * internal error while `--json`, which never renders these lines, succeeded.
+ *
+ * A value that cannot be published is named instead of printed. The operator
+ * still sees which flags to repeat, and the one value withheld is the one they
+ * typed themselves and therefore already have.
+ */
 export function renderApplyInstructions(argv: readonly string[]): string[] {
+  const exact = instructionLines(argv);
+  return exact.every(isPublishable)
+    ? exact
+    : instructionLines(withheldArgv(argv));
+}
+
+function instructionLines(argv: readonly string[]): string[] {
   const posix = renderPosixCommand(argv);
   return [
     `Apply argv: ${JSON.stringify(argv)}`,
@@ -27,4 +48,29 @@ export function renderApplyInstructions(argv: readonly string[]): string[] {
     // Compatibility for existing parsers; Apply argv is authoritative.
     `Apply command: ${posix}`,
   ];
+}
+
+/**
+ * The same argv with each unpublishable value replaced by what it stands for.
+ *
+ * The flag ahead of the value names it, so the placeholder can say which of
+ * the operator's own arguments to put back rather than leaving a blank.
+ */
+function withheldArgv(argv: readonly string[]): readonly string[] {
+  return argv.map((value, index) => {
+    if (isPublishable(value)) return value;
+    const flag = argv[index - 1];
+    return flag?.startsWith("--") === true
+      ? `<the ${flag} value you passed>`
+      : "<value withheld>";
+  });
+}
+
+function isPublishable(text: string): boolean {
+  try {
+    validatePublicText(text);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/runtime/src/domain/cli/spec.ts
+++ b/packages/runtime/src/domain/cli/spec.ts
@@ -110,6 +110,7 @@ export type JsonContractId =
   | "adapter-message@1.0.0"
   | "doctor-report@1.0.0"
   | "phase-handoff@1.4.0"
+  | "migration-plan@1.0.0"
   | "project-profile@1.0.0";
 
 export interface Decision {

--- a/packages/runtime/src/domain/schema/contracts.ts
+++ b/packages/runtime/src/domain/schema/contracts.ts
@@ -48,6 +48,7 @@ import type {
   ProjectConfigV1_4,
   ProjectConfigV1_5,
   PreToolUseV1,
+  MigrationPlanV1,
   ProjectProfileV1,
   RequirementDiscoveryV1,
   RepairLoopStopV1,
@@ -95,6 +96,7 @@ export interface ContractValues {
   readonly "host.memory-change": MemoryChangeV1_2 | MemoryChangeV1_4;
   readonly "host.memory-curation": MemoryCurationV1_4;
   readonly "host.memory-migration": MemoryMigrationV1_2 | MemoryMigrationV1_4;
+  readonly "host.migration-plan": MigrationPlanV1;
   readonly "host.pre-tool-use": PreToolUseV1;
   readonly "host.project-profile": ProjectProfileV1;
   readonly "state.approval": ApprovalV1;

--- a/packages/runtime/src/infra/schema/catalog.ts
+++ b/packages/runtime/src/infra/schema/catalog.ts
@@ -21,6 +21,7 @@ import memoryChangeV1_4Schema from "../../../../../schemas/host/memory-change.v1
 import memoryCurationV1_4Schema from "../../../../../schemas/host/memory-curation.v1.4.schema.json" with { type: "json" };
 import memoryMigrationV1_2Schema from "../../../../../schemas/host/memory-migration.v1.2.schema.json" with { type: "json" };
 import memoryMigrationV1_4Schema from "../../../../../schemas/host/memory-migration.v1.4.schema.json" with { type: "json" };
+import migrationPlanSchema from "../../../../../schemas/host/migration-plan.v1.schema.json" with { type: "json" };
 import operationMessageSchema from "../../../../../schemas/host/operation-message.v1.schema.json" with { type: "json" };
 import preToolUseSchema from "../../../../../schemas/host/pre-tool-use.v1.schema.json" with { type: "json" };
 import projectProfileSchema from "../../../../../schemas/host/project-profile.v1.schema.json" with { type: "json" };
@@ -243,6 +244,13 @@ export const EMBEDDED_SCHEMA_CATALOG: readonly EmbeddedSchemaEntry[] =
       version: "1.4.0",
       path: "schemas/host/memory-migration.v1.4.schema.json",
       schema: memoryMigrationV1_4Schema,
+    },
+    {
+      id: "host.migration-plan",
+      family: "host",
+      version: "1.0.0",
+      path: "schemas/host/migration-plan.v1.schema.json",
+      schema: migrationPlanSchema,
     },
     {
       id: "host.operation-message",

--- a/quality/performance-budgets.json
+++ b/quality/performance-budgets.json
@@ -1,6 +1,6 @@
 {
   "runtimeSourceBytes": 1700000,
-  "contractSchemaBytes": 370000,
+  "contractSchemaBytes": 410000,
   "helpP95Ms": 2000,
   "versionP95Ms": 2000,
   "handshakeP95Ms": 2000,

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -101,6 +101,9 @@ The host family contains:
 - [`host.project-profile@1.0.0`](host/project-profile.v1.schema.json), the
   read-only derived project profile every host presents before the
   initialization interview,
+- [`host.migration-plan@1.0.0`](host/migration-plan.v1.schema.json), the
+  configuration migration plan `kratos migrate config` publishes, carrying the
+  plan digest and the plan instant an apply has to repeat,
 - [`gap-proposal.v1.schema.json`](host/gap-proposal.v1.schema.json), and
 - [`init-answers.v1.schema.json`](host/init-answers.v1.schema.json) plus its
   [`init-answers.v1.1.schema.json`](host/init-answers.v1.1.schema.json) and

--- a/schemas/contracts/contract-manifest.v1.12.schema.json
+++ b/schemas/contracts/contract-manifest.v1.12.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kratos.dev/schemas/contracts/contract-manifest/v1.12",
+  "title": "Kratos contract family manifest v1.12",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contractVersion",
+    "pluginVersion",
+    "resultContract",
+    "reasonCatalog",
+    "stateContract",
+    "hostContract",
+    "schemas",
+    "legacyProfiles"
+  ],
+  "properties": {
+    "contractVersion": { "const": "1.0.0" },
+    "pluginVersion": { "const": "0.3.0" },
+    "resultContract": { "const": "1.0.0" },
+    "reasonCatalog": { "const": "1.11.0" },
+    "stateContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current", "readable", "migrationOnly"],
+      "properties": {
+        "current": { "const": "1.5.0" },
+        "readable": {
+          "const": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"]
+        },
+        "migrationOnly": { "const": ["0.9.0", "go-v3@0.6.5"] }
+      }
+    },
+    "hostContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current", "accepted"],
+      "properties": {
+        "current": { "const": "1.4.0" },
+        "accepted": {
+          "const": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"]
+        }
+      }
+    },
+    "schemas": {
+      "type": "array",
+      "minItems": 18,
+      "maxItems": 72,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/schemaEntry" }
+    },
+    "legacyProfiles": {
+      "type": "array",
+      "minItems": 14,
+      "maxItems": 14,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/legacyProfile" }
+    }
+  },
+  "$defs": {
+    "schemaEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "family", "version", "path", "boundary", "typeName"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^(?:state|host)\\.[a-z][a-z-]*$"
+        },
+        "family": { "enum": ["state", "host"] },
+        "version": {
+          "enum": [
+            "1.0.0",
+            "1.1.0",
+            "1.2.0",
+            "1.3.0",
+            "1.4.0",
+            "1.5.0",
+            "1.6.0"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^schemas/(?:state|host)/[a-z-]+\\.v1(?:\\.[123456])?\\.schema\\.json$"
+        },
+        "boundary": { "enum": ["persisted", "cross-process"] },
+        "typeName": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Za-z0-9]*V1(?:_[123456])?$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "family": { "const": "state" } },
+            "required": ["family"]
+          },
+          "then": {
+            "properties": {
+              "id": { "type": "string", "pattern": "^state\\." },
+              "path": { "type": "string", "pattern": "^schemas/state/" },
+              "boundary": { "const": "persisted" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "family": { "const": "host" } },
+            "required": ["family"]
+          },
+          "then": {
+            "properties": {
+              "id": { "type": "string", "pattern": "^host\\." },
+              "path": { "type": "string", "pattern": "^schemas/host/" },
+              "boundary": { "const": "cross-process" }
+            }
+          }
+        }
+      ]
+    },
+    "legacyProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "oracleId",
+        "payloadContract",
+        "schemaVersion",
+        "compatibility",
+        "parityRow"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z-]+\\.schema\\.json$"
+        },
+        "oracleId": { "const": "go-v3-v0.6.5" },
+        "payloadContract": {
+          "type": "string",
+          "pattern": "^go-v3\\.[a-z][a-z-]+@1$"
+        },
+        "schemaVersion": { "const": 1 },
+        "compatibility": { "const": "migration-only" },
+        "parityRow": {
+          "oneOf": [
+            { "type": "string", "pattern": "^SCHEMA-[A-Z-]+-JSON$" },
+            { "type": "null" }
+          ]
+        },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "name": { "const": "prd-output.schema.json" } },
+            "required": ["name"]
+          },
+          "then": {
+            "required": ["sha256"],
+            "properties": {
+              "payloadContract": { "const": "go-v3.prd-output@1" },
+              "parityRow": { "type": "null" },
+              "sha256": {
+                "const": "7fa4f468520fac2f2a0d3b766257e162d25f37520dd7507230616257f2fe503e"
+              }
+            }
+          },
+          "else": {
+            "not": { "required": ["sha256"] },
+            "properties": { "parityRow": { "type": "string" } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/host/migration-plan.v1.schema.json
+++ b/schemas/host/migration-plan.v1.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kratos.dev/schemas/host/migration-plan/v1",
+  "title": "Kratos configuration migration plan v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contractVersion", "hostContract", "status", "plan"],
+  "properties": {
+    "contractVersion": { "const": "1.0.0" },
+    "hostContract": { "const": "1.4.0" },
+    "status": { "enum": ["current", "preview", "applied"] },
+    "plan": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/plan" }]
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "instant": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[^\\r\\n]+$"
+    },
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$))(?![A-Za-z][A-Za-z0-9+.-]*:)(?!.*[\\u0000-\\u001F\\u007F]).+$"
+    },
+    "write": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "$ref": "#/$defs/path" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planDigest", "planTime", "writes"],
+      "properties": {
+        "planDigest": { "$ref": "#/$defs/sha256" },
+        "planTime": { "$ref": "#/$defs/instant" },
+        "writes": {
+          "type": "array",
+          "maxItems": 256,
+          "items": { "$ref": "#/$defs/write" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/check-contracts.mjs
+++ b/scripts/check-contracts.mjs
@@ -56,7 +56,7 @@ async function verifyArtifacts() {
   const manifestSchema = await readJson(
     join(
       repositoryRoot,
-      "schemas/contracts/contract-manifest.v1.11.schema.json",
+      "schemas/contracts/contract-manifest.v1.12.schema.json",
     ),
   );
   const resultSchema = await readJson(

--- a/tests/cli-commands.test.ts
+++ b/tests/cli-commands.test.ts
@@ -20,10 +20,13 @@ import {
 } from "@kratos/runtime/domain/cli";
 import { renderMemoryApplyCommand } from "@kratos/runtime/domain/cli/memory";
 import {
+  configMigrationApplyArgv,
   memoryMigrationApplyArgv,
+  renderApplyInstructions,
   renderMemoryMigrationApply,
   renderPowerShellCommand,
 } from "@kratos/runtime/domain/cli";
+import { validatePublicText } from "@kratos/runtime/domain/result";
 import { USAGE_WHY } from "@kratos/runtime/domain/result";
 
 function invoke(argv: readonly string[]) {
@@ -64,6 +67,54 @@ describe("implemented commands", () => {
     ).toBe(
       String.raw`kratos memory promote --root 'a root'\''$;$(bad)' 'proposal '\''x'\''; $(bad).json' --yes --proposal-digest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --plan-digest bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --plan-time 2026-08-29T00:00:00Z`,
     );
+  });
+
+  it("withholds an absolute root from the apply instructions instead of failing to publish them", () => {
+    // The result contract refuses to publish an absolute path. Echoing the
+    // --root the operator passed made the whole preview unpublishable, which
+    // surfaced as an internal failure in human mode while --json, which never
+    // renders these lines, succeeded.
+    const parsed = parseInvocation(
+      ["migrate", "config", "--root", "/srv/projects/api"],
+      DEFAULT_REGISTRY,
+    );
+    if (parsed.kind !== "invocation") throw new Error("expected invocation");
+
+    const lines = renderApplyInstructions(
+      configMigrationApplyArgv(
+        parsed.invocation,
+        "a".repeat(64),
+        "2026-08-29T00:00:00Z",
+      ),
+    );
+
+    for (const line of lines) {
+      expect(() => validatePublicText(line), line).not.toThrow();
+      expect(line).not.toContain("/srv/projects/api");
+    }
+    expect(lines.join("\n")).toContain("<the --root value you passed>");
+    // The digest and the plan time still authorize the apply exactly.
+    expect(lines.join("\n")).toContain(`--plan-digest ${"a".repeat(64)}`);
+    expect(lines.join("\n")).toContain("--plan-time 2026-08-29T00:00:00Z");
+  });
+
+  it("keeps the exact argv when every value can be published", () => {
+    const parsed = parseInvocation(
+      ["migrate", "config", "--root", "projects/api"],
+      DEFAULT_REGISTRY,
+    );
+    if (parsed.kind !== "invocation") throw new Error("expected invocation");
+
+    const lines = renderApplyInstructions(
+      configMigrationApplyArgv(
+        parsed.invocation,
+        "a".repeat(64),
+        "2026-08-29T00:00:00Z",
+      ),
+    );
+
+    expect(lines.join("\n")).toContain("projects/api");
+    expect(lines.join("\n")).not.toContain("value you passed");
   });
 
   it("renders a migration apply command that reconstructs hostile argv without executing it", async () => {

--- a/tests/cli-contracts.test.ts
+++ b/tests/cli-contracts.test.ts
@@ -25,6 +25,7 @@ const schemaPaths = new Map([
   ["phase-handoff@1.3.0", "schemas/host/phase-handoff.v1.3.schema.json"],
   ["phase-handoff@1.1.0", "schemas/host/phase-handoff.v1.1.schema.json"],
   ["phase-handoff@1.2.0", "schemas/host/phase-handoff.v1.2.schema.json"],
+  ["migration-plan@1.0.0", "schemas/host/migration-plan.v1.schema.json"],
   ["project-profile@1.0.0", "schemas/host/project-profile.v1.schema.json"],
 ]);
 const validators = new Map<string, (value: unknown) => boolean>();

--- a/tests/config-migration.test.ts
+++ b/tests/config-migration.test.ts
@@ -2,6 +2,7 @@ import goldenV1 from "./fixtures/events/golden-event-v1.json" with { type: "json
 
 import type {
   EventV1,
+  MigrationPlanV1,
   MigrationV1_1,
   ProjectConfigV1,
   ProjectConfigV1_1,
@@ -1320,6 +1321,38 @@ describe("configuration migration", () => {
     expect(run.storage.snapshot()).toEqual(before);
   });
 
+  it("authorizes the apply from the machine-readable preview alone", async () => {
+    // The plan digest is derived from the plan instant, so a caller holding
+    // only --json could not reconstruct the apply while the instant lived in
+    // the human render alone.
+    const run = legacyProjectWithHistory();
+
+    expect(
+      await runCommandLine(["--json", "migrate", "config"], run.ports),
+    ).toBe(0);
+
+    const preview = JSON.parse(
+      run.output.structured_.join(""),
+    ) as MigrationPlanV1;
+    expect(preview.status).toBe("preview");
+    expect(preview.plan?.planDigest).toMatch(/^[a-f0-9]{64}$/u);
+    expect(preview.plan?.writes.map(({ path }) => path)).toContain(CONFIG_REF);
+    if (preview.plan === null) throw new Error("expected a plan");
+
+    const applied = await runCommandLine(
+      [
+        "--json",
+        ...authorizedArguments({
+          planDigest: preview.plan.planDigest,
+          planTime: preview.plan.planTime,
+        }),
+      ],
+      run.ports,
+    );
+
+    expect(applied).toBe(0);
+  });
+
   it("treats a current configuration as an idempotent no-op", async () => {
     const first = legacyProjectWithHistory();
     expect(await runAuthorizedConfigMigration(first)).toBe(0);
@@ -1336,8 +1369,12 @@ describe("configuration migration", () => {
     ).toBe(0);
 
     expect(current.storage.snapshot()).toEqual(before);
-    expect(JSON.parse(current.output.structured_.join(""))).toMatchObject({
-      stateChanged: false,
+    // A configuration already on the current contract has no plan to carry.
+    expect(JSON.parse(current.output.structured_.join(""))).toEqual({
+      contractVersion: "1.0.0",
+      hostContract: "1.4.0",
+      status: "current",
+      plan: null,
     });
   });
 

--- a/tests/contract-manifest.test.ts
+++ b/tests/contract-manifest.test.ts
@@ -87,7 +87,7 @@ beforeAll(async () => {
     readJson<JsonObject>(
       join(
         repositoryRoot,
-        "schemas/contracts/contract-manifest.v1.11.schema.json",
+        "schemas/contracts/contract-manifest.v1.12.schema.json",
       ),
     ),
     readJson<Discovery>(
@@ -126,7 +126,7 @@ describe("contract family manifest", () => {
   });
 
   it("registers every readable payload schema by id and version with safe paths", async () => {
-    expect(manifest.schemas).toHaveLength(71);
+    expect(manifest.schemas).toHaveLength(72);
     expect(manifest.schemas).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/tests/contract-schemas.test.ts
+++ b/tests/contract-schemas.test.ts
@@ -50,6 +50,7 @@ const artifacts = [
   ["host/gap-proposal.v1.schema.json", "gap-proposal.json", "host"],
   ["host/hook-observation.v1.schema.json", "hook-observation.json", "host"],
   ["host/phase-lifecycle.v1.schema.json", "phase-lifecycle.json", "host"],
+  ["host/migration-plan.v1.schema.json", "migration-plan.json", "host"],
   ["host/pre-tool-use.v1.schema.json", "pre-tool-use.json", "host"],
   ["host/project-profile.v1.schema.json", "project-profile.json", "host"],
   ["state/gap.v1.schema.json", "gap.json", "state"],
@@ -853,6 +854,10 @@ describe("versioned state and host schemas", () => {
     [
       "contracts/contract-manifest.v1.10.schema.json",
       "061fa654abbb12d4aa6dd065e1ce8dd0c19242871fc816c27730917dc1d48f0b",
+    ],
+    [
+      "contracts/contract-manifest.v1.11.schema.json",
+      "7cd291e9aec78e3b2480896267991d7d03cf07a472fba0a09ae4bb9b3322d838",
     ],
     [
       "host/adapter-message.v1.1.schema.json",

--- a/tests/contract-type-generation.test.ts
+++ b/tests/contract-type-generation.test.ts
@@ -29,7 +29,7 @@ describe("schema-derived contract declarations", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe(
-      "contract families v1.0.0: verified (71 schemas; 14 legacy profiles; generated types current)\n",
+      "contract families v1.0.0: verified (72 schemas; 14 legacy profiles; generated types current)\n",
     );
     expect(after).toBe(before);
     expect(after).toContain("Generated from registered JSON Schemas.");

--- a/tests/schema-registry-fixtures.test.ts
+++ b/tests/schema-registry-fixtures.test.ts
@@ -64,6 +64,7 @@ import repairResolution from "../fixtures/contracts/v1/repair-resolution.json" w
 import repairResolutionV1_1 from "../fixtures/contracts/v1.1/repair-resolution.json" with { type: "json" };
 import repairRestart from "../fixtures/contracts/v1/repair-restart.json" with { type: "json" };
 import preToolUse from "../fixtures/contracts/v1/pre-tool-use.json" with { type: "json" };
+import migrationPlan from "../fixtures/contracts/v1/migration-plan.json" with { type: "json" };
 import projectProfile from "../fixtures/contracts/v1/project-profile.json" with { type: "json" };
 import requirementDiscovery from "../fixtures/contracts/v1/requirement-discovery.json" with { type: "json" };
 import runUsage from "../fixtures/contracts/v1/run-usage.json" with { type: "json" };
@@ -342,6 +343,16 @@ const fixtures = [
     requiredField: "operation",
     structuralReasonCode: "guard.target_uninspectable",
     fixture: preToolUse,
+    invalidVersionReason: "contract.host_version_invalid",
+    unsupportedVersionReason: "contract.host_version_unsupported",
+  },
+  {
+    id: "host.migration-plan",
+    version: "1.0.0",
+    versionField: "hostContract",
+    requiredField: "status",
+    structuralReasonCode: "trail.output_invalido",
+    fixture: migrationPlan,
     invalidVersionReason: "contract.host_version_invalid",
     unsupportedVersionReason: "contract.host_version_unsupported",
   },


### PR DESCRIPTION
## Problem

`migrate config` was unusable in both of its output modes: the human preview failed as `runtime.internal_failure`, and `--json`, which succeeded, omitted the one value an apply cannot be reconstructed without.

## The crash is not where the issue supposed

Not `configPlanDetails` — those lines are computed in both modes and are fine. The result contract refuses to publish an absolute path (`packages/contracts/src/operation-result.ts:53`), the preview echoed the `--root` the operator passed, and the human path is the only one that validates rendered text (`composition/cli.ts:289`). Isolating the preview's lines shows it exactly:

```
THROWS :: Apply command: … --root '/home/user/proj' --yes …   :: unsafe text is not publishable
OK     :: Apply command: … --root relative/proj --yes
OK     :: - .brain/config.json sha256=deadbeef
OK     :: projectProfile.commands.test: resolved; value=go test ./...
```

So it fails exactly when `--root` is absolute, which is how the command is normally invoked — hence "not data-dependent". `migrate memory` renders through the same helper and had the same defect.

**Fix:** the apply instructions degrade instead of failing. The exact argv is rendered whenever it can be published; a value that cannot be is named rather than printed (`--root <the --root value you passed>`). The operator still sees which flag to repeat, and the one value withheld is the one they typed themselves. This reuses the try-then-degrade idiom already in the migration renderer and repairs `migrate memory` in the same move.

## The plan a host cannot reconstruct

The apply is authorized by the exact plan digest and the exact instant the preview planned at, and the digest is derived from that instant — two previews of an unchanged project return different digests. Both lived in the human render alone: the digest inside `summary` prose, the instant nowhere at all.

`host.migration-plan@1.0.0` is now the command's JSON contract, carrying `planDigest`, `planTime`, and the exact write paths for a preview and for a completed apply, and `status: "current"` with a null plan for a configuration with nothing to migrate.

## What reviewers should look at

**This replaces the result envelope on that command's successful `--json` output.** It is a deliberate contract change, not an addition — a host reading `status`/`reasonCode`/`summary` from `migrate config --json` must adapt. It follows how `doctor-report` and `project-profile` already work, and `docs/compatibility/contract-versioning.md` records it.

Registering the schema took the family manifest past the 71-entry ceiling of `contract-manifest.v1.11`, so `contract-manifest.v1.12` is published for the new bound and its predecessor's digest is frozen beside the other superseded formats. `contractSchemaBytes` is raised 370000 → 410000, the same 40k step the budget has taken three times before.

## Verification

`authorizes the apply from the machine-readable preview alone` takes the digest and instant from the `--json` preview and applies with them, exit 0 — the issue's expectation, end to end. `withholds an absolute root from the apply instructions instead of failing to publish them` asserts every rendered line passes `validatePublicText` and that the path never appears; its sibling asserts a publishable root is still rendered exactly, so the degradation does not fire needlessly.

`vitest run`: 237 files, 5689 tests passing. `typecheck`, `lint`, `format:check`, `english:check`, `spellcheck`, `contracts:check` (72 schemas), `result:check`, `performance:check` clean.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kj3juwFnqhAK61MG14WM8