### PR TITLE
docs(release): state what a plugin rollback does not recover

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -94,6 +94,40 @@ Before handing a package to a host, confirm the runtime inside it answers:
 `version` prints the plugin version; `handshake --json` prints the contract
 versions the package carries. Repeat for `codex/` and `antigravity/`.
 
+## What a rollback can and cannot recover
+
+Reinstalling the previous release restores the plugin. It does not restore a
+project the newer plugin already wrote to, and for one class of project the
+older plugin refuses to read it at all.
+
+A configuration records the `pluginVersion` that wrote it, and an upgrade
+carries that value forward rather than restating it. Up to and including
+v0.3.0, each versioned `state.project-config` schema pinned the field to the
+version shipping it, so a package refuses any configuration a different plugin
+version wrote. v0.4.0 replaced that constant with a semver pattern, which is
+what lets a newer plugin read an older project -- but it cannot change a
+package that already shipped.
+
+The result is one-directional. Rolling the plugin back is safe for a project
+that predates the release you are leaving, and destructive for one that
+release initialized or migrated: the older runtime reports
+`context_unreadable` and exits 4.
+
+Before rolling back, decide per project:
+
+- **Initialized under the older plugin, then updated.** Its configuration still
+  records the older version. It reads on both.
+- **Initialized or migrated under the newer plugin.** It does not read on the
+  older one. Restore the project from a snapshot taken before the update, or
+  keep the newer plugin.
+
+Editing `pluginVersion` by hand inside managed state is the workaround the
+migration command exists to remove, and it is not a supported recovery.
+
+Keep the previous `~/.kratos/releases/<version>` tree until the new one is
+accepted, and take a snapshot of any project before updating the plugin under
+it.
+
 ## Install in Claude Code
 
 Claude Code installs a plugin from a marketplace, and accepts a local directory
@@ -123,8 +157,10 @@ claude plugin install kratos@kratos-open-source
 ### Roll back
 
 Rolling back is the same sequence pointed at the previous release directory,
-which is why each release is extracted under its own version. Keep the previous
-`~/.kratos/releases/<version>` tree until the new one is accepted.
+which is why each release is extracted under its own version. Read
+[what a rollback can and cannot recover](#what-a-rollback-can-and-cannot-recover)
+first: the plugin goes back, and a project the newer plugin initialized or
+migrated does not.
 
 ### Uninstall
 
@@ -166,7 +202,9 @@ marketplace in place.
 ### Roll back
 
 Remove the marketplace, add the previous release's `marketplace` directory, and
-reinstall from `codex /plugins`.
+reinstall from `codex /plugins`. The project-side limit in
+[what a rollback can and cannot recover](#what-a-rollback-can-and-cannot-recover)
+applies here too.
 
 ### Uninstall
 
@@ -222,6 +260,10 @@ agy plugin install "$KRATOS_HOME/antigravity"
 agy plugin uninstall kratos
 agy plugin install ~/.kratos/releases/<previous-version>/antigravity
 ```
+
+The project-side limit in
+[what a rollback can and cannot recover](#what-a-rollback-can-and-cannot-recover)
+applies here too.
 
 `agy plugin disable kratos` suspends the plugin without removing it, and
 `agy plugin enable kratos` restores it. Prefer disabling while diagnosing a
@@ -291,9 +333,21 @@ node scripts/install-plugin.mjs install \
 
 The same script supports `update`, `rollback`, `commit`, and `uninstall` with
 the same `--host` and `--target` arguments. It refuses a downgrade, keeps the
-replaced version as a rollback copy until `commit`, and `uninstall` quarantines
-the installation instead of deleting it. None of these operations touches
-project-owned state.
+replaced version as a rollback copy at `<target>.rollback` until `commit`, and
+never deletes what it replaces: `rollback` moves the rejected version to
+`<target>.failed` and `uninstall` moves the installation to
+`<target>.uninstalled`.
+
+Each quarantine blocks the operation that would overwrite it, so a second
+`rollback` refuses while `<target>.failed` is present, and `install` refuses
+while either quarantine is. Inspect the quarantined tree, then remove it to
+proceed. `update` over a bundle whose runtime and asset digests already match
+the installed one is a no-op, so it leaves no rollback copy and `commit` then
+has nothing to discard.
+
+None of these operations touches project-owned state, which is also why none of
+them recovers it -- see
+[what a rollback can and cannot recover](#what-a-rollback-can-and-cannot-recover).
 
 ## Initialize a project
 

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -291,11 +291,35 @@ the right first move while diagnosing a problem.
 
 ### Rolling back the project state as well
 
-This release introduces no state migration, so a project initialized or
-migrated under v0.3.0 is readable by the v0.3.0 runtime and the plugin can be
-rolled back on its own. A project migrated from `1.4.0` to `1.5.0` is still not
-readable by the v0.2.0 runtime; roll that back only together with the project
-state it wrote, from a snapshot taken before the migration.
+This release introduces no state migration, so the `stateContract` is not what
+constrains a rollback. `pluginVersion` is, and it constrains it in one
+direction only.
+
+**A project this release touched does not go back.** A project v0.4.0
+initialized records `pluginVersion: "0.4.0"`, and a project v0.4.0 migrated
+records whatever version wrote it. The v0.3.0 runtime rejects both: the
+`state.project-config@1.5.0` schema it shipped pins the field to the constant
+`0.3.0`, so it refuses the document with `must be equal to constant` and
+`doctor` fails with `context_unreadable` and exit code 4.
+
+The fix in this release is what makes a newer plugin read what an older one
+wrote. It cannot reach backwards into a package that already shipped, so the
+asymmetry is permanent for this pair of versions:
+
+| Project | On v0.4.0 | Back on v0.3.0 |
+| --- | --- | --- |
+| Initialized under v0.3.0, plugin updated | Reads | Reads; its configuration still records `0.3.0` |
+| Initialized under v0.4.0 | Reads | **Refused**, exit code 4 |
+| Migrated from v0.2.0 by v0.4.0 | Reads | **Refused**, exit code 4 |
+
+So roll the plugin back only for projects that predate it. For a project this
+release initialized or migrated, restore the project from a snapshot taken
+before the update, or accept that it now requires v0.4.0 or newer. Editing
+`pluginVersion` by hand inside managed state is the workaround this release
+exists to remove, and it is not a supported recovery.
+
+A project migrated from `1.4.0` to `1.5.0` is still not readable by the v0.2.0
+runtime for the separate reason that `1.5.0` postdates it.
 
 ### Staged installations
 

--- a/docs/verification/v0.4.0-release-readiness.md
+++ b/docs/verification/v0.4.0-release-readiness.md
@@ -192,6 +192,28 @@ its tag and installed, then updated to v0.4.0: the rollback copy is retained, a
 downgrade while it exists is refused, `rollback` restores v0.3.0, and
 `update` followed by `commit` discards the backup.
 
+**Rolling the plugin back, tested after publication.** The plugin rolls back;
+a project this release wrote to does not. A project v0.4.0 initialized records
+`pluginVersion: "0.4.0"`, and the v0.3.0 runtime refuses it: `doctor` reports
+`context-readable: enforce blocked.context_unreadable` and exits 4. The cause
+is the `state.project-config@1.5.0` schema that v0.3.0 shipped, which pins the
+field to the constant `0.3.0` and rejects the document with `must be equal to
+constant`. The fix in this release makes a newer plugin read an older project;
+it cannot reach into a package that already shipped, so the asymmetry is
+permanent for this pair.
+
+| Project | On v0.4.0 | Back on v0.3.0 |
+| --- | --- | --- |
+| Initialized under v0.3.0, plugin updated | Reads | Reads |
+| Initialized under v0.4.0 | Reads | Refused, exit 4 |
+| Migrated from v0.2.0 by v0.4.0 | Reads | Refused, exit 4 |
+
+This was found after the tag was published. The notes had stated that the
+plugin could be rolled back on its own, which was read off the unchanged
+`stateContract` without testing the direction. The published release notes and
+`docs/INSTALLATION.md` are corrected; the published archives are not affected,
+because the defect was in the guidance rather than in the package.
+
 One observation, not introduced by this release and not changed here:
 `rollback` quarantines the rejected version as `<target>.failed` and never
 deletes it, and both `install` and `rollback` refuse while that quarantine


### PR DESCRIPTION
The v0.4.0 notes told an operator the plugin could be rolled back on its own, because this release introduces no state migration. That was read off the unchanged `stateContract` without testing the direction, and it is wrong for the projects most likely to be rolled back.

## What was tested

A project v0.4.0 initialized records `pluginVersion: "0.4.0"`, because a configuration records the version that wrote it and an upgrade carries that value forward. Run against both built packages:

| Project | On v0.4.0 | Back on v0.3.0 |
| --- | --- | --- |
| Initialized under v0.3.0, plugin updated | Reads | Reads |
| Initialized under v0.4.0 | Reads | Refused, exit 4 |
| Migrated from v0.2.0 by v0.4.0 | Reads | Refused, exit 4 |

The v0.3.0 runtime reports `context-readable: enforce blocked.context_unreadable` and exits 4. Cause confirmed against the schema v0.3.0 shipped: `state.project-config@1.5.0` pins `pluginVersion` to the constant `0.3.0` and rejects the document with `must be equal to constant`.

This is the same defect v0.4.0 fixed, seen from the other side. Replacing the constant with a semver pattern lets a newer plugin read an older project; it cannot reach into a package that already shipped, so the asymmetry between these two versions is permanent and belongs in the guidance.

## Changes

- `docs/releases/v0.4.0.md` — the rollback section states the direction and the per-project decision instead of claiming the plugin rolls back on its own.
- `docs/INSTALLATION.md` — one section stating it, placed before the host instructions and linked from each host's rollback steps, because an operator reads those two at different times. The staged-installer paragraph now also describes the quarantines it leaves: `rollback` retains the rejected version at `<target>.failed`, each quarantine blocks the operation that would overwrite it, and an `update` over a matching bundle is a no-op that leaves no rollback copy. The page previously documented the `uninstall` quarantine alone.
- `docs/verification/v0.4.0-release-readiness.md` — records the finding and that it was found after the tag, rather than presenting it as verified before it.

## Not affected

The published archives. The defect was in what the release said, not in what it shipped, so `v0.4.0` is not withdrawn or superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)