### PR TITLE
fix(init): record derived answers without asking the operator

### DIFF
--- a/distribution/antigravity/skills/kratos/SKILL.md
+++ b/distribution/antigravity/skills/kratos/SKILL.md
@@ -24,21 +24,21 @@ Before `kratos init`, run
 `node scripts/kratos.mjs --json profile derive --root <absolute-project-root>`
 from this skill directory. Its `host.project-profile@1.0.0` payload is the only
 source of interview candidates. Then load `scripts/project-profile-relay.mjs`
-from this skill directory and ask every exported `projectProfileQuestions` entry
-in order.
+from this skill directory.
 
-Present an answer the payload reports as `derived` with its value and its
-evidence string for confirmation, and ask an answer it reports as `unresolved`
-blank. Never present a candidate the payload does not carry, and never add a
-description the payload does not carry. The runtime derives these, and a
-suggestion you author makes one repository answer differently for different
-operators.
+Record an answer the payload reports as `derived` exactly as it stands, with
+its value and its evidence string, and ask the operator nothing about it. Ask
+only the `projectProfileQuestions` entries the payload reports as `unresolved`,
+in order, and ask those blank. Never present a candidate the payload does not
+carry, and never add a description the payload does not carry. The runtime
+derives these, and a suggestion you author makes one repository answer
+differently for different operators.
 
-Record confirmed answers as `resolved`, unconfirmed derived values with their
-evidence as `derived`, explicitly omitted items as `not-applicable` with a
-reason, or `unresolved` if blank. Commands are exact single-line strings run
-from the project root, paths are project-relative lists, and implementation
-languages are programming languages rather than the human-language policy.
+Record an answer the operator gives as `resolved`, an item the operator
+explicitly omits as `not-applicable` with a reason, and anything still blank as
+`unresolved`. Commands are exact single-line strings run from the project root,
+paths are project-relative lists, and implementation languages are programming
+languages rather than the human-language policy.
 
 Pass the keyed answers to `relayProjectProfileAnswers`, place its returned
 value in `host.init-answers@1.6.0` as `projectProfile`, and pipe that complete

--- a/distribution/claude-code/skills/kratos/SKILL.md
+++ b/distribution/claude-code/skills/kratos/SKILL.md
@@ -24,21 +24,21 @@ Before `kratos init`, run
 `node scripts/kratos.mjs --json profile derive --root <absolute-project-root>`
 from this skill directory. Its `host.project-profile@1.0.0` payload is the only
 source of interview candidates. Then load `scripts/project-profile-relay.mjs`
-from this skill directory and ask every exported `projectProfileQuestions` entry
-in order.
+from this skill directory.
 
-Present an answer the payload reports as `derived` with its value and its
-evidence string for confirmation, and ask an answer it reports as `unresolved`
-blank. Never present a candidate the payload does not carry, and never add a
-description the payload does not carry. The runtime derives these, and a
-suggestion you author makes one repository answer differently for different
-operators.
+Record an answer the payload reports as `derived` exactly as it stands, with
+its value and its evidence string, and ask the operator nothing about it. Ask
+only the `projectProfileQuestions` entries the payload reports as `unresolved`,
+in order, and ask those blank. Never present a candidate the payload does not
+carry, and never add a description the payload does not carry. The runtime
+derives these, and a suggestion you author makes one repository answer
+differently for different operators.
 
-Record confirmed answers as `resolved`, unconfirmed derived values with their
-evidence as `derived`, explicitly omitted items as `not-applicable` with a
-reason, or `unresolved` if blank. Commands are exact single-line strings run
-from the project root, paths are project-relative lists, and implementation
-languages are programming languages rather than the human-language policy.
+Record an answer the operator gives as `resolved`, an item the operator
+explicitly omits as `not-applicable` with a reason, and anything still blank as
+`unresolved`. Commands are exact single-line strings run from the project root,
+paths are project-relative lists, and implementation languages are programming
+languages rather than the human-language policy.
 
 Pass the keyed answers to `relayProjectProfileAnswers`, place its returned
 value in `host.init-answers@1.6.0` as `projectProfile`, and pipe that complete

--- a/distribution/codex/skills/kratos/SKILL.md
+++ b/distribution/codex/skills/kratos/SKILL.md
@@ -24,21 +24,21 @@ Before `kratos init`, run
 `node scripts/kratos.mjs --json profile derive --root <absolute-project-root>`
 from this skill directory. Its `host.project-profile@1.0.0` payload is the only
 source of interview candidates. Then load `scripts/project-profile-relay.mjs`
-from this skill directory and ask every exported `projectProfileQuestions` entry
-in order.
+from this skill directory.
 
-Present an answer the payload reports as `derived` with its value and its
-evidence string for confirmation, and ask an answer it reports as `unresolved`
-blank. Never present a candidate the payload does not carry, and never add a
-description the payload does not carry. The runtime derives these, and a
-suggestion you author makes one repository answer differently for different
-operators.
+Record an answer the payload reports as `derived` exactly as it stands, with
+its value and its evidence string, and ask the operator nothing about it. Ask
+only the `projectProfileQuestions` entries the payload reports as `unresolved`,
+in order, and ask those blank. Never present a candidate the payload does not
+carry, and never add a description the payload does not carry. The runtime
+derives these, and a suggestion you author makes one repository answer
+differently for different operators.
 
-Record confirmed answers as `resolved`, unconfirmed derived values with their
-evidence as `derived`, explicitly omitted items as `not-applicable` with a
-reason, or `unresolved` if blank. Commands are exact single-line strings run
-from the project root, paths are project-relative lists, and implementation
-languages are programming languages rather than the human-language policy.
+Record an answer the operator gives as `resolved`, an item the operator
+explicitly omits as `not-applicable` with a reason, and anything still blank as
+`unresolved`. Commands are exact single-line strings run from the project root,
+paths are project-relative lists, and implementation languages are programming
+languages rather than the human-language policy.
 
 Pass the keyed answers to `relayProjectProfileAnswers`, place its returned
 value in `host.init-answers@1.6.0` as `projectProfile`, and pipe that complete

--- a/docs/superpowers/specs/2026-09-04-derived-answers-recorded-without-confirmation-design.md
+++ b/docs/superpowers/specs/2026-09-04-derived-answers-recorded-without-confirmation-design.md
@@ -1,0 +1,127 @@
+# Derived Answers Recorded Without Confirmation Design
+
+Date: 2026-09-04
+Status: APPROVED
+Issue: #214; supersedes `AC-8` of `ADP-08` (#190)
+Dependencies: `ADP-08` (#190), `ADP-09` (#206), `ADP-10` (#209), `ADP-13` (#208)
+Approval source: the project lead's direct instruction during a `kratos init` run
+
+## Problem and outcome
+
+The initialization interview asked the operator to confirm every answer the
+runtime had already derived. On a repository where derivation resolved eight of
+the ten profile leaves, the host still put ten questions to the operator, eight
+of them restating a value and its evidence and waiting for a nod. The derivation
+work under `ADP-08` through `ADP-13` exists so that the operator answers less,
+not so that the operator ratifies more.
+
+This design removes the confirmation step. The host records a `derived` leaf as
+the runtime derived it, with its value and its evidence string, and asks the
+operator only about the leaves the runtime reported as `unresolved`. The four
+leaf states and their meaning are unchanged: `resolved` still means a human
+stated the value, `derived` still means the runtime read it from evidence, and
+the two remain distinct in configuration, in the rendered stack profile, and in
+diagnostics.
+
+## What changes
+
+1. **Host skills** (`distribution/*/skills/kratos/SKILL.md`): the interview
+   section instructs the host to record derived answers without asking and to
+   ask, in order, only the `projectProfileQuestions` entries the payload reports
+   as `unresolved`. The two guards stay: the host never presents a candidate the
+   payload does not carry and never adds a description the payload does not
+   carry.
+
+2. **Permission provenance** (`domain/init/permissions.ts`): a derived command
+   earns its `Bash(<command>)` allowance from the evidence the runtime recorded.
+   The new `derived_profile` origin carries that evidence string, and
+   `assertPermissionProvenance` accepts such an entry only when a `derived` slot
+   carries both the same command and the same evidence. The `explicit_profile`
+   origin is unchanged and still requires a `resolved` slot.
+
+3. **Runtime prose** (`domain/init/derive.ts`, `domain/init/stack.ts`): the
+   comments that described every derived value as "offered for confirmation"
+   now describe it as recorded with its evidence.
+
+4. **Package manager** (`domain/init/derive.ts`): a command derived from
+   `package.json#scripts` names the package manager the repository attests to
+   instead of `npm` unconditionally. The `packageManager` field outranks any
+   lockfile; one lockfile at the root (`package-lock.json`,
+   `npm-shrinkwrap.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`,
+   `bun.lockb`) decides; no lockfile leaves npm as the default nothing
+   contradicts; lockfiles of two different managers derive nothing from the
+   manifest, so the command slots reach the interview as `unresolved`. The
+   evidence names what decided (`package.json#scripts.test via pnpm-lock.yaml`).
+   Bun goes through `bun run <script>` for every slot, because `bun test` is
+   Bun's own runner and not the declared script.
+
+5. **Source below tests** (`domain/init/derive.ts`): a directory that carries a
+   source candidate name but sits below a test directory (`tests/unit/lib`) is
+   no longer offered as a source root. It mirrors the source tree rather than
+   being one, and naming it as a second root also stopped the directory layout
+   from being derived for the real one.
+
+Nothing else moves. The relay, the `host.init-answers@1.6.0` contract, the
+`state.project-config@1.5.0` contract, the stack profile rendering, and
+`kratos doctor` are untouched.
+
+## Superseded acceptance criterion
+
+`AC-8` of `ADP-08` read: "Gates requiring operator consent fail closed on
+unconfirmed `derived` values with diagnostic reason." Its only implementation
+was the permission gate, which ignored `derived` command slots and so withheld
+the allowance from every command the runtime derived. With confirmation gone,
+that gate would never fire again for a derived command and would silently
+withhold allowances from every project whose commands are not on the canonical
+stack table (`pnpm test`, `make test`, `pytest` declared in `pyproject.toml`).
+
+The criterion is replaced by:
+
+- `AC-8'`: a permission derived from a `derived` command slot carries the
+  `derived_profile` origin and the exact evidence string the profile recorded,
+  and provenance validation rejects an entry whose command or evidence the
+  profile does not carry.
+
+The rationale is that manifest evidence is verifiable provenance. A command read
+from `package.json#scripts.test` is traceable to a file the operator committed;
+a command the operator types into an interview is not more trustworthy than
+that, only more expensive to obtain.
+
+That rationale holds only while the derived command is the one the project
+runs. Before this change the manifest derivation emitted `npm test` for every
+`package.json`, and the confirmation step was where a pnpm or yarn project had
+that corrected. Removing the step without fixing the derivation would have
+granted an allowance to a command nobody runs, which is why items 4 and 5 are
+part of this change rather than follow-ups.
+
+## Consequences
+
+- A repository that carries lockfiles of two managers, which usually means one
+  of them is stale, reaches the interview with every command slot unresolved.
+  The remedy is in the repository, not in the runtime: remove the lockfile the
+  project does not use, or state the manager in `package.json#packageManager`.
+- An operator who wants a derived value changed has no interview step in which
+  to change it. The `profile` command exposes only `derive`. A correction path
+  (`profile set`, or re-running `init` with an explicit answer) is out of scope
+  here and should be filed as its own issue.
+- The generated `.claude/settings.json` gains an allowance for every derived
+  command. On a Node project whose scripts use the canonical `npm` forms this is
+  a no-op, because the `stack` origin already granted them; on a project using
+  `pnpm`, `make`, or `just` it is the difference between the allowance existing
+  or not.
+- The historical records of `ADP-08` (`2026-09-02-project-profile-derivation-design.md`,
+  its plan, and `issue-190-project-profile-derivation-evidence.md`) describe
+  the confirmation step as delivered. They are left as written; this document
+  is the record of why that step was removed.
+
+## Alternatives rejected
+
+- **Record derived commands as `resolved` so the old gate grants them:** makes
+  `resolved` mean two things and discards the evidence string the schema
+  requires a derived leaf to carry.
+- **Keep the confirmation only for command slots:** keeps most of the friction
+  for the leaves most likely to be derived correctly, since commands come from
+  declarative manifests rather than heuristics.
+- **Grant no allowance for derived commands:** leaves the permission gate as
+  dead code and regresses every non-canonical toolchain relative to the
+  interview it replaces.

--- a/packages/runtime/src/domain/init/derive.ts
+++ b/packages/runtime/src/domain/init/derive.ts
@@ -257,8 +257,11 @@ function derivePathSlot(
   evidence: RepositoryEvidence,
   layout: ObservedLayout,
   candidates: readonly string[],
+  notBelow: readonly string[] = [],
 ): DerivedPathSlot | undefined {
-  const found = candidateDirectories(evidence, layout, candidates);
+  const found = candidateDirectories(evidence, layout, candidates).filter(
+    (candidate) => !sitsBelow(candidate.path, notBelow),
+  );
   if (found.length === 0) return undefined;
   const ranked = rankCandidates(withoutEnclosed(found));
   const selected = selectPaths(ranked);
@@ -272,6 +275,19 @@ function derivePathSlot(
     },
     directories: ranked.filter((candidate) => named.has(candidate.path)),
   };
+}
+
+/**
+ * Whether any directory above the path carries one of the names.
+ *
+ * A `lib` below `tests` mirrors the source tree rather than being one, and
+ * offering it as a second source root also hides the layout of the real one.
+ */
+function sitsBelow(path: string, names: readonly string[]): boolean {
+  return path
+    .split("/")
+    .slice(0, -1)
+    .some((segment) => names.includes(segment));
 }
 
 function depthOf(path: string): number {
@@ -297,8 +313,9 @@ interface DerivedPaths {
  *
  * Nothing here reaches a disk: the listing is whatever the bounded scan
  * observed, and a listing that stopped early describes part of a tree, so a
- * repository the scan could not cover simply has less to derive from and the
- * operator is asked. Every answer is offered for confirmation.
+ * repository the scan could not cover simply has less to derive from, so the
+ * operator is asked for what stayed unresolved. A derived answer is recorded
+ * as derived and is not put to the operator.
  */
 function derivePaths(
   evidence: RepositoryEvidence,
@@ -310,7 +327,12 @@ function derivePaths(
     configuration?: ProjectProfileLeaf<readonly string[]>;
   } = {};
 
-  const source = derivePathSlot(evidence, layout, SOURCE_PATH_CANDIDATES);
+  const source = derivePathSlot(
+    evidence,
+    layout,
+    SOURCE_PATH_CANDIDATES,
+    TESTS_PATH_CANDIDATES,
+  );
   if (source !== undefined) paths.source = source.leaf;
 
   const tests = derivePathSlot(evidence, layout, TESTS_PATH_CANDIDATES);
@@ -330,8 +352,87 @@ function derivePaths(
   };
 }
 
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+const PACKAGE_MANAGERS: readonly PackageManager[] = [
+  "npm",
+  "pnpm",
+  "yarn",
+  "bun",
+];
+
+/**
+ * The lockfile each package manager leaves at the root, in a fixed order so the
+ * evidence names the same file whichever order the directory listing came in.
+ */
+const PACKAGE_MANAGER_LOCKFILES: readonly (readonly [
+  string,
+  PackageManager,
+])[] = [
+  ["package-lock.json", "npm"],
+  ["npm-shrinkwrap.json", "npm"],
+  ["pnpm-lock.yaml", "pnpm"],
+  ["yarn.lock", "yarn"],
+  ["bun.lock", "bun"],
+  ["bun.lockb", "bun"],
+];
+
+interface PackageManagerChoice {
+  readonly manager: PackageManager;
+  /** What decided it, or undefined when nothing did and npm is the default. */
+  readonly via: string | undefined;
+}
+
+/**
+ * Which package manager runs the scripts a `package.json` declares.
+ *
+ * The `packageManager` field is a statement and outranks any lockfile. One
+ * lockfile at the root is an attestation. No lockfile leaves npm, the manager
+ * every Node installation ships with, as the default nothing contradicts. Two
+ * lockfiles that disagree are two readings, and which one the project means is
+ * the operator's call, so nothing is derived from the manifest at all.
+ */
+function packageManagerOf(
+  parsed: Record<string, unknown>,
+  rootEntries: readonly string[],
+): PackageManagerChoice | undefined {
+  const declared = parsed.packageManager;
+  if (typeof declared === "string") {
+    const at = declared.indexOf("@");
+    const name = at === -1 ? declared : declared.slice(0, at);
+    const manager = PACKAGE_MANAGERS.find((known) => known === name);
+    if (manager !== undefined) {
+      return { manager, via: "package.json#packageManager" };
+    }
+  }
+
+  const present = PACKAGE_MANAGER_LOCKFILES.filter(([file]) =>
+    rootEntries.includes(file),
+  );
+  const managers = new Set(present.map(([, manager]) => manager));
+  if (managers.size > 1) return undefined;
+  const first = present[0];
+  if (first === undefined) return { manager: "npm", via: undefined };
+  return { manager: first[1], via: first[0] };
+}
+
+/**
+ * The command that runs one declared script under one package manager.
+ *
+ * `test` and `start` are verbs every manager has; other scripts go through
+ * `run`. Bun goes through `run` for everything, because `bun test` is Bun's
+ * own runner and not the script the project declared.
+ */
+function scriptCommand(manager: PackageManager, script: string): string {
+  if (manager !== "bun" && (script === "test" || script === "start")) {
+    return `${manager} ${script}`;
+  }
+  return `${manager} run ${script}`;
+}
+
 function derivePackageJsonCommands(
   content: string,
+  rootEntries: readonly string[],
   commands: Record<string, ProjectProfileLeaf<string>>,
 ): void {
   try {
@@ -345,64 +446,30 @@ function derivePackageJsonCommands(
     ) {
       return;
     }
+    const choice = packageManagerOf(parsed, rootEntries);
+    if (choice === undefined) return;
     const scripts = parsed.scripts as Record<string, unknown>;
+    const declares = (script: string): boolean => {
+      const value = scripts[script];
+      return typeof value === "string" && value.trim().length > 0;
+    };
 
-    if (
-      typeof scripts.test === "string" &&
-      scripts.test.trim().length > 0 &&
-      !("test" in commands)
-    ) {
-      commands.test = {
+    const slots: readonly (readonly [string, readonly string[]])[] = [
+      ["test", ["test"]],
+      ["lint", ["lint"]],
+      ["build", ["build"]],
+      ["run", ["start", "run"]],
+    ];
+    for (const [slot, candidates] of slots) {
+      if (slot in commands) continue;
+      const script = candidates.find(declares);
+      if (script === undefined) continue;
+      const via = choice.via === undefined ? "" : ` via ${choice.via}`;
+      commands[slot] = {
         status: "derived",
-        value: "npm test",
-        evidence: "package.json#scripts.test",
+        value: scriptCommand(choice.manager, script),
+        evidence: `package.json#scripts.${script}${via}`,
       };
-    }
-
-    if (
-      typeof scripts.lint === "string" &&
-      scripts.lint.trim().length > 0 &&
-      !("lint" in commands)
-    ) {
-      commands.lint = {
-        status: "derived",
-        value: "npm run lint",
-        evidence: "package.json#scripts.lint",
-      };
-    }
-
-    if (
-      typeof scripts.build === "string" &&
-      scripts.build.trim().length > 0 &&
-      !("build" in commands)
-    ) {
-      commands.build = {
-        status: "derived",
-        value: "npm run build",
-        evidence: "package.json#scripts.build",
-      };
-    }
-
-    if (!("run" in commands)) {
-      if (
-        typeof scripts.start === "string" &&
-        scripts.start.trim().length > 0
-      ) {
-        commands.run = {
-          status: "derived",
-          value: "npm start",
-          evidence: "package.json#scripts.start",
-        };
-      } else if (
-        typeof scripts.run === "string" &&
-        scripts.run.trim().length > 0
-      ) {
-        commands.run = {
-          status: "derived",
-          value: "npm run run",
-          evidence: "package.json#scripts.run",
-        };
-      }
     }
   } catch {
     // Declarative derivation ignores unparseable manifests safely
@@ -550,11 +617,16 @@ function deriveStackCommands(
 function deriveCommands(
   stack: StackProfile,
   manifests: ManifestContents,
+  evidence: RepositoryEvidence,
 ): PartialProjectProfile["commands"] | undefined {
   const commands: Record<string, ProjectProfileLeaf<string>> = {};
 
   if (manifests.packageJson !== undefined) {
-    derivePackageJsonCommands(manifests.packageJson, commands);
+    derivePackageJsonCommands(
+      manifests.packageJson,
+      evidence.rootEntries,
+      commands,
+    );
   }
 
   if (manifests.pyprojectToml !== undefined) {
@@ -919,8 +991,8 @@ function layoutLeaf(
  * Derive the three conventions a phase agent has to preserve.
  *
  * Each is an observed regularity rather than a stated preference, which is why
- * they can be derived at all, and each is offered for confirmation like every
- * other derived leaf.
+ * they can be derived at all, and each is recorded as derived without the
+ * operator being asked, like every other derived leaf.
  */
 function deriveConventions(
   stack: StackProfile,
@@ -964,7 +1036,7 @@ export function deriveProjectProfile(
 ): PartialProjectProfile {
   const stack = profileStack(evidence);
   const observed = observedPaths(evidence);
-  const commands = deriveCommands(stack, manifests);
+  const commands = deriveCommands(stack, manifests, evidence);
   const paths = derivePaths(evidence, observeLayout(observed));
   const conventions = deriveConventions(stack, paths, observed);
 

--- a/packages/runtime/src/domain/init/permissions.ts
+++ b/packages/runtime/src/domain/init/permissions.ts
@@ -1,7 +1,8 @@
 import type { ResolvedAnswers } from "./answers.js";
 import type { StackId, StackProfile } from "./stack.js";
 
-export type PermissionOrigin = "git" | "stack" | "explicit_profile";
+export type PermissionOrigin =
+  "git" | "stack" | "explicit_profile" | "derived_profile";
 
 export interface PermissionProvenance {
   readonly permission: string;
@@ -90,26 +91,26 @@ export function deriveHostPermissions(
     }
   }
 
-  // 3. Explicit project profile answers provenance
-  const profileCommands = answers.projectProfile.commands;
-  const slots = [
-    profileCommands.test,
-    profileCommands.lint,
-    profileCommands.build,
-    profileCommands.run,
-  ];
-  for (const slot of slots) {
-    if (slot.status === "resolved" && slot.value.trim().length > 0) {
-      const perm = `Bash(${slot.value.trim()})`;
-      if (!allowSet.has(perm)) {
-        allowSet.add(perm);
-        provenance.push({
-          permission: perm,
-          origin: "explicit_profile",
-          evidence: slot.value.trim(),
-        });
-      }
-    }
+  // 3. Project profile command provenance. A resolved command is one the
+  // operator stated; a derived command is one the runtime read from a manifest
+  // and the host recorded without asking, so its allowance traces to the
+  // evidence string rather than to a confirmation.
+  for (const slot of profileCommandSlots(answers)) {
+    if (slot.status !== "resolved" && slot.status !== "derived") continue;
+    const command = slot.value.trim();
+    if (command.length === 0) continue;
+    const perm = `Bash(${command})`;
+    if (allowSet.has(perm)) continue;
+    allowSet.add(perm);
+    provenance.push(
+      slot.status === "resolved"
+        ? { permission: perm, origin: "explicit_profile", evidence: command }
+        : {
+            permission: perm,
+            origin: "derived_profile",
+            evidence: slot.evidence,
+          },
+    );
   }
 
   const allow = [...allowSet].sort(compareText);
@@ -166,29 +167,28 @@ export function assertPermissionProvenance(
       return;
     }
     case "explicit_profile": {
-      const profileCommands = answers.projectProfile.commands;
-      const resolvedValues = [
-        profileCommands.test.status === "resolved"
-          ? profileCommands.test.value
-          : null,
-        profileCommands.lint.status === "resolved"
-          ? profileCommands.lint.value
-          : null,
-        profileCommands.build.status === "resolved"
-          ? profileCommands.build.value
-          : null,
-        profileCommands.run.status === "resolved"
-          ? profileCommands.run.value
-          : null,
-      ].filter((val): val is string => typeof val === "string");
-
-      if (
-        !resolvedValues.some(
-          (cmd) => entry.permission === `Bash(${cmd.trim()})`,
-        )
-      ) {
+      const stated = profileCommandSlots(answers).some(
+        (slot) =>
+          slot.status === "resolved" &&
+          entry.permission === `Bash(${slot.value.trim()})`,
+      );
+      if (!stated) {
         throw new Error(
           `PERMISSION_WITHOUT_PROVENANCE: Explicit command '${entry.permission}' not found in resolved profile.`,
+        );
+      }
+      return;
+    }
+    case "derived_profile": {
+      const derived = profileCommandSlots(answers).some(
+        (slot) =>
+          slot.status === "derived" &&
+          entry.permission === `Bash(${slot.value.trim()})` &&
+          entry.evidence === slot.evidence,
+      );
+      if (!derived) {
+        throw new Error(
+          `PERMISSION_WITHOUT_PROVENANCE: Derived command '${entry.permission}' does not carry the evidence the profile recorded.`,
         );
       }
       return;
@@ -200,6 +200,11 @@ export function assertPermissionProvenance(
       );
     }
   }
+}
+
+function profileCommandSlots(answers: ResolvedAnswers) {
+  const commands = answers.projectProfile.commands;
+  return [commands.test, commands.lint, commands.build, commands.run];
 }
 
 function compareText(left: string, right: string): number {

--- a/packages/runtime/src/domain/init/stack.ts
+++ b/packages/runtime/src/domain/init/stack.ts
@@ -304,8 +304,8 @@ const SUFFIX_MARKERS: readonly (readonly [string, StackId])[] = [
  * declared script is read from the manifest rather than assumed here.
  *
  * These are conventions, not facts about the repository. Anything a manifest
- * declares outranks them, and like every derived value they reach the operator
- * for confirmation.
+ * declares outranks them, and like every derived value they are recorded with
+ * their evidence rather than put to the operator.
  */
 export interface StackCommands {
   readonly test?: string;

--- a/packages/runtime/src/domain/prompt-ceilings/discovery.ts
+++ b/packages/runtime/src/domain/prompt-ceilings/discovery.ts
@@ -49,21 +49,21 @@ Before \`kratos init\`, run
 \`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>\`
 from this skill directory. Its \`host.project-profile@1.0.0\` payload is the only
 source of interview candidates. Then load \`scripts/project-profile-relay.mjs\`
-from this skill directory and ask every exported \`projectProfileQuestions\` entry
-in order.
+from this skill directory.
 
-Present an answer the payload reports as \`derived\` with its value and its
-evidence string for confirmation, and ask an answer it reports as \`unresolved\`
-blank. Never present a candidate the payload does not carry, and never add a
-description the payload does not carry. The runtime derives these, and a
-suggestion you author makes one repository answer differently for different
-operators.
+Record an answer the payload reports as \`derived\` exactly as it stands, with
+its value and its evidence string, and ask the operator nothing about it. Ask
+only the \`projectProfileQuestions\` entries the payload reports as \`unresolved\`,
+in order, and ask those blank. Never present a candidate the payload does not
+carry, and never add a description the payload does not carry. The runtime
+derives these, and a suggestion you author makes one repository answer
+differently for different operators.
 
-Record confirmed answers as \`resolved\`, unconfirmed derived values with their
-evidence as \`derived\`, explicitly omitted items as \`not-applicable\` with a
-reason, or \`unresolved\` if blank. Commands are exact single-line strings run
-from the project root, paths are project-relative lists, and implementation
-languages are programming languages rather than the human-language policy.
+Record an answer the operator gives as \`resolved\`, an item the operator
+explicitly omits as \`not-applicable\` with a reason, and anything still blank as
+\`unresolved\`. Commands are exact single-line strings run from the project root,
+paths are project-relative lists, and implementation languages are programming
+languages rather than the human-language policy.
 
 Pass the keyed answers to \`relayProjectProfileAnswers\`, place its returned
 value in \`host.init-answers@1.6.0\` as \`projectProfile\`, and pipe that complete
@@ -146,21 +146,21 @@ Before \`kratos init\`, run
 \`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>\`
 from this skill directory. Its \`host.project-profile@1.0.0\` payload is the only
 source of interview candidates. Then load \`scripts/project-profile-relay.mjs\`
-from this skill directory and ask every exported \`projectProfileQuestions\` entry
-in order.
+from this skill directory.
 
-Present an answer the payload reports as \`derived\` with its value and its
-evidence string for confirmation, and ask an answer it reports as \`unresolved\`
-blank. Never present a candidate the payload does not carry, and never add a
-description the payload does not carry. The runtime derives these, and a
-suggestion you author makes one repository answer differently for different
-operators.
+Record an answer the payload reports as \`derived\` exactly as it stands, with
+its value and its evidence string, and ask the operator nothing about it. Ask
+only the \`projectProfileQuestions\` entries the payload reports as \`unresolved\`,
+in order, and ask those blank. Never present a candidate the payload does not
+carry, and never add a description the payload does not carry. The runtime
+derives these, and a suggestion you author makes one repository answer
+differently for different operators.
 
-Record confirmed answers as \`resolved\`, unconfirmed derived values with their
-evidence as \`derived\`, explicitly omitted items as \`not-applicable\` with a
-reason, or \`unresolved\` if blank. Commands are exact single-line strings run
-from the project root, paths are project-relative lists, and implementation
-languages are programming languages rather than the human-language policy.
+Record an answer the operator gives as \`resolved\`, an item the operator
+explicitly omits as \`not-applicable\` with a reason, and anything still blank as
+\`unresolved\`. Commands are exact single-line strings run from the project root,
+paths are project-relative lists, and implementation languages are programming
+languages rather than the human-language policy.
 
 Pass the keyed answers to \`relayProjectProfileAnswers\`, place its returned
 value in \`host.init-answers@1.6.0\` as \`projectProfile\`, and pipe that complete
@@ -237,21 +237,21 @@ Before \`kratos init\`, run
 \`node scripts/kratos.mjs --json profile derive --root <absolute-project-root>\`
 from this skill directory. Its \`host.project-profile@1.0.0\` payload is the only
 source of interview candidates. Then load \`scripts/project-profile-relay.mjs\`
-from this skill directory and ask every exported \`projectProfileQuestions\` entry
-in order.
+from this skill directory.
 
-Present an answer the payload reports as \`derived\` with its value and its
-evidence string for confirmation, and ask an answer it reports as \`unresolved\`
-blank. Never present a candidate the payload does not carry, and never add a
-description the payload does not carry. The runtime derives these, and a
-suggestion you author makes one repository answer differently for different
-operators.
+Record an answer the payload reports as \`derived\` exactly as it stands, with
+its value and its evidence string, and ask the operator nothing about it. Ask
+only the \`projectProfileQuestions\` entries the payload reports as \`unresolved\`,
+in order, and ask those blank. Never present a candidate the payload does not
+carry, and never add a description the payload does not carry. The runtime
+derives these, and a suggestion you author makes one repository answer
+differently for different operators.
 
-Record confirmed answers as \`resolved\`, unconfirmed derived values with their
-evidence as \`derived\`, explicitly omitted items as \`not-applicable\` with a
-reason, or \`unresolved\` if blank. Commands are exact single-line strings run
-from the project root, paths are project-relative lists, and implementation
-languages are programming languages rather than the human-language policy.
+Record an answer the operator gives as \`resolved\`, an item the operator
+explicitly omits as \`not-applicable\` with a reason, and anything still blank as
+\`unresolved\`. Commands are exact single-line strings run from the project root,
+paths are project-relative lists, and implementation languages are programming
+languages rather than the human-language policy.
 
 Pass the keyed answers to \`relayProjectProfileAnswers\`, place its returned
 value in \`host.init-answers@1.6.0\` as \`projectProfile\`, and pipe that complete

--- a/tests/init-permissions-provenance.test.ts
+++ b/tests/init-permissions-provenance.test.ts
@@ -142,6 +142,106 @@ describe("permission allowlist derivation and strict provenance", () => {
     expect(result.allow).toContain("Bash(make lint-all)");
   });
 
+  it("derives a permission for a derived project profile command and keeps its evidence", () => {
+    // The host records a derived answer without asking the operator, so a
+    // command the runtime read from a manifest must earn its allowance from
+    // that evidence rather than from a confirmation that no longer happens.
+    const profile: StackProfile = profileStack({ rootEntries: [] });
+    const answers = mockAnswers({
+      projectProfile: {
+        commands: {
+          test: {
+            status: "derived",
+            value: "pnpm test",
+            evidence: "package.json#scripts.test",
+          },
+          lint: {
+            status: "derived",
+            value: "make lint",
+            evidence: "Makefile:lint",
+          },
+          build: { status: "unresolved" },
+          run: { status: "not-applicable", reason: "library" },
+        },
+        paths: {
+          source: { status: "unresolved" },
+          tests: { status: "unresolved" },
+          configuration: { status: "unresolved" },
+        },
+        conventions: {
+          directoryLayout: { status: "unresolved" },
+          naming: { status: "unresolved" },
+          implementationLanguages: { status: "unresolved" },
+        },
+      },
+    });
+    const result = deriveHostPermissions(answers, profile, { hasGit: false });
+
+    expect(result.allow).toEqual(["Bash(make lint)", "Bash(pnpm test)"]);
+    expect(result.provenance).toEqual([
+      {
+        permission: "Bash(pnpm test)",
+        origin: "derived_profile",
+        evidence: "package.json#scripts.test",
+      },
+      {
+        permission: "Bash(make lint)",
+        origin: "derived_profile",
+        evidence: "Makefile:lint",
+      },
+    ]);
+  });
+
+  it("rejects a derived permission whose evidence the profile does not carry", () => {
+    const profile: StackProfile = profileStack({ rootEntries: [] });
+    const answers = mockAnswers({
+      projectProfile: {
+        commands: {
+          test: {
+            status: "derived",
+            value: "pnpm test",
+            evidence: "package.json#scripts.test",
+          },
+          lint: { status: "unresolved" },
+          build: { status: "unresolved" },
+          run: { status: "unresolved" },
+        },
+        paths: {
+          source: { status: "unresolved" },
+          tests: { status: "unresolved" },
+          configuration: { status: "unresolved" },
+        },
+        conventions: {
+          directoryLayout: { status: "unresolved" },
+          naming: { status: "unresolved" },
+          implementationLanguages: { status: "unresolved" },
+        },
+      },
+    });
+
+    const wrongEvidence = {
+      permission: "Bash(pnpm test)",
+      origin: "derived_profile" as const,
+      evidence: "Makefile:test",
+    };
+    expect(() => {
+      assertPermissionProvenance(wrongEvidence, answers, profile, {
+        hasGit: false,
+      });
+    }).toThrow(/PERMISSION_WITHOUT_PROVENANCE/);
+
+    const wrongCommand = {
+      permission: "Bash(pnpm run build)",
+      origin: "derived_profile" as const,
+      evidence: "package.json#scripts.test",
+    };
+    expect(() => {
+      assertPermissionProvenance(wrongCommand, answers, profile, {
+        hasGit: false,
+      });
+    }).toThrow(/PERMISSION_WITHOUT_PROVENANCE/);
+  });
+
   it("asserts provenance for all derived permissions and throws on unproven allowances", () => {
     const profile = profileStack({ rootEntries: ["package.json"] });
     const answers = mockAnswers();

--- a/tests/init-profile-derivation.test.ts
+++ b/tests/init-profile-derivation.test.ts
@@ -64,6 +64,158 @@ describe("pure project profile derivation", () => {
     });
   });
 
+  it("names the package manager the lockfile at the root attests to", () => {
+    // `npm test` on a pnpm project is the wrong command, and a wrong command
+    // that is recorded without being put to the operator is granted an
+    // allowance nobody checked.
+    const manifests: ManifestContents = {
+      packageJson: JSON.stringify({
+        scripts: {
+          test: "vitest run",
+          lint: "eslint .",
+          build: "next build",
+          start: "next start",
+        },
+      }),
+    };
+
+    const pnpm = deriveProjectProfile(
+      { rootEntries: ["package.json", "pnpm-lock.yaml"] },
+      manifests,
+    );
+    expect(pnpm.commands).toEqual({
+      test: {
+        status: "derived",
+        value: "pnpm test",
+        evidence: "package.json#scripts.test via pnpm-lock.yaml",
+      },
+      lint: {
+        status: "derived",
+        value: "pnpm run lint",
+        evidence: "package.json#scripts.lint via pnpm-lock.yaml",
+      },
+      build: {
+        status: "derived",
+        value: "pnpm run build",
+        evidence: "package.json#scripts.build via pnpm-lock.yaml",
+      },
+      run: {
+        status: "derived",
+        value: "pnpm start",
+        evidence: "package.json#scripts.start via pnpm-lock.yaml",
+      },
+    });
+
+    const yarn = deriveProjectProfile(
+      { rootEntries: ["package.json", "yarn.lock"] },
+      manifests,
+    );
+    expect(yarn.commands?.test).toEqual({
+      status: "derived",
+      value: "yarn test",
+      evidence: "package.json#scripts.test via yarn.lock",
+    });
+    expect(
+      yarn.commands?.lint?.status === "derived" && yarn.commands.lint.value,
+    ).toBe("yarn run lint");
+
+    // `bun test` is Bun's own runner, not the declared script, so every slot
+    // goes through `bun run`.
+    const bun = deriveProjectProfile(
+      { rootEntries: ["package.json", "bun.lockb"] },
+      manifests,
+    );
+    expect(bun.commands).toEqual({
+      test: {
+        status: "derived",
+        value: "bun run test",
+        evidence: "package.json#scripts.test via bun.lockb",
+      },
+      lint: {
+        status: "derived",
+        value: "bun run lint",
+        evidence: "package.json#scripts.lint via bun.lockb",
+      },
+      build: {
+        status: "derived",
+        value: "bun run build",
+        evidence: "package.json#scripts.build via bun.lockb",
+      },
+      run: {
+        status: "derived",
+        value: "bun run start",
+        evidence: "package.json#scripts.start via bun.lockb",
+      },
+    });
+
+    const npm = deriveProjectProfile(
+      { rootEntries: ["package.json", "package-lock.json"] },
+      manifests,
+    );
+    expect(npm.commands?.test).toEqual({
+      status: "derived",
+      value: "npm test",
+      evidence: "package.json#scripts.test via package-lock.json",
+    });
+  });
+
+  it("lets the packageManager field outrank the lockfile", () => {
+    const manifests: ManifestContents = {
+      packageJson: JSON.stringify({
+        packageManager: "pnpm@9.12.0+sha512.abc",
+        scripts: { test: "vitest run" },
+      }),
+    };
+
+    const derived = deriveProjectProfile(
+      { rootEntries: ["package.json", "package-lock.json"] },
+      manifests,
+    );
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "pnpm test",
+      evidence: "package.json#scripts.test via package.json#packageManager",
+    });
+  });
+
+  it("derives no command from package.json when two lockfiles disagree", () => {
+    // Two lockfiles admit two readings that produce different commands, and
+    // that is the operator's call, not a coin the runtime flips.
+    const manifests: ManifestContents = {
+      packageJson: JSON.stringify({
+        scripts: { test: "vitest run", lint: "eslint ." },
+      }),
+    };
+
+    const derived = deriveProjectProfile(
+      { rootEntries: ["package.json", "pnpm-lock.yaml", "package-lock.json"] },
+      manifests,
+    );
+
+    expect(derived.commands).toBeUndefined();
+  });
+
+  it("ignores a packageManager field naming a manager it does not know", () => {
+    const manifests: ManifestContents = {
+      packageJson: JSON.stringify({
+        packageManager: "volta@1.0.0",
+        scripts: { test: "vitest run" },
+      }),
+    };
+
+    const derived = deriveProjectProfile(
+      { rootEntries: ["package.json", "yarn.lock"] },
+      manifests,
+    );
+
+    expect(derived.commands?.test).toEqual({
+      status: "derived",
+      value: "yarn test",
+      evidence: "package.json#scripts.test via yarn.lock",
+    });
+  });
+
   it("derives commands from Makefile targets", () => {
     const manifests: ManifestContents = {
       makefile: [
@@ -442,6 +594,42 @@ describe("pure project profile derivation", () => {
       status: "derived",
       value: ["apps/backend/tests"],
       evidence: "directory:apps/backend/tests (nested)",
+    });
+  });
+
+  it("does not offer a directory below the tests as source code", () => {
+    // `tests/unit/lib` carries a source candidate name, but a `lib` that sits
+    // below `tests` mirrors the source tree rather than being one, and naming
+    // it as a second source root also hid the layout of the real one.
+    const evidence = {
+      rootEntries: ["src", "tests", "package.json"],
+      files: [
+        "src/lib/parse-order.ts",
+        "src/lib/user-store.ts",
+        "src/lib/http-server.ts",
+        "src/index.ts",
+        "tests/unit/lib/parse-order.test.ts",
+        "tests/unit/lib/user-store.test.ts",
+      ],
+    };
+
+    const derived = deriveProjectProfile(evidence, {});
+
+    expect(derived.paths?.source).toEqual({
+      status: "derived",
+      value: ["src"],
+      evidence: "directory:src",
+    });
+    expect(derived.paths?.tests).toEqual({
+      status: "derived",
+      value: ["tests"],
+      evidence: "directory:tests",
+    });
+    expect(derived.conventions?.directoryLayout).toEqual({
+      status: "derived",
+      value:
+        "Place new source under `src/` at the repository root and its tests in the sibling `tests/` directory.",
+      evidence: "layout:root src; 4 source files, 2 test files",
     });
   });
 


### PR DESCRIPTION
# Pull request

## Linked issue and work ID

Closes #214

Work ID: `ADP-14`

## Outcome and design

The initialization interview asked the operator to confirm every answer the
runtime had already derived. On a repository where derivation resolved eight of
ten profile leaves, the host still put ten questions, eight of them restating a
value and its evidence and waiting for a nod. The derivation work under ADP-08
through ADP-13 exists so the operator answers less, not so the operator
ratifies more.

The host skills now record a `derived` leaf as the runtime derived it, with its
value and evidence string, and ask only the `projectProfileQuestions` entries
the payload reports as `unresolved`. The four leaf states keep their meaning:
`resolved` still means a human stated the value.

Removing the confirmation exposed two defects it had been masking, both fixed
here because the removal makes each worse:

- **Permission provenance.** `permissions.ts` granted `Bash(<command>)` only to
  `resolved` command slots. With no confirmation, no derived command would ever
  earn an allowance again and the branch became dead code. A new
  `derived_profile` origin grants the allowance from the recorded evidence, and
  `assertPermissionProvenance` accepts it only when a `derived` slot carries
  both the same command and the same evidence.
- **Package manager.** `derivePackageJsonCommands` emitted `npm test` for every
  `package.json`. Derivation now honours `package.json#packageManager`, then a
  single root lockfile, defaults to npm when none exists, and derives nothing
  when lockfiles of two managers disagree. Bun goes through `bun run <script>`,
  since `bun test` is Bun's own runner rather than the declared script.

Also: a source candidate below a test directory (`tests/unit/lib`) is no longer
offered as a source root. It mirrored the source tree, and naming it as a
second root stopped `deriveDirectoryLayout` from describing the real one.

Design record:
`docs/superpowers/specs/2026-09-04-derived-answers-recorded-without-confirmation-design.md`

**Out of scope**, filed as consequences in the design record: a correction path
for a wrong derived value (`profile` exposes only `derive`; there is no
`profile set`), and naming derivation for projects that mix PascalCase
components with kebab-case modules, where dominance stays under the 80%
threshold.

## Compatibility and public contracts

- **Host contract**: `SKILL.md` for all three hosts changes its interview
  instruction. No schema, command, flag, reason code, or exit code changes.
- **`host.init-answers@1.6.0` / `state.project-config@1.5.0`**: unchanged. The
  four leaf states and their meaning are untouched.
- **Superseded**: AC-8 of ADP-08 ("Gates requiring operator consent fail closed
  on unconfirmed `derived` values") is replaced by AC-8', stated in the design
  record. Its only implementation was the permission gate this PR changes.
- **Behavioral change visible to users**: a project whose commands are not on
  the canonical stack table (`pnpm test`, `make test`, `pytest`) now receives a
  `Bash(...)` allowance it did not receive before. A project with lockfiles of
  two managers now reaches the interview with command slots unresolved instead
  of receiving `npm` commands.
- **Go-v3 parity**: unaffected; `npm run parity:check` reports the unchanged
  baseline.

## State, migration, security, and rollback

- **Project state**: none. No event, snapshot, or `.brain` layout changes. An
  existing `.brain/config.json` is read and written exactly as before.
- **Migration**: none required. A project initialized under v0.4.0 keeps its
  recorded profile; re-running `init` derives under the new rules.
- **Security / trust boundary**: this PR widens the generated permission
  allowlist. The widening is bounded by provenance — an entry is rejected
  unless a `derived` command slot carries both the same command string and the
  same evidence string — and the evidence traces to a manifest committed to the
  repository. No secret, credential, or network access is involved. Derivation
  remains offline and reads no file outside the project root.
- **Rollback**: revert the commit. No state written under the new behavior
  becomes unreadable, since no contract or schema changed.

## Deterministic test evidence

- Acceptance evidence record: `docs/superpowers/specs/2026-09-04-derived-answers-recorded-without-confirmation-design.md`
- Focused verification: `npx vitest run tests/init-profile-derivation.test.ts tests/init-permissions-provenance.test.ts`
- Full repository verification: `npm run verify`
- Diff hygiene: `git diff --check` (clean)

Platform: Linux x86_64, Node 24.18.0, npm 11.16.0 (the exact toolchain in
CONTRIBUTING.md).

```text
$ npx vitest run tests/init-profile-derivation.test.ts tests/init-permissions-provenance.test.ts
Tests  54 passed (54)

$ npm run verify
format:check, spellcheck, english:check, lint, typecheck   PASS
test                     Test Files 238 passed | Tests 5716 passed (5716)
test:coverage            Test Files 238 passed | Tests 5716 passed (5716)
mutation:check           gate mutation score: 4 / 4 (100.00%)
gaps:calibrate, performance:check, oracle:verify           PASS
parity:check, result:check, contracts:check                PASS
differential:check                                         PASS
prompts:ceilings:check   host-skill 4804 / 4448 / 4496 of 6000  PASS
build, package:verify    verified for Codex, Claude Code, Antigravity
benchmark                PASS
EXIT=0
```

Seven tests added: four for package-manager derivation, one for the source
candidate below a test directory, two for `derived_profile` permission
provenance.

## Prompt and model evaluations

Not applicable. The `SKILL.md` change is covered deterministically by
`prompts:ceilings:check` and `package:verify`; its behavioral effect is the
interview the host runs, which the runtime does not execute.

## Failure evidence

Each test was written first and observed failing against `53070dc`.

```text
$ npx vitest run tests/init-permissions-provenance.test.ts
 × derives a permission for a derived project profile command and keeps its evidence
   AssertionError: expected [] to deeply equal [ Array(2) ]
 Tests  1 failed | 10 passed (11)
```

`deriveHostPermissions` returned no provenance at all for a profile whose
command slots were `derived`, because the loop tested `status === "resolved"`.

```text
$ npx vitest run tests/init-profile-derivation.test.ts
 × names the package manager the lockfile at the root attests to
 × lets the packageManager field outrank the lockfile
 × derives no command from package.json when two lockfiles disagree
 × ignores a packageManager field naming a manager it does not know
 × does not offer a directory below the tests as source code
 Tests  5 failed | 36 passed (41)
```

The first four failed because `derivePackageJsonCommands` hard-coded the `npm`
forms and never read `packageManager` or any lockfile. The fifth failed because
`candidateDirectories` matched `lib` as a path suffix regardless of what sat
above it, so `paths.source` was `["src", "tests/unit/lib"]` and
`conventions.directoryLayout` was left unresolved.

## Provenance

- Sources used: none. No legacy, third-party, or private material was consulted;
  the change is written against this repository's own code and contracts.
- Contribution method: `original`.
- Publication authority and required notices: not applicable, no adapted or
  verbatim third-party material.
- Confirmed: no secret, credential, customer or personal data, private
  infrastructure, or confidential business information is included.

## Checklist

- [x] The PR contains one coherent outcome and no unrelated opportunistic refactor.
- [x] The closing issue, epic, dependencies, work ID, design, and ADRs are linked.
- [x] Public-contract, compatibility, state, migration, security, and rollback impact is explicit.
- [x] Deterministic tests are separate from any prompt/model evaluations.
- [x] Focused tests and the complete required verification suite pass.
- [x] Failure evidence from the test-first cycle is included.
- [x] Documentation and migration/recovery guidance are updated where required.
- [x] All repository text and durable discussion use normative English.
- [x] Every commit contains the contributor's own valid `Signed-off-by` DCO trailer.
- [x] Legacy/third-party provenance and publication authority are reviewable.
- [x] No unresolved placeholder, secret, private data, or confidential detail remains.
